### PR TITLE
Fix unimported class names resolving to wrong java/lang package in static calls

### DIFF
--- a/web/javac/compiler.ts
+++ b/web/javac/compiler.ts
@@ -773,7 +773,7 @@ function inferType(ctx: CompileContext, expr: Expr): Type {
       return { className: "java/lang/Object" };
     }
     case "staticCall": {
-      const internalName = resolveClassName(ctx, expr.className.replace(/\./g, "/"));
+      const internalName = resolveClassName(ctx, expr.className);
       const resolved = resolveMethodCandidate(ctx, internalName, expr.method, expr.args, true);
       if (resolved) return resolved.returnType;
       return { className: "java/lang/Object" };
@@ -1182,7 +1182,7 @@ function compileExpr(ctx: CompileContext, emitter: BytecodeEmitter, expr: Expr, 
       break;
     }
     case "staticCall": {
-      const internalName = resolveClassName(ctx, expr.className.replace(/\./g, "/"));
+      const internalName = resolveClassName(ctx, expr.className);
       const resolved = resolveMethodCandidate(ctx, internalName, expr.method, expr.args, true);
       if (resolved) {
         expr.args.forEach((arg, i) => compileExpr(ctx, emitter, arg, resolved.paramTypes[i] ?? { className: "java/lang/Object" }));


### PR DESCRIPTION
## Summary

Static call compilation built `internalName` via `expr.className.replace(/\./g, "/")`, bypassing `resolveClassName()`. Short names like `LocalDateTime` (without an import) were left as-is, and the JVM resolved them as `java/lang/LocalDateTime` — failing at runtime with "Method not found".

Route both `staticCall` sites (`inferType` and `compileExpr`) through `resolveClassName()`, which correctly applies the import map and wildcard package imports.

## Test plan

- [ ] `make test` — all 310 tests pass
- [ ] `import java.time.LocalDateTime; LocalDateTime.now()` resolves to `java/time/LocalDateTime`
- [ ] Unimported short names with a wildcard import (e.g. `import java.time.*`) resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)