### PR TITLE
Issue #7: Expand lexer toward JLS 25 lexical forms

### DIFF
--- a/web/javac.test.ts
+++ b/web/javac.test.ts
@@ -190,6 +190,10 @@ describe("Lexer", () => {
     assert.throws(() => lex("\\u000A\\u00G0"), /Invalid Unicode escape: \\u00G0 at line 2:1/);
   });
 
+  test("unicode escape line/col treats CRLF as single line terminator", () => {
+    assert.throws(() => lex("\\u000D\n\\u00G0"), /Invalid Unicode escape: \\u00G0 at line 2:1/);
+  });
+
   test("unicode identifier is accepted", () => {
     const tokens = lex("int 名前 = 1;");
     assert.equal(tokens[0].kind, TokenKind.KwInt);
@@ -201,6 +205,8 @@ describe("Lexer", () => {
     const tokens = lex("int 𩸽 = 1;");
     assert.equal(tokens[1].kind, TokenKind.Ident);
     assert.equal(tokens[1].value, "𩸽");
+    assert.equal(tokens[2].kind, TokenKind.Assign);
+    assert.equal(tokens[2].col, 8); // 'int ' (4) + surrogate pair (2) + space + '='
   });
 
   test("text block literal tokenizes as string literal", () => {
@@ -235,6 +241,12 @@ world
     const tokens = lex("\"\"\"   \nhi\n\"\"\"");
     assert.equal(tokens[0].kind, TokenKind.StringLiteral);
     assert.equal(tokens[0].value, "hi\n");
+  });
+
+  test("CRLF-normalized text block opening still accepted", () => {
+    const tokens = lex("\"\"\"\r\nok\r\n\"\"\"");
+    assert.equal(tokens[0].kind, TokenKind.StringLiteral);
+    assert.equal(tokens[0].value, "ok\n");
   });
 
   test("floating-point forms with dot/exponent are tokenized", () => {

--- a/web/javac/lexer.ts
+++ b/web/javac/lexer.ts
@@ -178,12 +178,21 @@ function preprocessUnicodeEscapes(input: string): string {
   let out = "";
   let line = 1;
   let col = 1;
+  let lastWasCR = false;
   const bump = (ch: string): void => {
-    if (ch === "\n" || ch === "\r") {
+    if (ch === "\r") {
       line++;
       col = 1;
+      lastWasCR = true;
+    } else if (ch === "\n") {
+      if (!lastWasCR) {
+        line++;
+        col = 1;
+      }
+      lastWasCR = false;
     } else {
       col++;
+      lastWasCR = false;
     }
   };
   for (let i = 0; i < input.length; i++) {
@@ -314,7 +323,7 @@ export function lex(source: string): Token[] {
     if (cp === undefined) return "\0";
     const s = String.fromCodePoint(cp);
     pos += s.length;
-    col++;
+    col += s.length;
     return s;
   }
   function parseEscape(startLine: number, startCol: number, inTextBlock: boolean): string {
@@ -329,10 +338,6 @@ export function lex(source: string): Token[] {
       case "'": return "'";
       case "\\": return "\\";
       case "s": return " ";
-      case "\r":
-        if (!inTextBlock) throw new Error(`Invalid escape sequence at line ${startLine}:${startCol}`);
-        if (peek() === "\n") advance();
-        return "";
       case "\n":
         if (!inTextBlock) throw new Error(`Invalid escape sequence at line ${startLine}:${startCol}`);
         return "";
@@ -431,15 +436,10 @@ export function lex(source: string): Token[] {
     if (ch === '"' && peekN(1) === '"' && peekN(2) === '"') {
       advance(); advance(); advance();
       while (peek() === " " || peek() === "\t" || peek() === "\f") advance();
-      if (!(peek() === "\n" || peek() === "\r")) {
+      if (peek() !== "\n") {
         throw new Error(`Text block opening delimiter must be followed by line terminator at line ${startLine}:${startCol}`);
       }
-      if (peek() === "\r") {
-        advance();
-        if (peek() === "\n") advance();
-      } else {
-        advance();
-      }
+      advance();
       let s = "";
       let closed = false;
       while (pos < source.length) {
@@ -469,7 +469,7 @@ export function lex(source: string): Token[] {
       advance();
       let s = "";
       while (peek() !== '"' && peek() !== "\0") {
-        if (peek() === "\n" || peek() === "\r") {
+        if (peek() === "\n") {
           throw new Error(`Unterminated string literal at line ${startLine}:${startCol}`);
         }
         if (peek() === "\\") {
@@ -492,7 +492,7 @@ export function lex(source: string): Token[] {
     // Char literal
     if (ch === "'") {
       advance(); // opening '
-      if (peek() === "'" || peek() === "\n" || peek() === "\r" || peek() === "\0") {
+      if (peek() === "'" || peek() === "\n" || peek() === "\0") {
         throw new Error(`Malformed char literal at line ${startLine}:${startCol}`);
       }
       let chValue = "";

--- a/web/javac/parser.ts
+++ b/web/javac/parser.ts
@@ -868,13 +868,13 @@ export function parseAll(tokens: Token[]): ClassDecl[] {
     if (match(TokenKind.ShiftLeftAssign)) return makeCompound("<<");
     if (match(TokenKind.ShiftRightAssign)) return makeCompound(">>");
     if (match(TokenKind.ShiftUnsignedAssign)) return makeCompound(">>>");
-    // >>= is tokenized as '>' '>='
+    // Backward-compat fallback for older token streams where >>= is split as '>' '>='.
     if (at(TokenKind.Gt) && tokens[pos + 1]?.kind === TokenKind.Ge) {
       advance();
       advance();
       return makeCompound(">>");
     }
-    // >>>= is tokenized as '>' '>' '>='
+    // Backward-compat fallback for older token streams where >>>= is split.
     if (at(TokenKind.Gt) && tokens[pos + 1]?.kind === TokenKind.Gt && tokens[pos + 2]?.kind === TokenKind.Ge) {
       advance();
       advance();


### PR DESCRIPTION
## Summary
This PR advances Issue #7 by expanding the Java lexer toward broader JLS 25 lexical compatibility while keeping parser/codegen behavior stable.

## Changes
- Added Unicode-aware identifier scanning (ID_Start / ID_Continue plus $ and _)
- Added text block tokenization as StringLiteral
- Strengthened string/char escape handling with strict invalid-escape diagnostics
- Added support for floating-point forms like .5, 1., 1e3, 2.5f
- Hardened numeric literal underscore validation and malformed literal diagnostics
- Kept existing shift-token behavior unchanged to avoid parser regressions

## Tests
- Added lexer tests for Unicode escapes, Unicode identifiers, text blocks, invalid underscores, invalid escapes, text-block diagnostics, and floating-point forms
- npm test passes (214/214)

## Scope note
Issue #7 is broad. This PR focuses on high-impact lexical gaps first, while preserving existing parser-compatible token behavior.