### PR TITLE
Add Docker Compose workflow for local builds and web playground

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Build artifacts (rebuilt inside container)
+node_modules/
+jvm-core/pkg/
+dist/
+jdk-shim/out/
+jdk-shim/bundle.bin
+test-classes/
+web/javac.js
+
+# Version control and IDE
+.git/
+.gitignore
+.cursor/
+
+# Docs and plans (not needed for build)
+*.plan.md
+.cursor/plans/
+
+# Misc
+*.log
+.DS_Store

--- a/Dockerfile.java
+++ b/Dockerfile.java
@@ -1,0 +1,14 @@
+# 199xVM — JDK 25 + Maven + Node (shim, dev-jars, test-bundle). Node is required for build-test-bundle.sh (compile-compact.mjs).
+FROM eclipse-temurin:25-jdk
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    make \
+    maven \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Default: keep container alive for docker-compose run; override with make shim / make dev-jars / make test-bundle
+CMD ["sleep", "infinity"]

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,0 +1,15 @@
+# 199xVM — Node (web compiler, tests, dist). Use for: make javac, make test, make dist, npx serve
+# Node 22+ required for --experimental-strip-types (compiler tests)
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Default: keep container alive for docker-compose run; override with make javac / make test / npx serve
+CMD ["sleep", "infinity"]

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,0 +1,9 @@
+# 199xVM — Rust/WASM build (VM only). Use for: make wasm, cargo test --package jvm-core
+FROM rust:1-bookworm
+
+RUN cargo install wasm-pack
+
+WORKDIR /app
+
+# Default: keep container alive for docker-compose run; override with make wasm / cargo test
+CMD ["sleep", "infinity"]

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ JAR_NAMES := $(RAOH_JAR) $(RAOH_JSON_JAR) $(JACKSON_ANN_JAR) \
 
 WEB_JARS := $(addprefix web/,$(JAR_NAMES))
 
-.PHONY: all dev-jars shim test-bundle javac wasm dist test clean deploy
+.PHONY: all dev-jars shim test-bundle javac wasm dist test clean deploy docker-playground dist-docker
 
 # ============================================================
 # all — build everything needed for local development
@@ -163,6 +163,24 @@ endif
 	gcloud storage cp dist/index.html "$(GCS)/index.html" --cache-control="no-cache" --content-type="text/html; charset=utf-8"
 	@echo ""
 	@echo "==> Done: $(GCS)/"
+
+# ============================================================
+# docker-playground — build all artifacts via Docker then start web server
+# ============================================================
+# Requires: Docker (or OrbStack). Runs dev-jars, wasm, shim, javac, dist in containers, then docker-compose up (web only).
+docker-playground: dist-docker
+	@echo "==> Starting web server (docker-compose up)..."
+	docker-compose up
+
+# Build dist via Docker (all artifacts built in containers)
+dist-docker:
+	@echo "==> Building artifacts in Docker..."
+	docker-compose run --rm java make dev-jars
+	docker-compose run --rm rust make wasm
+	docker-compose run --rm java make shim
+	docker-compose run --rm node sh -c "npm ci && make javac"
+	docker-compose run --rm node make dist
+	@echo "==> dist/ ready."
 
 # ============================================================
 # clean — remove generated artifacts

--- a/README.md
+++ b/README.md
@@ -136,6 +136,43 @@ npm run build:javac
 wasm-pack build jvm-core --target web
 ```
 
+### Docker (three ways: VM only / Compiler only / Web Playground)
+
+Use Docker or OrbStack with the project’s `docker-compose.yml`. Only the **web** service is started by `docker-compose up`; the **rust**, **java**, and **node** services are for one-off builds/tests via `docker-compose run <service> ...`.
+
+**1. VM (wasm) only**
+
+```sh
+docker-compose run rust make wasm
+docker-compose run rust cargo test --package jvm-core --lib
+```
+
+The `--lib` flag runs only unit tests. For full integration tests (which need `test-classes/bundle.bin`), build the test bundle first:  
+`docker-compose run node npm ci && docker-compose run node make javac`, then `docker-compose run java make test-bundle`. After that, `docker-compose run rust cargo test --package jvm-core` runs all tests.
+
+**2. Compiler only**
+
+```sh
+docker-compose run node npm ci   # first time (or when package.json changes)
+docker-compose run node make javac
+docker-compose run node make test
+```
+
+**3. Web Playground (full dist + serve)**
+
+Build all artifacts, then start the web server:
+
+```sh
+docker-compose run java make dev-jars
+docker-compose run rust make wasm
+docker-compose run java make shim
+docker-compose run node npm ci && docker-compose run node make javac
+docker-compose run node make dist
+docker-compose up
+```
+
+Then open http://localhost:3000/web/ (or serve from `dist/` if you prefer). Alternatively, use `make docker-playground` to run the build steps above and then `docker-compose up`.
+
 ## Known limitations (high level)
 
 - Full Java 25 language/toolchain parity is out of scope today

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+# 199xVM — Docker Compose (JTBD: VM only / Compiler only / Web Playground)
+# - "build" profile: rust, java, node — used only for `docker-compose run <svc> make <target>`
+# - no profile: web — started by `docker-compose up` (serve dist or project root)
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.node
+    command: npx serve . -p 3000
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    working_dir: /app
+
+  rust:
+    profiles:
+      - build
+    build:
+      context: .
+      dockerfile: Dockerfile.rust
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: sleep infinity
+
+  java:
+    profiles:
+      - build
+    build:
+      context: .
+      dockerfile: Dockerfile.java
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: sleep infinity
+
+  node:
+    profiles:
+      - build
+    build:
+      context: .
+      dockerfile: Dockerfile.node
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    working_dir: /app
+    command: sleep infinity
+
+volumes:
+  node_modules:


### PR DESCRIPTION
## Summary

This PR adds a Docker-based development workflow for 199xVM so contributors can build and run the project without installing the full Rust, Java, and Node toolchain directly on the host.

## Changes

- add `docker-compose.yml` with dedicated `web`, `rust`, `java`, and `node` services
- add `Dockerfile.rust`, `Dockerfile.java`, and `Dockerfile.node`
- add `.dockerignore` to keep Docker build contexts smaller and avoid copying generated artifacts
- add `dist-docker` and `docker-playground` targets to the `Makefile`
- document Docker usage for:
  - VM-only workflows
  - compiler-only workflows
  - full web playground builds and local serving

## Notes

- `docker-compose up` starts only the `web` service
- build/test tasks for Rust, Java, and Node are intended to run via `docker-compose run <service> ...`
- `make docker-playground` provides a single entry point for building artifacts in containers and then starting the local web server

## Testing

- Local