### PR TITLE
Add the (presumably missing) factorial integration test fixture

### DIFF
--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -103,17 +103,9 @@ fn try_catch_npe() {
     assert_eq!(result, "CAUGHT");
 }
 
-// ---------------------------------------------------------------------------
-// Factorial with long arithmetic
-// ---------------------------------------------------------------------------
-
-fn factorial_bundle() -> &'static [u8] {
-    include_bytes!("../../test-classes/factorial-bundle.bin")
-}
-
 #[test]
 fn factorial_long() {
-    let bundle = combined_bundle(shim_bundle(), factorial_bundle());
+    let bundle = combined_bundle(shim_bundle(), test_bundle());
     let result = jvm_core::run_static_native(
         &bundle,
         "Factorial",

--- a/test-sources/Factorial.java
+++ b/test-sources/Factorial.java
@@ -1,0 +1,11 @@
+long fact(int n) {
+    long result = 1;
+    for (int i = 2; i <= n; i++) {
+        result = result * i;
+    }
+    return result;
+}
+
+String run() {
+    return "10!=" + fact(10) + " 15!=" + fact(15);
+}


### PR DESCRIPTION
TL;DR: I couldn't find the `factorial-bundle.bin`. Maybe it's missing?

## Summary
- add a compact `Factorial` fixture under `test-sources`
- update the integration test to load `Factorial` from the normal test bundle instead of a separate factorial bundle

## Testing
- `docker-compose run --rm java make test-bundle`
- `docker-compose run --rm rust cargo test --package jvm-core factorial_long -- --exact`