### PR TITLE
Add resource-aware bundle lookup and ClassLoader APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /target/
 /dist/
+/.cpcache/
+/.clj-kondo/
+/.lsp/
 node_modules/
 jvm-core/pkg/
 jvm-core/target/
@@ -9,3 +12,4 @@ jdk-shim/bundle.bin
 jdk-shim/out/
 web/javac.js
 web/*.jar
+/clj-smoke/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ JAR_NAMES := $(RAOH_JAR) $(RAOH_JSON_JAR) $(JACKSON_ANN_JAR) \
 
 WEB_JARS := $(addprefix web/,$(JAR_NAMES))
 
-.PHONY: all dev-jars shim test-bundle javac wasm dist test clean deploy docker-playground dist-docker
+.PHONY: all dev-jars shim test-bundle clj-smoke-bundle clj-smoke-run clj-smoke-docker javac wasm dist test clean deploy docker-playground dist-docker
 
 # ============================================================
 # all — build everything needed for local development
@@ -71,6 +71,28 @@ test-classes/bundle.bin: build-test-bundle.sh web/javac.js $(shell find test-sou
 	./build-test-bundle.sh
 
 test-bundle: test-classes/bundle.bin
+
+# ============================================================
+# clj-smoke-bundle — compile isolated Clojure smoke classes → clj-smoke/bundle.bin
+# ============================================================
+clj-smoke/bundle.bin: build-clj-smoke.sh test-sources/clojure/deps.edn $(shell find test-sources/clojure -type f 2>/dev/null)
+	./build-clj-smoke.sh
+
+clj-smoke-bundle: clj-smoke/bundle.bin
+
+# ============================================================
+# clj-smoke-run — run the isolated Clojure smoke bundle against the VM
+# ============================================================
+clj-smoke-run: clj-smoke/bundle.bin jdk-shim/bundle.bin
+	cargo run --package jvm-core --bin run_bundle jdk-shim/bundle.bin clj-smoke/bundle.bin ClojureSmokeEntry run '()Ljava/lang/String;'
+
+# ============================================================
+# clj-smoke-docker — build + run the isolated Clojure smoke flow in containers
+# ============================================================
+clj-smoke-docker:
+	docker-compose run --rm java make shim
+	docker-compose run --rm clj make clj-smoke-bundle
+	docker-compose run --rm rust cargo run --package jvm-core --bin run_bundle /app/jdk-shim/bundle.bin /app/clj-smoke/bundle.bin ClojureSmokeEntry run '()Ljava/lang/String;'
 
 # ============================================================
 # javac — build web/javac.js from web/javac.ts
@@ -189,5 +211,6 @@ clean:
 	rm -rf dist
 	rm -rf jdk-shim/out jdk-shim/bundle.bin
 	rm -rf test-classes
+	rm -rf clj-smoke/target clj-smoke/bundle.bin
 	rm -f  web/javac.js
 	rm -rf jvm-core/pkg

--- a/README.md
+++ b/README.md
@@ -175,6 +175,30 @@ Then open <http://localhost:3000/>. Alternatively, use `make docker-playground` 
 
 > **Note:** `docker-compose up` (web service) serves `dist/`. Run `dist-docker` or the manual steps above before starting it, otherwise `dist/` will be empty.
 
+**4. Clojure smoke (isolated diagnostic path)**
+
+This path is intentionally separate from `make test`, `cargo test`, and the normal Java/Web build flow. It exists to bundle a tiny AOT-compiled Clojure entrypoint plus the Clojure runtime, then run it through 199xVM so missing shim/runtime support is surfaced incrementally.
+
+The `clj` service uses the Docker Official Image for Clojure on Temurin Java 25 with `tools.deps`.
+The smoke source and `deps.edn` live under `test-sources/clojure/`; `clj-smoke/` is only generated output and cache.
+
+```sh
+make clj-smoke-docker
+```
+
+Manual steps if you want to inspect each stage:
+
+```sh
+docker-compose run --rm java make shim
+docker-compose run --rm clj make clj-smoke-bundle
+docker-compose run --rm rust cargo run --package jvm-core --bin run_bundle \
+  /app/jdk-shim/bundle.bin \
+  /app/clj-smoke/bundle.bin \
+  ClojureSmokeEntry run '()Ljava/lang/String;'
+```
+
+The smoke command prints either the returned string or the first VM error encountered. It is a diagnostic command, not a required test gate.
+
 ## Known limitations (high level)
 
 - Full Java 25 language/toolchain parity is out of scope today

--- a/build-clj-smoke.sh
+++ b/build-clj-smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SMOKE_DIR="$ROOT_DIR/clj-smoke"
+CLJ_SRC_DIR="$ROOT_DIR/test-sources/clojure"
+TARGET_DIR="$SMOKE_DIR/target"
+AOT_DIR="$TARGET_DIR/aot"
+UNPACK_DIR="$TARGET_DIR/unpacked"
+BUNDLE_FILE="$SMOKE_DIR/bundle.bin"
+CLJ_DEPS="$(tr '\n' ' ' < "$CLJ_SRC_DIR/deps.edn")"
+
+rm -rf "$AOT_DIR" "$UNPACK_DIR"
+mkdir -p "$AOT_DIR" "$UNPACK_DIR"
+
+echo "Resolving Clojure smoke dependencies with tools.deps..."
+(
+  cd "$ROOT_DIR"
+  clojure -Sdeps "$CLJ_DEPS" -P
+)
+CLASSPATH="$(
+  cd "$ROOT_DIR"
+  clojure -Sdeps "$CLJ_DEPS" -Spath
+)"
+
+echo "AOT-compiling smoke namespace..."
+java \
+  -Dclojure.compile.path="$AOT_DIR" \
+  -cp "$CLASSPATH" \
+  clojure.main \
+  -e "(compile 'smoke.core)"
+
+echo "Unpacking runtime classes..."
+IFS=':' read -r -a cp_entries <<< "$CLASSPATH"
+for jar_file in "${cp_entries[@]}"; do
+  [[ "$jar_file" == *.jar ]] || continue
+  [[ "$jar_file" = /* ]] || jar_file="$ROOT_DIR/$jar_file"
+  jar_name="$(basename "$jar_file" .jar)"
+  jar_out="$UNPACK_DIR/$jar_name"
+  mkdir -p "$jar_out"
+  (
+    cd "$jar_out"
+    jar xf "$jar_file"
+  )
+done
+
+: > "$BUNDLE_FILE"
+count=0
+while IFS= read -r -d '' classfile; do
+  size=$(wc -c < "$classfile")
+  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
+    $(( (size >> 24) & 0xff )) \
+    $(( (size >> 16) & 0xff )) \
+    $(( (size >>  8) & 0xff )) \
+    $(( size & 0xff )))" >> "$BUNDLE_FILE"
+  cat "$classfile" >> "$BUNDLE_FILE"
+  count=$((count + 1))
+done < <(
+  {
+    find "$AOT_DIR" -type f -name '*.class' \( -path "$AOT_DIR/smoke/*" -o -name 'ClojureSmokeEntry.class' \) -print0
+    find "$UNPACK_DIR" -type f -name '*.class' -print0
+  } | sort -z
+)
+
+total=$(wc -c < "$BUNDLE_FILE")
+echo "Bundled $count Clojure smoke classes → $BUNDLE_FILE ($total bytes)"
+echo "Entry point: ClojureSmokeEntry.run()Ljava/lang/String;"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,15 @@ services:
     working_dir: /app
     command: sleep infinity
 
+  clj:
+    profiles:
+      - build
+    image: clojure:temurin-25-tools-deps-trixie-slim
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: sleep infinity
+
   node:
     profiles:
       - build

--- a/jdk-shim/java/lang/Class.java
+++ b/jdk-shim/java/lang/Class.java
@@ -144,18 +144,15 @@ public final class Class<T> implements Type {
     }
 
     private static native Class<?> forName0(String className);
+    private static native Class<?> forName1(String className, boolean initialize, ClassLoader loader);
 
     public static Class<?> forName(String className) throws ClassNotFoundException {
-        Class<?> c = forName0(className);
-        if (c == null) {
-            throw new ClassNotFoundException(className);
-        }
-        return c;
+        return forName1(className, true, ClassLoader.getSystemClassLoader());
     }
 
     public static Class<?> forName(String className, boolean initialize, ClassLoader loader)
             throws ClassNotFoundException {
-        Class<?> c = forName0(className);
+        Class<?> c = forName1(className, initialize, loader);
         if (c == null) {
             throw new ClassNotFoundException(className);
         }

--- a/jdk-shim/java/lang/ClassLoader.java
+++ b/jdk-shim/java/lang/ClassLoader.java
@@ -25,13 +25,108 @@
 
 package java.lang;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+
 public class ClassLoader {
-    protected ClassLoader() {}
+    private final ClassLoader parent;
+
+    protected ClassLoader() {
+        this(null);
+    }
+
+    protected ClassLoader(ClassLoader parent) {
+        this.parent = parent;
+    }
+
+    protected ClassLoader(String name, ClassLoader parent) {
+        this(parent);
+    }
 
     public static native ClassLoader getSystemClassLoader();
 
+    private static native int resourceCount0(String name);
+
+    private static String normalizeResourceName(String name) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        int index = 0;
+        while (index < name.length() && name.charAt(index) == '/') {
+            index++;
+        }
+        return index == 0 ? name : name.substring(index);
+    }
+
+    private static URL newBundleUrl(String name, int index) {
+        try {
+            String suffix = index == 0 ? "" : "?entry=" + index;
+            return new URL("bundle", "", "/" + name + suffix);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    public static URL getSystemResource(String name) {
+        String resourceName = normalizeResourceName(name);
+        return resourceCount0(resourceName) > 0 ? newBundleUrl(resourceName, 0) : null;
+    }
+
+    public static InputStream getSystemResourceAsStream(String name) {
+        URL url = getSystemResource(name);
+        if (url == null) {
+            return null;
+        }
+        try {
+            return url.openStream();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public static Enumeration<URL> getSystemResources(String name) throws IOException {
+        String resourceName = normalizeResourceName(name);
+        int count = resourceCount0(resourceName);
+        if (count == 0) {
+            return Collections.emptyEnumeration();
+        }
+        ArrayList<URL> urls = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            URL url = newBundleUrl(resourceName, i);
+            if (url != null) {
+                urls.add(url);
+            }
+        }
+        return Collections.enumeration(urls);
+    }
+
     public Class<?> loadClass(String name) throws ClassNotFoundException {
         return loadClass(name, false);
+    }
+
+    public URL getResource(String name) {
+        return getSystemResource(name);
+    }
+
+    public InputStream getResourceAsStream(String name) {
+        return getSystemResourceAsStream(name);
+    }
+
+    public Enumeration<URL> getResources(String name) throws IOException {
+        return getSystemResources(name);
+    }
+
+    protected URL findResource(String name) {
+        return getSystemResource(name);
+    }
+
+    protected Enumeration<URL> findResources(String name) throws IOException {
+        return getSystemResources(name);
     }
 
     // Simplified parent-delegation: checks the local registry via native stubs only.
@@ -48,6 +143,12 @@ public class ClassLoader {
     protected native Class<?> findLoadedClass(String name);
 
     protected native Class<?> findClass(String name) throws ClassNotFoundException;
+
+    public final ClassLoader getParent() {
+        return parent;
+    }
+
+    protected final void resolveClass(Class<?> c) {}
 
     protected final Class<?> defineClass(String name, byte[] b, int off, int len) {
         return null;

--- a/jdk-shim/java/lang/Thread.java
+++ b/jdk-shim/java/lang/Thread.java
@@ -126,7 +126,7 @@ public class Thread implements Runnable {
     }
 
     public final ClassLoader getContextClassLoader() {
-        return contextClassLoader;
+        return contextClassLoader != null ? contextClassLoader : ClassLoader.getSystemClassLoader();
     }
 
     public void setContextClassLoader(ClassLoader cl) {

--- a/jdk-shim/java/net/URL.java
+++ b/jdk-shim/java/net/URL.java
@@ -25,6 +25,8 @@
 
 package java.net;
 
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -32,9 +34,9 @@ import java.io.InputStream;
  * Class {@code URL} represents a Uniform Resource Locator, a pointer to a
  * "resource" on the World Wide Web.
  *
- * <p>This shim implementation delegates parsing to {@link URI} and does not
- * support network I/O. {@link #openConnection()} and {@link #openStream()}
- * always throw {@link UnsupportedOperationException}.
+ * <p>This shim implementation delegates parsing to {@link URI}. Network I/O is
+ * not supported, but {@code bundle:} URLs are backed by the 199xVM bundle
+ * resource table.
  *
  * @author  James Gosling
  * @since   1.0
@@ -49,6 +51,32 @@ public final class URL implements java.io.Serializable {
     private final int port;
     private final String file;
     private final String ref;
+
+    private static native byte[] bundleResourceBytes0(String name, int index);
+    private static native long bundleResourceLastModified0(String name, int index);
+
+    private static String bundleResourceName(URL url) {
+        String path = url.getPath();
+        if (path == null || path.isEmpty()) {
+            return "";
+        }
+        return path.charAt(0) == '/' ? path.substring(1) : path;
+    }
+
+    private static int bundleResourceIndex(URL url) {
+        String query = url.getQuery();
+        if (query == null || query.isEmpty()) {
+            return 0;
+        }
+        if (!query.startsWith("entry=")) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(query.substring("entry=".length()));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
 
     /**
      * Creates a {@code URL} object from the {@code String} representation.
@@ -247,23 +275,52 @@ public final class URL implements java.io.Serializable {
     /**
      * Opens a connection to this {@code URL}.
      *
-     * <p>Network I/O is not supported in 199xVM.
-     *
-     * @throws UnsupportedOperationException always.
+     * <p>Network I/O is not supported in 199xVM. {@code bundle:} URLs resolve
+     * against the VM's embedded resource table.
      */
     public java.net.URLConnection openConnection() throws IOException {
+        if ("bundle".equals(protocol)) {
+            final String resourceName = bundleResourceName(this);
+            final int resourceIndex = bundleResourceIndex(this);
+            return new URLConnection(this) {
+                @Override
+                public void connect() throws IOException {}
+
+                @Override
+                public InputStream getInputStream() throws IOException {
+                    byte[] bytes = bundleResourceBytes0(resourceName, resourceIndex);
+                    if (bytes == null) {
+                        throw new FileNotFoundException(resourceName);
+                    }
+                    return new ByteArrayInputStream(bytes);
+                }
+
+                @Override
+                public int getContentLength() {
+                    byte[] bytes = bundleResourceBytes0(resourceName, resourceIndex);
+                    return bytes != null ? bytes.length : -1;
+                }
+
+                @Override
+                public long getContentLengthLong() {
+                    return getContentLength();
+                }
+
+                @Override
+                public long getLastModified() {
+                    return bundleResourceLastModified0(resourceName, resourceIndex);
+                }
+            };
+        }
         throw new UnsupportedOperationException("Network I/O not supported in 199xVM");
     }
 
     /**
      * Opens a connection to this {@code URL} and returns an {@code InputStream}.
      *
-     * <p>Network I/O is not supported in 199xVM.
-     *
-     * @throws UnsupportedOperationException always.
      */
     public InputStream openStream() throws IOException {
-        throw new UnsupportedOperationException("Network I/O not supported in 199xVM");
+        return openConnection().getInputStream();
     }
 
     /**

--- a/jvm-core/src/interpreter/bytecode.rs
+++ b/jvm-core/src/interpreter/bytecode.rs
@@ -759,7 +759,7 @@ impl Vm {
                     self.ensure_class_init(&new_class)?;
                     // A ParseError entry means the class was registered but malformed —
                     // surface consistently as ClassFormatError (same as Class.forName0 path).
-                    if matches!(self.classes.get(&new_class), Some(super::LazyClass::ParseError(_))) {
+                    if matches!(self.classes.get(&new_class), Some(super::LazyClass::ParseError { .. })) {
                         self.throw_class_format_error(&new_class);
                         return Err(format!("java/lang/ClassFormatError: malformed class file for {new_class}"));
                     }

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -49,14 +49,28 @@ pub(super) struct MethodExecInfo {
 /// implementing standard ClassLoader lazy-loading semantics.
 pub(in crate::interpreter) enum LazyClass {
     /// Raw bytes not yet parsed.
-    Pending(Vec<u8>),
+    Pending(Rc<Vec<u8>>),
     /// Fully parsed class file.
-    Ready(ClassFile),
+    Ready {
+        class_file: ClassFile,
+        bytes: Option<Rc<Vec<u8>>>,
+    },
     /// Bytes were present but could not be parsed (malformed class).
     /// The entry is preserved so callers can distinguish "never registered"
     /// from "registered but broken", and to avoid repeated parse attempts.
     /// The inner `String` holds the original parse error message.
-    ParseError(String),
+    ParseError {
+        message: String,
+        bytes: Option<Rc<Vec<u8>>>,
+    },
+}
+
+/// A non-class resource registered in the VM's bundle image.
+pub(in crate::interpreter) struct ResourceEntry {
+    /// Resource payload bytes.
+    pub bytes: Vec<u8>,
+    /// Source timestamp exposed via URLConnection#getLastModified.
+    pub last_modified: i64,
 }
 
 mod annotations;
@@ -306,6 +320,12 @@ pub struct Vm {
     /// Static field storage keyed by class name → field name.
     /// Avoids allocating a `"ClassName.fieldName"` string on every getstatic/putstatic.
     pub(in crate::interpreter) static_fields: HashMap<String, HashMap<String, JValue>>,
+    /// Non-class resources keyed by classpath-relative name.
+    pub(in crate::interpreter) resources: HashMap<String, Vec<ResourceEntry>>,
+    /// Stable synthetic timestamp exposed for synthesized `*.class` resources.
+    /// Updated when newer explicit resources are loaded so AOT classes look at
+    /// least as fresh as bundled source resources during bootstrap.
+    synthetic_class_last_modified: i64,
     /// Classes whose `<clinit>` has already been run successfully.
     pub(in crate::interpreter) clinit_done: HashSet<String>,
     /// Classes whose `<clinit>` threw an exception (erroneous state per JVMS §5.5).
@@ -334,6 +354,8 @@ impl Vm {
             classes: HashMap::new(),
             string_pool: HashMap::new(),
             static_fields: HashMap::new(),
+            resources: HashMap::new(),
+            synthetic_class_last_modified: 1,
             clinit_done: HashSet::new(),
             clinit_failed: HashSet::new(),
             class_pool: HashMap::new(),
@@ -641,16 +663,77 @@ impl Vm {
     /// Register a pre-parsed class file (always stored as `Ready`).
     pub fn load_class(&mut self, class_file: ClassFile) {
         let name = class_file.constant_pool.class_name(class_file.this_class).to_owned();
-        self.classes.insert(name, LazyClass::Ready(class_file));
+        self.classes.insert(name, LazyClass::Ready { class_file, bytes: None });
     }
 
     /// Register raw `.class` bytes for lazy parsing.
     /// The class is parsed only when first accessed via [`Self::ensure_class_ready`].
     /// If the class is already registered (e.g., as `Ready`), the existing entry is kept.
     pub fn load_lazy(&mut self, name: String, bytes: Vec<u8>) {
-        self.classes.entry(name).or_insert(LazyClass::Pending(bytes));
+        self.classes.entry(name).or_insert(LazyClass::Pending(Rc::new(bytes)));
     }
 
+    fn normalize_resource_name(name: &str) -> &str {
+        name.trim_start_matches('/')
+    }
+
+    /// Register a non-class resource from a bundle.
+    pub fn load_resource(&mut self, name: String, bytes: Vec<u8>, last_modified: i64) {
+        let normalized = Self::normalize_resource_name(&name).to_owned();
+        self.synthetic_class_last_modified = self
+            .synthetic_class_last_modified
+            .max(last_modified.saturating_add(1));
+        self.resources
+            .entry(normalized)
+            .or_default()
+            .push(ResourceEntry { bytes, last_modified });
+    }
+
+    /// Return how many classpath resources are registered for the given name.
+    pub(in crate::interpreter) fn resource_count(&self, name: &str) -> usize {
+        let normalized = Self::normalize_resource_name(name);
+        if let Some(entries) = self.resources.get(normalized) {
+            entries.len()
+        } else if self.class_resource_bytes(normalized).is_some() {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Clone the bytes for a resource entry by logical name and classpath order index.
+    pub(in crate::interpreter) fn resource_bytes(&self, name: &str, index: usize) -> Option<Vec<u8>> {
+        let normalized = Self::normalize_resource_name(name);
+        if let Some(entries) = self.resources.get(normalized) {
+            entries.get(index).map(|entry| entry.bytes.clone())
+        } else if index == 0 {
+            self.class_resource_bytes(normalized).map(|bytes| bytes.to_vec())
+        } else {
+            None
+        }
+    }
+
+    /// Get the last-modified timestamp for a resource entry by logical name and index.
+    pub(in crate::interpreter) fn resource_last_modified(&self, name: &str, index: usize) -> Option<i64> {
+        let normalized = Self::normalize_resource_name(name);
+        if let Some(entries) = self.resources.get(normalized) {
+            entries.get(index).map(|entry| entry.last_modified)
+        } else if index == 0 && self.class_resource_bytes(normalized).is_some() {
+            Some(self.synthetic_class_last_modified)
+        } else {
+            None
+        }
+    }
+
+    fn class_resource_bytes(&self, resource_name: &str) -> Option<&[u8]> {
+        let class_name = resource_name.strip_suffix(".class")?;
+        match self.classes.get(class_name)? {
+            LazyClass::Pending(bytes) => Some(bytes.as_slice()),
+            LazyClass::Ready { bytes: Some(bytes), .. } => Some(bytes.as_slice()),
+            LazyClass::ParseError { bytes: Some(bytes), .. } => Some(bytes.as_slice()),
+            LazyClass::Ready { bytes: None, .. } | LazyClass::ParseError { bytes: None, .. } => None,
+        }
+    }
     /// Ensure the named class is fully parsed (`Ready`).
     /// If the entry is `Pending`, parses it in place and promotes it to `Ready`.
     /// On parse failure the entry is set to `ParseError` so the failure is
@@ -662,11 +745,19 @@ impl Vm {
             return;
         }
         if let Some(LazyClass::Pending(bytes)) = self.classes.remove(name) {
-            match class_file::parse(&bytes) {
-                Ok(cf) => { self.classes.insert(name.to_owned(), LazyClass::Ready(cf)); }
+            match class_file::parse(bytes.as_slice()) {
+                Ok(cf) => {
+                    self.classes.insert(name.to_owned(), LazyClass::Ready {
+                        class_file: cf,
+                        bytes: Some(bytes),
+                    });
+                }
                 Err(e) => {
                     eprintln!("Warning: failed to parse class '{name}': {e}");
-                    self.classes.insert(name.to_owned(), LazyClass::ParseError(e.to_string()));
+                    self.classes.insert(name.to_owned(), LazyClass::ParseError {
+                        message: e.to_string(),
+                        bytes: Some(bytes),
+                    });
                 }
             }
         }
@@ -676,8 +767,8 @@ impl Vm {
     /// Caller must have called `ensure_class_ready` first (or know the class is already Ready).
     pub(in crate::interpreter) fn get_class(&self, name: &str) -> Option<&ClassFile> {
         match self.classes.get(name)? {
-            LazyClass::Ready(cf) => Some(cf),
-            LazyClass::Pending(_) | LazyClass::ParseError(_) => None,
+            LazyClass::Ready { class_file, .. } => Some(class_file),
+            LazyClass::Pending(_) | LazyClass::ParseError { .. } => None,
         }
     }
 

--- a/jvm-core/src/interpreter/native_static.rs
+++ b/jvm-core/src/interpreter/native_static.rs
@@ -219,9 +219,9 @@ impl super::Vm {
                 }
                 self.ensure_class_ready(&internal);
                 match self.classes.get(&internal) {
-                    Some(super::LazyClass::Ready(_)) => {}
-                    Some(super::LazyClass::ParseError(msg)) => {
-                        let msg = msg.clone();
+                    Some(super::LazyClass::Ready { .. }) => {}
+                    Some(super::LazyClass::ParseError { message, .. }) => {
+                        let msg = message.clone();
                         self.throw_class_format_error(&msg);
                         return Some(JValue::Void);
                     }
@@ -232,9 +232,75 @@ impl super::Vm {
                 }
                 Some(JValue::Ref(Some(self.class_object(internal))))
             }
+            ("java/lang/Class", "forName1", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;") => {
+                let runtime_name = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))?;
+                let initialize = _args.get(1).map(|v| v.as_int() != 0).unwrap_or(false);
+                let internal = Self::class_internal_name_from_runtime_name(&runtime_name);
+                if matches!(
+                    internal.as_str(),
+                    "boolean" | "byte" | "char" | "short" | "int" | "long" | "float" | "double" | "void"
+                ) {
+                    return Some(JValue::Ref(Some(self.class_object(internal))));
+                }
+                if internal.starts_with('[') {
+                    return Some(JValue::Ref(Some(self.class_object(internal))));
+                }
+                self.ensure_class_ready(&internal);
+                match self.classes.get(&internal) {
+                    Some(super::LazyClass::Ready { .. }) => {}
+                    Some(super::LazyClass::ParseError { message, .. }) => {
+                        let msg = message.clone();
+                        self.throw_class_format_error(&msg);
+                        return Some(JValue::Void);
+                    }
+                    _ => {
+                        self.throw_class_not_found(&runtime_name);
+                        return Some(JValue::Void);
+                    }
+                }
+                if initialize && self.ensure_class_init(&internal).is_err() {
+                    return Some(JValue::Void);
+                }
+                Some(JValue::Ref(Some(self.class_object(internal))))
+            }
             ("java/lang/ClassLoader", "getSystemClassLoader", "()Ljava/lang/ClassLoader;") => {
                 let cl = self.get_or_create_system_classloader();
                 Some(JValue::Ref(Some(cl)))
+            }
+            ("java/lang/ClassLoader", "resourceCount0", "(Ljava/lang/String;)I") => {
+                let name = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .unwrap_or_default();
+                Some(JValue::Int(self.resource_count(&name) as i32))
+            }
+            ("java/net/URL", "bundleResourceBytes0", "(Ljava/lang/String;I)[B") => {
+                let name = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .unwrap_or_default();
+                let index = _args.get(1).map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                match self.resource_bytes(&name, index) {
+                    Some(bytes) => {
+                        let elems = bytes.into_iter().map(|b| JValue::Int(i32::from(b))).collect();
+                        Some(JValue::Ref(Some(JObject::new_array("[B", elems))))
+                    }
+                    None => Some(JValue::Ref(None)),
+                }
+            }
+            ("java/net/URL", "bundleResourceLastModified0", "(Ljava/lang/String;I)J") => {
+                let name = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .unwrap_or_default();
+                let index = _args.get(1).map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                Some(JValue::Long(self.resource_last_modified(&name, index).unwrap_or(0)))
             }
             ("java/lang/System", "currentTimeMillis", "()J") => {
                 #[cfg(target_arch = "wasm32")]

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -217,9 +217,9 @@ impl super::Vm {
                 let internal = Self::class_internal_name_from_runtime_name(&name_str);
                 self.ensure_class_ready(&internal);
                 match self.classes.get(&internal) {
-                    Some(LazyClass::Ready(_)) => {}
-                    Some(LazyClass::ParseError(msg)) => {
-                        let msg = msg.clone();
+                    Some(LazyClass::Ready { .. }) => {}
+                    Some(LazyClass::ParseError { message, .. }) => {
+                        let msg = message.clone();
                         self.throw_class_format_error(&msg);
                         return Some(JValue::Void);
                     }
@@ -237,7 +237,7 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
                     .unwrap_or_default();
                 let internal = Self::class_internal_name_from_runtime_name(&name_str);
-                if matches!(self.classes.get(&internal), Some(LazyClass::Ready(_))) {
+                if matches!(self.classes.get(&internal), Some(LazyClass::Ready { .. })) {
                     Some(JValue::Ref(Some(self.class_object(internal))))
                 } else {
                     Some(JValue::Ref(None))
@@ -348,29 +348,25 @@ impl super::Vm {
                 m.borrow_mut().fields.insert("__input".to_owned(), JValue::Ref(Some(self.intern_string(input))));
                 Some(JValue::Ref(Some(m)))
             }
-            ("java/util/regex/Matcher", "matches") => {
-                let (regex, input) = {
-                    let mb = this.borrow();
-                    let regex = mb.fields.get("__pattern")
-                        .and_then(|v| v.as_ref())
-                        .and_then(|p| p.borrow().fields.get("__regex").cloned())
-                        .and_then(|v| v.as_ref().cloned())
-                        .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
-                        .unwrap_or_default();
-                    let input = mb.fields.get("__input")
-                        .and_then(|v| v.as_ref())
-                        .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
-                        .unwrap_or_default();
-                    (regex, input)
-                };
-                let ok = super::native_static::regex_full_match(&regex, &input);
-                Some(JValue::Int(if ok { 1 } else { 0 }))
-            }
             ("java/lang/Class", "getName") => {
                 let internal = self
                     .class_internal_name_from_obj(this)
                     .unwrap_or_else(|| "java/lang/Object".to_owned());
                 Some(JValue::Ref(Some(self.intern_string(Self::class_display_name(&internal)))))
+            }
+            ("java/lang/Class", "getClassLoader") => {
+                let target = self
+                    .class_internal_name_from_obj(this)
+                    .unwrap_or_else(|| "java/lang/Object".to_owned());
+                let loader = if matches!(
+                    target.as_str(),
+                    "boolean" | "byte" | "char" | "short" | "int" | "long" | "float" | "double" | "void"
+                ) {
+                    None
+                } else {
+                    Some(self.get_or_create_system_classloader())
+                };
+                Some(JValue::Ref(loader))
             }
             ("java/lang/Class", "getModifiers") => {
                 let target = self

--- a/jvm-core/src/lib.rs
+++ b/jvm-core/src/lib.rs
@@ -14,12 +14,14 @@ use class_file::{parse, parse_class_name};
 use heap::JValue;
 use interpreter::Vm;
 
-/// Load one or more `.class` files and invoke a static method.
+const RESOURCE_MAGIC: &[u8; 4] = b"RSRC";
+
+/// Load a bundle image and invoke a static method.
 ///
 /// # Arguments
 ///
-/// * `class_data` — concatenated raw `.class` bytes (each class preceded by a
-///   4-byte big-endian length).
+/// * `class_data` — concatenated bundle entries (each entry preceded by a
+///   4-byte big-endian payload length).
 /// * `main_class` — internal class name of the entry point (e.g.
 ///   `"net/unit8/raoh/Decoders"`).
 /// * `method_name` — static method to invoke (e.g. `"run"`).
@@ -92,11 +94,13 @@ pub fn run_static_native(
     out
 }
 
-/// Load classes from bundle bytes into a VM using lazy parsing.
+/// Load classes and resources from bundle bytes into a VM using lazy parsing.
 ///
-/// Each class's raw bytes are registered under its internal class name.
-/// The class is not parsed until it is first accessed during execution,
-/// matching standard ClassLoader lazy-loading semantics.
+/// Class entries are raw `.class` bytes registered under their internal class
+/// name. Resource entries use a small `RSRC` envelope carrying path, payload,
+/// and last-modified metadata. Classes are not parsed until first access,
+/// matching standard ClassLoader lazy-loading semantics, and `*.class`
+/// resources are synthesized from the loaded class table.
 pub fn load_bundle(vm: &mut Vm, class_bundle: &[u8]) {
     let mut pos = 0usize;
     while pos + 4 <= class_bundle.len() {
@@ -110,9 +114,15 @@ pub fn load_bundle(vm: &mut Vm, class_bundle: &[u8]) {
         if pos + len > class_bundle.len() { break; }
         let class_bytes = &class_bundle[pos..pos + len];
         pos += len;
+        if let Some((name, last_modified, bytes)) = parse_resource_entry(class_bytes) {
+            vm.load_resource(name, bytes, last_modified);
+            continue;
+        }
         match parse_class_name(class_bytes) {
-            Some(name) => vm.load_lazy(name, class_bytes.to_vec()),
-            None => eprintln!("Warning: skipping class with unreadable name"),
+            Some(name) => {
+                vm.load_lazy(name, class_bytes.to_vec());
+            }
+            None => eprintln!("Warning: skipping bundle entry with unreadable name"),
         }
     }
 }
@@ -139,4 +149,21 @@ fn jvalue_to_string(v: &JValue) -> String {
         }
         JValue::ReturnAddress(a) => format!("ret:{a}"),
     }
+}
+
+fn parse_resource_entry(payload: &[u8]) -> Option<(String, i64, Vec<u8>)> {
+    if payload.len() < 20 || &payload[..4] != RESOURCE_MAGIC {
+        return None;
+    }
+    let path_len = u32::from_be_bytes(payload[4..8].try_into().ok()?) as usize;
+    let last_modified = i64::from_be_bytes(payload[8..16].try_into().ok()?);
+    let data_len = u32::from_be_bytes(payload[16..20].try_into().ok()?) as usize;
+    let expected_len = 20usize.checked_add(path_len)?.checked_add(data_len)?;
+    if payload.len() != expected_len {
+        return None;
+    }
+    let path_bytes = &payload[20..20 + path_len];
+    let data_bytes = payload[20 + path_len..].to_vec();
+    let path = std::str::from_utf8(path_bytes).ok()?.to_owned();
+    Some((path, last_modified, data_bytes))
 }

--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -208,6 +208,18 @@ fn classloader_api() {
 }
 
 #[test]
+fn class_resource_lookup() {
+    let bundle = combined_bundle(shim_bundle(), test_bundle());
+    let result = jvm_core::run_static_native(
+        &bundle,
+        "ClassResourceLookupTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "202|254|186|190|true");
+}
+
+#[test]
 fn classloader_missing_class_throws_cnfe() {
     let bundle = combined_bundle(shim_bundle(), test_bundle());
     let result = jvm_core::run_static_native(
@@ -574,4 +586,3 @@ fn priority_queue_poll_order() {
     );
     assert_eq!(result, "10,20,30");
 }
-

--- a/test-sources/ClassResourceLookupTest.java
+++ b/test-sources/ClassResourceLookupTest.java
@@ -1,0 +1,22 @@
+import java.io.InputStream;
+
+public class ClassResourceLookupTest {
+    public static String run() throws Exception {
+        var loader = ClassLoader.getSystemClassLoader();
+        long t1 = loader.getResource("MatcherTest.class").openConnection().getLastModified();
+        long t2 = loader.getResource("MatcherTest.class").openConnection().getLastModified();
+        InputStream in = loader.getResourceAsStream("MatcherTest.class");
+        if (in == null) {
+            return "missing";
+        }
+        byte[] bytes = in.readAllBytes();
+        if (bytes.length < 4) {
+            return "short";
+        }
+        return (bytes[0] & 0xff) + "|"
+                + (bytes[1] & 0xff) + "|"
+                + (bytes[2] & 0xff) + "|"
+                + (bytes[3] & 0xff) + "|"
+                + (t1 == t2 && t1 > 0L);
+    }
+}

--- a/test-sources/clojure/deps.edn
+++ b/test-sources/clojure/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["test-sources/clojure/src"]
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}}}

--- a/test-sources/clojure/src/smoke/core.clj
+++ b/test-sources/clojure/src/smoke/core.clj
@@ -1,0 +1,8 @@
+(ns smoke.core
+  (:gen-class
+    :name ClojureSmokeEntry
+    :methods [^{:static true} [run [] String]]
+    :prefix "entry-"))
+
+(defn entry-run []
+  "ok")


### PR DESCRIPTION
## Summary
This PR adds the runtime/resource foundation used by the new Clojure smoke path.

It does three main things:

- extends the bundle format so resources can travel alongside classes
- adds runtime lookup for classpath resources, including synthetic `*.class` resources
- adds the minimum `ClassLoader`/`URL` surface needed for that lookup path

This PR also includes the isolated Clojure smoke source/build path that exercises this foundation.

## Why this PR is split this way
The broader Clojure work spans bundle/runtime behavior, bootstrap shims, regex behavior, and smoke maintenance.

This PR is intentionally limited to the resource-aware runtime/bundle model so that the foundation can be reviewed independently from the later bootstrap-facing shims.

## Design note
I considered a separate resource sidecar and a larger archive/jar/module model.

For now I chose a minimal extension of the existing bundle format because it seems closest to the current self-contained design and keeps the change set smaller. If you think the bundle/classpath model should go in a different direction, I am very open to that feedback.

## Out of scope
- the later bootstrap shims needed for Clojure startup
- regex/native capture fixes
- the steady-state smoke maintenance targets and README cleanup that build on top of this

## Validation
- `docker-compose run --rm java make shim`
- `docker-compose run --rm java make test-bundle`
- `docker-compose run --rm rust cargo test --package jvm-core`

Refs #53
