### PR TITLE
Fix resolveClassName falling back to java/lang/ for unimported classes

### DIFF
--- a/web/javac.test.ts
+++ b/web/javac.test.ts
@@ -1577,6 +1577,25 @@ describe("Code generator", () => {
     } finally { resetMethodRegistry(); reloadShimRegistry(); }
   });
 
+  test("unimported class does not fall back to java/lang/ package", () => {
+    // DateTimeFormatter is in java.time.format, not java.lang.
+    // Without an explicit import, resolveClassName should return the bare name
+    // rather than silently emitting java/lang/DateTimeFormatter.
+    const bytes = compile(`
+      public class UnimportedClass {
+        public static String run() {
+          return DateTimeFormatter.ofPattern("yyyy");
+        }
+      }
+    `);
+    assertValidClassFile(bytes);
+    const text = new TextDecoder().decode(bytes);
+    assert.ok(!text.includes("java/lang/DateTimeFormatter"),
+      "must NOT emit java/lang/DateTimeFormatter for unimported class");
+    assert.ok(!text.includes("java/lang/DateTimeForm"),
+      "no java/lang/ prefix on DateTimeFormatter");
+  });
+
   test("named import resolves class reference", () => {
     const bytes = compile(`
       import net.unit8.raoh.Ok;

--- a/web/javac/compiler.ts
+++ b/web/javac/compiler.ts
@@ -3308,7 +3308,7 @@ function resolveClassNameInDecl(classDecl: ClassDecl, classDecls: Map<string, Cl
       const candidate = `${pkg}/${name}`;
       if (hasKnownMethodOwnerPrefix(candidate)) return candidate;
     }
-    return `${classDecl.packageImports[0]}/${name}`;
+    return name;
   }
   return name;
 }


### PR DESCRIPTION
## Summary

When `resolveClassName()` could not match a short class name to any wildcard-import package, it returned `packageImports[0] + "/" + name`. Because `java/lang` is unconditionally the first entry in `packageImports`, this silently emitted wrong bytecode — e.g. `java/lang/DateTimeFormatter` instead of the correct `java/time/format/DateTimeFormatter`, producing a confusing VM error:

```
ERROR: Method not found: java/lang/DateTimeFormatter.ofPattern(Ljava/lang/String;)Ljava/lang/Object;
```

**Fix**: return the bare name when no package resolves the class. The VM error will then show the actual unresolved name, making it clear the import is missing.

## Root cause

`parser.ts`'s `resolveClassName` correctly guards `java/lang` resolution with `JAVA_LANG_SIMPLE_NAMES`, but `compiler.ts`'s copy did not have this guard.

## Test plan

- [ ] `make test` — all 310 tests pass
- [ ] `DateTimeFormatter.ofPattern(...)` without import → VM error shows `DateTimeFormatter.ofPattern` (not `java/lang/DateTimeFormatter`)
- [ ] `import java.time.format.DateTimeFormatter` → resolves correctly to `java/time/format/DateTimeFormatter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)