### PR TITLE
Add bootstrap shims for minimal Clojure runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /target/
 /dist/
+/.cpcache/
+/.clj-kondo/
+/.lsp/
 node_modules/
 jvm-core/pkg/
 jvm-core/target/
@@ -9,3 +12,4 @@ jdk-shim/bundle.bin
 jdk-shim/out/
 web/javac.js
 web/*.jar
+/clj-smoke/

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,13 @@
 /.cpcache/
 /.clj-kondo/
 /.lsp/
+/.vscode/
 node_modules/
 jvm-core/pkg/
 jvm-core/target/
 hello-classes/
 test-classes/
+test-bench-classes/
 jdk-shim/bundle.bin
 jdk-shim/out/
 web/javac.js

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ JAR_NAMES := $(RAOH_JAR) $(RAOH_JSON_JAR) $(JACKSON_ANN_JAR) \
 
 WEB_JARS := $(addprefix web/,$(JAR_NAMES))
 
-.PHONY: all dev-jars shim test-bundle javac wasm dist test clean deploy docker-playground dist-docker
+.PHONY: all dev-jars shim test-bundle clj-smoke-bundle clj-smoke-run clj-smoke-docker javac wasm dist test clean deploy docker-playground dist-docker
 
 # ============================================================
 # all — build everything needed for local development
@@ -71,6 +71,28 @@ test-classes/bundle.bin: build-test-bundle.sh web/javac.js $(shell find test-sou
 	./build-test-bundle.sh
 
 test-bundle: test-classes/bundle.bin
+
+# ============================================================
+# clj-smoke-bundle — compile isolated Clojure smoke classes → clj-smoke/bundle.bin
+# ============================================================
+clj-smoke/bundle.bin: build-clj-smoke.sh test-sources/clojure/deps.edn $(shell find test-sources/clojure -type f 2>/dev/null)
+	./build-clj-smoke.sh
+
+clj-smoke-bundle: clj-smoke/bundle.bin
+
+# ============================================================
+# clj-smoke-run — run the isolated Clojure smoke bundle against the VM
+# ============================================================
+clj-smoke-run: clj-smoke/bundle.bin jdk-shim/bundle.bin
+	cargo run --package jvm-core --bin run_bundle jdk-shim/bundle.bin clj-smoke/bundle.bin ClojureSmokeEntry run '()Ljava/lang/String;'
+
+# ============================================================
+# clj-smoke-docker — build + run the isolated Clojure smoke flow in containers
+# ============================================================
+clj-smoke-docker:
+	docker-compose run --rm java make shim
+	docker-compose run --rm clj make clj-smoke-bundle
+	docker-compose run --rm rust cargo run --package jvm-core --bin run_bundle /app/jdk-shim/bundle.bin /app/clj-smoke/bundle.bin ClojureSmokeEntry run '()Ljava/lang/String;'
 
 # ============================================================
 # javac — build web/javac.js from web/javac.ts
@@ -189,5 +211,6 @@ clean:
 	rm -rf dist
 	rm -rf jdk-shim/out jdk-shim/bundle.bin
 	rm -rf test-classes
+	rm -rf clj-smoke/target clj-smoke/bundle.bin
 	rm -f  web/javac.js
 	rm -rf jvm-core/pkg

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ JAR_NAMES := $(RAOH_JAR) $(RAOH_JSON_JAR) $(JACKSON_ANN_JAR) \
 
 WEB_JARS := $(addprefix web/,$(JAR_NAMES))
 
-.PHONY: all dev-jars shim test-bundle clj-smoke-bundle clj-smoke-run clj-smoke-docker javac wasm dist test clean deploy docker-playground dist-docker
+.PHONY: all dev-jars shim test-bundle clj-smoke-bundle clj-smoke-run clj-smoke-test clj-smoke-docker clj-smoke-test-docker javac wasm dist test clean deploy docker-playground dist-docker
 
 # ============================================================
 # all — build everything needed for local development
@@ -59,7 +59,7 @@ dev-jars: $(WEB_JARS)
 # ============================================================
 # shim — compile JDK shim classes → jdk-shim/bundle.bin
 # ============================================================
-jdk-shim/bundle.bin: build-shim.sh $(shell find jdk-shim -name '*.java' 2>/dev/null)
+jdk-shim/bundle.bin: build-shim.sh tools/BundleWriter.java $(shell find jdk-shim -name '*.java' 2>/dev/null)
 	./build-shim.sh
 
 shim: jdk-shim/bundle.bin
@@ -67,7 +67,7 @@ shim: jdk-shim/bundle.bin
 # ============================================================
 # test-bundle — compile test Java classes → test-classes/bundle.bin
 # ============================================================
-test-classes/bundle.bin: build-test-bundle.sh web/javac.js $(shell find test-sources -name '*.java' 2>/dev/null)
+test-classes/bundle.bin: build-test-bundle.sh tools/BundleWriter.java web/javac.js $(shell find test-sources -name '*.java' 2>/dev/null)
 	./build-test-bundle.sh
 
 test-bundle: test-classes/bundle.bin
@@ -75,7 +75,7 @@ test-bundle: test-classes/bundle.bin
 # ============================================================
 # clj-smoke-bundle — compile isolated Clojure smoke classes → clj-smoke/bundle.bin
 # ============================================================
-clj-smoke/bundle.bin: build-clj-smoke.sh test-sources/clojure/deps.edn $(shell find test-sources/clojure -type f 2>/dev/null)
+clj-smoke/bundle.bin: build-clj-smoke.sh tools/BundleWriter.java test-sources/clojure/deps.edn $(shell find test-sources/clojure -type f 2>/dev/null)
 	./build-clj-smoke.sh
 
 clj-smoke-bundle: clj-smoke/bundle.bin
@@ -87,12 +87,31 @@ clj-smoke-run: clj-smoke/bundle.bin jdk-shim/bundle.bin
 	cargo run --package jvm-core --bin run_bundle jdk-shim/bundle.bin clj-smoke/bundle.bin ClojureSmokeEntry run '()Ljava/lang/String;'
 
 # ============================================================
+# clj-smoke-test — assert the isolated Clojure smoke bundle returns "ok"
+# ============================================================
+clj-smoke-test: clj-smoke/bundle.bin jdk-shim/bundle.bin
+	@out="$$(cargo run --quiet --package jvm-core --bin run_bundle jdk-shim/bundle.bin clj-smoke/bundle.bin ClojureSmokeEntry run '()Ljava/lang/String;')"; \
+	if [ "$$out" != "ok" ]; then \
+	  printf '%s\n' "$$out"; \
+	  exit 1; \
+	fi; \
+	printf '%s\n' "$$out"
+
+# ============================================================
 # clj-smoke-docker — build + run the isolated Clojure smoke flow in containers
 # ============================================================
 clj-smoke-docker:
 	docker-compose run --rm java make shim
 	docker-compose run --rm clj make clj-smoke-bundle
-	docker-compose run --rm rust cargo run --package jvm-core --bin run_bundle /app/jdk-shim/bundle.bin /app/clj-smoke/bundle.bin ClojureSmokeEntry run '()Ljava/lang/String;'
+	docker-compose run --rm rust make clj-smoke-run
+
+# ============================================================
+# clj-smoke-test-docker — build + assert the isolated Clojure smoke flow in containers
+# ============================================================
+clj-smoke-test-docker:
+	docker-compose run --rm java make shim
+	docker-compose run --rm clj make clj-smoke-bundle
+	docker-compose run --rm rust make clj-smoke-test
 
 # ============================================================
 # javac — build web/javac.js from web/javac.ts
@@ -211,6 +230,7 @@ clean:
 	rm -rf dist
 	rm -rf jdk-shim/out jdk-shim/bundle.bin
 	rm -rf test-classes
+	rm -rf test-bench-classes
 	rm -rf clj-smoke/target clj-smoke/bundle.bin
 	rm -f  web/javac.js
 	rm -rf jvm-core/pkg

--- a/README.md
+++ b/README.md
@@ -175,6 +175,30 @@ Then open <http://localhost:3000/>. Alternatively, use `make docker-playground` 
 
 > **Note:** `docker-compose up` (web service) serves `dist/`. Run `dist-docker` or the manual steps above before starting it, otherwise `dist/` will be empty.
 
+**4. Clojure smoke (isolated diagnostic path)**
+
+This path is intentionally separate from `make test`, `cargo test`, and the normal Java/Web build flow. It exists to bundle a tiny AOT-compiled Clojure entrypoint plus the Clojure runtime, then run it through 199xVM so missing shim/runtime support is surfaced incrementally.
+
+The `clj` service uses the Docker Official Image for Clojure on Temurin Java 25 with `tools.deps`.
+The smoke source and `deps.edn` live under `test-sources/clojure/`; `clj-smoke/` is only generated output and cache.
+
+```sh
+make clj-smoke-docker
+```
+
+Manual steps if you want to inspect each stage:
+
+```sh
+docker-compose run --rm java make shim
+docker-compose run --rm clj make clj-smoke-bundle
+docker-compose run --rm rust cargo run --package jvm-core --bin run_bundle \
+  /app/jdk-shim/bundle.bin \
+  /app/clj-smoke/bundle.bin \
+  ClojureSmokeEntry run '()Ljava/lang/String;'
+```
+
+The smoke command prints either the returned string or the first VM error encountered. It is a diagnostic command, not a required test gate.
+
 ## Known limitations (high level)
 
 - Full Java 25 language/toolchain parity is out of scope today

--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ It is **not** a full implementation of `javac` or HotSpot, and it should not cur
 │   └── javac.test.ts            # compiler tests
 ├── jdk-shim/                    # Java standard library shims (pure Java)
 │   └── bundle.bin               # compiled shim class bundle
+├── tools/
+│   └── BundleWriter.java        # bundle writer for class/resource images
 ├── build-shim.sh
 ├── build-test-bundle.sh
+├── build-clj-smoke.sh
 └── build-dist.sh
 ```
 
@@ -101,6 +104,7 @@ JDK APIs are provided primarily as **pure Java shims** under `jdk-shim/` and com
 - Target is Java 25 API compatibility where practical
 - Prefer Java shim implementations over Rust native stubs
 - Keep Rust natives only for runtime-boundary functionality (for example output/time/string bridging)
+- The current bootstrap surface is broad enough to run a minimal AOT-compiled Clojure program through the isolated smoke path documented below
 
 ## Quick start
 
@@ -175,12 +179,21 @@ Then open <http://localhost:3000/>. Alternatively, use `make docker-playground` 
 
 > **Note:** `docker-compose up` (web service) serves `dist/`. Run `dist-docker` or the manual steps above before starting it, otherwise `dist/` will be empty.
 
-**4. Clojure smoke (isolated diagnostic path)**
+**4. Clojure smoke (isolated path)**
 
-This path is intentionally separate from `make test`, `cargo test`, and the normal Java/Web build flow. It exists to bundle a tiny AOT-compiled Clojure entrypoint plus the Clojure runtime, then run it through 199xVM so missing shim/runtime support is surfaced incrementally.
+This path is intentionally separate from `make test`, `cargo test`, and the normal Java/Web build flow. It bundles a tiny AOT-compiled Clojure entrypoint plus the Clojure runtime, then runs it through 199xVM.
 
 The `clj` service uses the Docker Official Image for Clojure on Temurin Java 25 with `tools.deps`.
 The smoke source and `deps.edn` live under `test-sources/clojure/`; `clj-smoke/` is only generated output and cache.
+Bundle assembly is handled by `tools/BundleWriter.java`: non-class resources are stored explicitly, while `*.class` resources are synthesized by the VM from the loaded class table.
+
+Stable green-path smoke test:
+
+```sh
+make clj-smoke-test-docker
+```
+
+Raw diagnostic run if you want the VM's direct output:
 
 ```sh
 make clj-smoke-docker
@@ -197,7 +210,16 @@ docker-compose run --rm rust cargo run --package jvm-core --bin run_bundle \
   ClojureSmokeEntry run '()Ljava/lang/String;'
 ```
 
-The smoke command prints either the returned string or the first VM error encountered. It is a diagnostic command, not a required test gate.
+`clj-smoke-test-docker` is the maintenance target: it expects `ClojureSmokeEntry.run()` to return `ok` and fails otherwise. `clj-smoke-docker` prints the raw VM result for debugging and is intentionally looser.
+
+This isolated path has already exercised and driven shim/runtime work in these areas:
+
+- `java.lang.ref`
+- `java.nio.charset`
+- `java.lang.ThreadLocal`
+- classpath/resource lookup and synthetic `*.class` resources
+- regex capture/group handling
+- minimal bootstrap `java.io`, `java.nio.file`, and `java.net` shims used by Clojure startup
 
 ## Known limitations (high level)
 

--- a/build-clj-smoke.sh
+++ b/build-clj-smoke.sh
@@ -8,6 +8,7 @@ TARGET_DIR="$SMOKE_DIR/target"
 AOT_DIR="$TARGET_DIR/aot"
 UNPACK_DIR="$TARGET_DIR/unpacked"
 BUNDLE_FILE="$SMOKE_DIR/bundle.bin"
+BUILD_HELPER="$ROOT_DIR/tools/BundleWriter.java"
 CLJ_DEPS="$(tr '\n' ' ' < "$CLJ_SRC_DIR/deps.edn")"
 
 rm -rf "$AOT_DIR" "$UNPACK_DIR"
@@ -44,24 +45,18 @@ for jar_file in "${cp_entries[@]}"; do
   )
 done
 
-: > "$BUNDLE_FILE"
-count=0
-while IFS= read -r -d '' classfile; do
-  size=$(wc -c < "$classfile")
-  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
-    $(( (size >> 24) & 0xff )) \
-    $(( (size >> 16) & 0xff )) \
-    $(( (size >>  8) & 0xff )) \
-    $(( size & 0xff )))" >> "$BUNDLE_FILE"
-  cat "$classfile" >> "$BUNDLE_FILE"
-  count=$((count + 1))
-done < <(
-  {
-    find "$AOT_DIR" -type f -name '*.class' \( -path "$AOT_DIR/smoke/*" -o -name 'ClojureSmokeEntry.class' \) -print0
-    find "$UNPACK_DIR" -type f -name '*.class' -print0
-  } | sort -z
+bundle_args=(
+  "$BUNDLE_FILE"
+  --class-root "$AOT_DIR"
+  --resource-root "$CLJ_SRC_DIR/src"
 )
+for jar_file in "${cp_entries[@]}"; do
+  [[ "$jar_file" == *.jar ]] || continue
+  [[ "$jar_file" = /* ]] || jar_file="$ROOT_DIR/$jar_file"
+  jar_name="$(basename "$jar_file" .jar)"
+  jar_root="$UNPACK_DIR/$jar_name"
+  bundle_args+=(--class-root "$jar_root" --resource-root "$jar_root")
+done
 
-total=$(wc -c < "$BUNDLE_FILE")
-echo "Bundled $count Clojure smoke classes → $BUNDLE_FILE ($total bytes)"
+java "$BUILD_HELPER" "${bundle_args[@]}"
 echo "Entry point: ClojureSmokeEntry.run()Ljava/lang/String;"

--- a/build-clj-smoke.sh
+++ b/build-clj-smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SMOKE_DIR="$ROOT_DIR/clj-smoke"
+CLJ_SRC_DIR="$ROOT_DIR/test-sources/clojure"
+TARGET_DIR="$SMOKE_DIR/target"
+AOT_DIR="$TARGET_DIR/aot"
+UNPACK_DIR="$TARGET_DIR/unpacked"
+BUNDLE_FILE="$SMOKE_DIR/bundle.bin"
+CLJ_DEPS="$(tr '\n' ' ' < "$CLJ_SRC_DIR/deps.edn")"
+
+rm -rf "$AOT_DIR" "$UNPACK_DIR"
+mkdir -p "$AOT_DIR" "$UNPACK_DIR"
+
+echo "Resolving Clojure smoke dependencies with tools.deps..."
+(
+  cd "$ROOT_DIR"
+  clojure -Sdeps "$CLJ_DEPS" -P
+)
+CLASSPATH="$(
+  cd "$ROOT_DIR"
+  clojure -Sdeps "$CLJ_DEPS" -Spath
+)"
+
+echo "AOT-compiling smoke namespace..."
+java \
+  -Dclojure.compile.path="$AOT_DIR" \
+  -cp "$CLASSPATH" \
+  clojure.main \
+  -e "(compile 'smoke.core)"
+
+echo "Unpacking runtime classes..."
+IFS=':' read -r -a cp_entries <<< "$CLASSPATH"
+for jar_file in "${cp_entries[@]}"; do
+  [[ "$jar_file" == *.jar ]] || continue
+  [[ "$jar_file" = /* ]] || jar_file="$ROOT_DIR/$jar_file"
+  jar_name="$(basename "$jar_file" .jar)"
+  jar_out="$UNPACK_DIR/$jar_name"
+  mkdir -p "$jar_out"
+  (
+    cd "$jar_out"
+    jar xf "$jar_file"
+  )
+done
+
+: > "$BUNDLE_FILE"
+count=0
+while IFS= read -r -d '' classfile; do
+  size=$(wc -c < "$classfile")
+  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
+    $(( (size >> 24) & 0xff )) \
+    $(( (size >> 16) & 0xff )) \
+    $(( (size >>  8) & 0xff )) \
+    $(( size & 0xff )))" >> "$BUNDLE_FILE"
+  cat "$classfile" >> "$BUNDLE_FILE"
+  count=$((count + 1))
+done < <(
+  {
+    find "$AOT_DIR" -type f -name '*.class' \( -path "$AOT_DIR/smoke/*" -o -name 'ClojureSmokeEntry.class' \) -print0
+    find "$UNPACK_DIR" -type f -name '*.class' -print0
+  } | sort -z
+)
+
+total=$(wc -c < "$BUNDLE_FILE")
+echo "Bundled $count Clojure smoke classes → $BUNDLE_FILE ($total bytes)"
+echo "Entry point: ClojureSmokeEntry.run()Ljava/lang/String;"

--- a/build-shim.sh
+++ b/build-shim.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SHIM_SRC="jdk-shim"
 OUT_DIR="$SHIM_SRC/out"
 BUNDLE="$SHIM_SRC/bundle.bin"
+BUILD_HELPER="tools/BundleWriter.java"
 
 # Entry points — javac resolves transitive deps via -sourcepath.
 ENTRY_POINTS=(
@@ -38,12 +39,15 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/lang/NoSuchMethodException.java"
   "$SHIM_SRC/java/lang/ReflectiveOperationException.java"
   "$SHIM_SRC/java/lang/Runtime.java"
+  "$SHIM_SRC/java/lang/System.java"
   "$SHIM_SRC/java/lang/Thread.java"
+  "$SHIM_SRC/java/lang/ThreadLocal.java"
   "$SHIM_SRC/java/lang/ref/Reference.java"
   "$SHIM_SRC/java/lang/ref/ReferenceQueue.java"
   "$SHIM_SRC/java/lang/ref/SoftReference.java"
   "$SHIM_SRC/java/lang/ref/WeakReference.java"
   "$SHIM_SRC/java/lang/SecurityException.java"
+  "$SHIM_SRC/java/lang/StackTraceElement.java"
   "$SHIM_SRC/java/lang/StackOverflowError.java"
   "$SHIM_SRC/java/lang/ThreadDeath.java"
   "$SHIM_SRC/java/lang/VerifyError.java"
@@ -90,7 +94,14 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/io/Flushable.java"
   "$SHIM_SRC/java/io/IOException.java"
   "$SHIM_SRC/java/io/CharConversionException.java"
+  "$SHIM_SRC/java/io/BufferedInputStream.java"
+  "$SHIM_SRC/java/io/BufferedOutputStream.java"
+  "$SHIM_SRC/java/io/BufferedReader.java"
+  "$SHIM_SRC/java/io/BufferedWriter.java"
   "$SHIM_SRC/java/io/EOFException.java"
+  "$SHIM_SRC/java/io/File.java"
+  "$SHIM_SRC/java/io/FileNotFoundException.java"
+  "$SHIM_SRC/java/io/NotSerializableException.java"
   "$SHIM_SRC/java/io/ObjectStreamException.java"
   "$SHIM_SRC/java/io/InvalidObjectException.java"
   "$SHIM_SRC/java/io/DataInput.java"
@@ -98,10 +109,18 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/io/ObjectInput.java"
   "$SHIM_SRC/java/io/ObjectOutput.java"
   "$SHIM_SRC/java/io/Externalizable.java"
+  "$SHIM_SRC/java/io/FileInputStream.java"
+  "$SHIM_SRC/java/io/FileOutputStream.java"
+  "$SHIM_SRC/java/io/FileWriter.java"
   "$SHIM_SRC/java/io/InputStream.java"
   "$SHIM_SRC/java/io/ByteArrayInputStream.java"
   "$SHIM_SRC/java/io/ByteArrayOutputStream.java"
+  "$SHIM_SRC/java/io/InputStreamReader.java"
+  "$SHIM_SRC/java/io/LineNumberReader.java"
   "$SHIM_SRC/java/io/OutputStream.java"
+  "$SHIM_SRC/java/io/OutputStreamWriter.java"
+  "$SHIM_SRC/java/io/PrintWriter.java"
+  "$SHIM_SRC/java/io/PushbackReader.java"
   "$SHIM_SRC/java/io/CharArrayReader.java"
   "$SHIM_SRC/java/io/Reader.java"
   "$SHIM_SRC/java/io/StringReader.java"
@@ -109,6 +128,7 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/io/Writer.java"
   "$SHIM_SRC/java/util/ArrayList.java"
   "$SHIM_SRC/java/util/AbstractCollection.java"
+  "$SHIM_SRC/java/util/RandomAccess.java"
   "$SHIM_SRC/java/util/AbstractQueue.java"
   "$SHIM_SRC/java/util/AbstractList.java"
   "$SHIM_SRC/java/util/AbstractMap.java"
@@ -124,6 +144,7 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/util/OptionalInt.java"
   "$SHIM_SRC/java/util/OptionalLong.java"
   "$SHIM_SRC/java/util/OptionalDouble.java"
+  "$SHIM_SRC/java/util/Properties.java"
   "$SHIM_SRC/java/util/SortedMap.java"
   "$SHIM_SRC/java/util/NavigableMap.java"
   "$SHIM_SRC/java/util/TreeMap.java"
@@ -140,6 +161,7 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/util/ArrayDeque.java"
   "$SHIM_SRC/java/util/Date.java"
   "$SHIM_SRC/java/util/Locale.java"
+  "$SHIM_SRC/java/util/UUID.java"
   "$SHIM_SRC/java/util/TimeZone.java"
   "$SHIM_SRC/java/util/regex/Pattern.java"
   "$SHIM_SRC/java/math/BigInteger.java"
@@ -205,6 +227,14 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/time/YearMonth.java"
   "$SHIM_SRC/java/time/MonthDay.java"
   "$SHIM_SRC/java/time/DayOfWeek.java"
+  "$SHIM_SRC/java/nio/charset/Charset.java"
+  "$SHIM_SRC/java/nio/charset/IllegalCharsetNameException.java"
+  "$SHIM_SRC/java/nio/charset/StandardCharsets.java"
+  "$SHIM_SRC/java/nio/charset/UnsupportedCharsetException.java"
+  "$SHIM_SRC/java/nio/file/Files.java"
+  "$SHIM_SRC/java/nio/file/Path.java"
+  "$SHIM_SRC/java/nio/file/SimplePath.java"
+  "$SHIM_SRC/java/nio/file/attribute/FileAttribute.java"
   "$SHIM_SRC/java/lang/IO.java"
   "$SHIM_SRC/java/lang/StrictMath.java"
   "$SHIM_SRC/java/lang/Record.java"
@@ -219,6 +249,7 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/util/stream/Gatherers.java"
   "$SHIM_SRC/java/util/concurrent/atomic/AtomicBoolean.java"
   "$SHIM_SRC/java/util/concurrent/atomic/AtomicReference.java"
+  "$SHIM_SRC/java/util/concurrent/atomic/AtomicInteger.java"
   "$SHIM_SRC/java/util/concurrent/atomic/AtomicReferenceArray.java"
   "$SHIM_SRC/java/util/concurrent/atomic/AtomicLongArray.java"
   "$SHIM_SRC/java/util/concurrent/atomic/AtomicLong.java"
@@ -257,10 +288,16 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/util/concurrent/locks/Condition.java"
   "$SHIM_SRC/java/util/concurrent/locks/Lock.java"
   "$SHIM_SRC/java/util/concurrent/locks/ReentrantLock.java"
+  "$SHIM_SRC/java/util/concurrent/locks/ReentrantReadWriteLock.java"
   "$SHIM_SRC/java/io/UnsupportedEncodingException.java"
+  "$SHIM_SRC/java/security/PrivilegedAction.java"
+  "$SHIM_SRC/java/security/AccessController.java"
+  "$SHIM_SRC/java/security/SecureClassLoader.java"
   "$SHIM_SRC/java/net/MalformedURLException.java"
   "$SHIM_SRC/java/net/URISyntaxException.java"
   "$SHIM_SRC/java/net/UnknownHostException.java"
+  "$SHIM_SRC/java/net/ServerSocket.java"
+  "$SHIM_SRC/java/net/Socket.java"
   "$SHIM_SRC/java/net/SocketException.java"
   "$SHIM_SRC/java/net/ProtocolException.java"
   "$SHIM_SRC/java/net/URLEncoder.java"
@@ -269,6 +306,7 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/net/InetAddress.java"
   "$SHIM_SRC/java/net/URLConnection.java"
   "$SHIM_SRC/java/net/URL.java"
+  "$SHIM_SRC/java/net/URLClassLoader.java"
 )
 
 rm -rf "$OUT_DIR"
@@ -280,19 +318,4 @@ javac --patch-module java.base="$SHIM_SRC" \
       -d "$OUT_DIR" \
       "${ENTRY_POINTS[@]}"
 
-# Build bundle.bin from compiled classes.
-: > "$BUNDLE"
-count=0
-while IFS= read -r -d '' classfile; do
-  size=$(wc -c < "$classfile")
-  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
-    $(( (size >> 24) & 0xff )) \
-    $(( (size >> 16) & 0xff )) \
-    $(( (size >>  8) & 0xff )) \
-    $(( size & 0xff )))" >> "$BUNDLE"
-  cat "$classfile" >> "$BUNDLE"
-  count=$((count + 1))
-done < <(find "$OUT_DIR" -name '*.class' -print0 | sort -z)
-
-total=$(wc -c < "$BUNDLE")
-echo "Bundled $count shim classes → $BUNDLE ($total bytes)"
+java "$BUILD_HELPER" "$BUNDLE" --class-root "$OUT_DIR"

--- a/build-test-bundle.sh
+++ b/build-test-bundle.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 SRC_DIR="test-sources"
 OUT_DIR="test-classes"
 OUT_FILE="$OUT_DIR/bundle.bin"
+BENCH_CLASS_DIR="test-bench-classes"
+BUILD_HELPER="tools/BundleWriter.java"
 
+rm -rf "$OUT_DIR" "$BENCH_CLASS_DIR"
 mkdir -p "$OUT_DIR"
 
 # Ensure web/javac.js exists for compact source compilation
@@ -40,43 +43,15 @@ for f in "${COMPACT_SOURCES[@]}"; do
   node compile-compact.mjs "$f" "$OUT_DIR/$classname.class"
 done
 
-# Bundle
-: > "$OUT_FILE"
-count=0
-while IFS= read -r -d '' classfile; do
-  size=$(wc -c < "$classfile")
-  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
-    $(( (size >> 24) & 0xff )) \
-    $(( (size >> 16) & 0xff )) \
-    $(( (size >>  8) & 0xff )) \
-    $(( size & 0xff )))" >> "$OUT_FILE"
-  cat "$classfile" >> "$OUT_FILE"
-  count=$((count + 1))
-done < <(find "$OUT_DIR" -maxdepth 1 -name '*.class' -print0 | sort -z)
-
-total=$(wc -c < "$OUT_FILE")
-echo "Bundled $count test classes → $OUT_FILE ($total bytes)"
+java "$BUILD_HELPER" "$OUT_FILE" --class-root "$OUT_DIR"
 
 # Benchmark bundle
 BENCH_SRC="$SRC_DIR/bench"
 BENCH_OUT="$OUT_DIR/bench-bundle.bin"
 
-mkdir -p "$OUT_DIR/bench"
+rm -rf "$BENCH_CLASS_DIR"
+mkdir -p "$BENCH_CLASS_DIR"
 
-javac "$BENCH_SRC"/*.java -d "$OUT_DIR/bench"
+javac "$BENCH_SRC"/*.java -d "$BENCH_CLASS_DIR"
 
-: > "$BENCH_OUT"
-bench_count=0
-while IFS= read -r -d '' classfile; do
-  size=$(wc -c < "$classfile")
-  printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
-    $(( (size >> 24) & 0xff )) \
-    $(( (size >> 16) & 0xff )) \
-    $(( (size >>  8) & 0xff )) \
-    $(( size & 0xff )))" >> "$BENCH_OUT"
-  cat "$classfile" >> "$BENCH_OUT"
-  bench_count=$((bench_count + 1))
-done < <(find "$OUT_DIR/bench" -name '*.class' -print0 | sort -z)
-
-bench_total=$(wc -c < "$BENCH_OUT")
-echo "Bundled $bench_count bench classes → $BENCH_OUT ($bench_total bytes)"
+java "$BUILD_HELPER" "$BENCH_OUT" --class-root "$BENCH_CLASS_DIR"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,15 @@ services:
     working_dir: /app
     command: sleep infinity
 
+  clj:
+    profiles:
+      - build
+    image: clojure:temurin-25-tools-deps-trixie-slim
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: sleep infinity
+
   node:
     profiles:
       - build

--- a/jdk-shim/java/io/BufferedInputStream.java
+++ b/jdk-shim/java/io/BufferedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,36 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
+public class BufferedInputStream extends InputStream {
+    protected InputStream in;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+    public BufferedInputStream(InputStream in) {
+        this(in, 8192);
     }
 
-    public SocketException() {
+    public BufferedInputStream(InputStream in, int size) {
+        this.in = in == null ? InputStream.nullInputStream() : in;
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    public int read() throws IOException {
+        return in.read();
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
+    public int read(byte[] b, int off, int len) throws IOException {
+        return in.read(b, off, len);
+    }
+
+    public long skip(long n) throws IOException {
+        return in.skip(n);
+    }
+
+    public int available() throws IOException {
+        return in.available();
+    }
+
+    public void close() throws IOException {
+        in.close();
     }
 }

--- a/jdk-shim/java/io/BufferedOutputStream.java
+++ b/jdk-shim/java/io/BufferedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,32 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
+public class BufferedOutputStream extends OutputStream {
+    protected OutputStream out;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+    public BufferedOutputStream(OutputStream out) {
+        this(out, 8192);
     }
 
-    public SocketException() {
+    public BufferedOutputStream(OutputStream out, int size) {
+        this.out = out == null ? OutputStream.nullOutputStream() : out;
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    public void write(int b) throws IOException {
+        out.write(b);
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    public void close() throws IOException {
+        out.close();
     }
 }

--- a/jdk-shim/java/io/BufferedReader.java
+++ b/jdk-shim/java/io/BufferedReader.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+public class BufferedReader extends Reader {
+    protected Reader in;
+
+    public BufferedReader(Reader in) {
+        this(in, 8192);
+    }
+
+    public BufferedReader(Reader in, int sz) {
+        super(in);
+        this.in = in == null ? Reader.nullReader() : in;
+    }
+
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        return in.read(cbuf, off, len);
+    }
+
+    public int read() throws IOException {
+        return in.read();
+    }
+
+    public boolean ready() throws IOException {
+        return in.ready();
+    }
+
+    public String readLine() throws IOException {
+        StringBuilder sb = null;
+        while (true) {
+            int ch = in.read();
+            if (ch == -1) {
+                return sb == null ? null : sb.toString();
+            }
+            if (ch == '\n') {
+                return sb == null ? "" : sb.toString();
+            }
+            if (ch == '\r') {
+                in.mark(1);
+                int next = in.read();
+                if (next != '\n' && next != -1) {
+                    in.reset();
+                }
+                return sb == null ? "" : sb.toString();
+            }
+            if (sb == null) {
+                sb = new StringBuilder();
+            }
+            sb.append((char) ch);
+        }
+    }
+
+    public void close() throws IOException {
+        in.close();
+    }
+
+    public void mark(int readAheadLimit) throws IOException {
+        in.mark(readAheadLimit);
+    }
+
+    public void reset() throws IOException {
+        in.reset();
+    }
+
+    public boolean markSupported() {
+        return in.markSupported();
+    }
+}

--- a/jdk-shim/java/io/BufferedWriter.java
+++ b/jdk-shim/java/io/BufferedWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,41 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
+public class BufferedWriter extends Writer {
+    protected Writer out;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+    public BufferedWriter(Writer out) {
+        this(out, 8192);
     }
 
-    public SocketException() {
+    public BufferedWriter(Writer out, int sz) {
+        super(out);
+        this.out = out == null ? Writer.nullWriter() : out;
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        out.write(cbuf, off, len);
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
+    public void write(int c) throws IOException {
+        out.write(c);
+    }
+
+    public void write(String s, int off, int len) throws IOException {
+        out.write(s, off, len);
+    }
+
+    public void newLine() throws IOException {
+        out.write(System.lineSeparator());
+    }
+
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    public void close() throws IOException {
+        out.close();
     }
 }

--- a/jdk-shim/java/io/File.java
+++ b/jdk-shim/java/io/File.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 1994, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class File implements Serializable, Comparable<File> {
+    private static final long serialVersionUID = 301077366599181567L;
+
+    public static final char separatorChar = '/';
+    public static final String separator = "/";
+    public static final char pathSeparatorChar = ':';
+    public static final String pathSeparator = ":";
+
+    private final String path;
+
+    public File(String pathname) {
+        this.path = normalize(pathname);
+    }
+
+    public File(String parent, String child) {
+        this(parent == null ? child : join(normalize(parent), normalize(child)));
+    }
+
+    public File(File parent, String child) {
+        this(parent == null ? child : join(parent.getPath(), normalize(child)));
+    }
+
+    private static String normalize(String path) {
+        if (path == null || path.length() == 0) {
+            return "";
+        }
+        return path.replace('\\', separatorChar);
+    }
+
+    private static String join(String parent, String child) {
+        if (parent == null || parent.length() == 0) {
+            return child == null ? "" : child;
+        }
+        if (child == null || child.length() == 0) {
+            return parent;
+        }
+        if (child.charAt(0) == separatorChar) {
+            return child;
+        }
+        return parent.endsWith(separator) ? parent + child : parent + separator + child;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getName() {
+        int idx = path.lastIndexOf(separatorChar);
+        return idx >= 0 ? path.substring(idx + 1) : path;
+    }
+
+    public String getParent() {
+        int idx = path.lastIndexOf(separatorChar);
+        if (idx <= 0) {
+            return idx == 0 ? separator : null;
+        }
+        return path.substring(0, idx);
+    }
+
+    public File getParentFile() {
+        String parent = getParent();
+        return parent == null ? null : new File(parent);
+    }
+
+    public boolean isAbsolute() {
+        return path.startsWith(separator);
+    }
+
+    public String getAbsolutePath() {
+        return isAbsolute() ? path : separator + path;
+    }
+
+    public File getAbsoluteFile() {
+        return new File(getAbsolutePath());
+    }
+
+    public String getCanonicalPath() throws IOException {
+        return getAbsolutePath();
+    }
+
+    public File getCanonicalFile() throws IOException {
+        return getAbsoluteFile();
+    }
+
+    public boolean exists() {
+        return false;
+    }
+
+    public boolean isFile() {
+        return !path.endsWith(separator);
+    }
+
+    public boolean isDirectory() {
+        return path.endsWith(separator);
+    }
+
+    public boolean mkdirs() {
+        return true;
+    }
+
+    public boolean delete() {
+        return false;
+    }
+
+    public URI toURI() {
+        try {
+            return new URI("file:" + getAbsolutePath());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    public int compareTo(File pathname) {
+        return getPath().compareTo(pathname.getPath());
+    }
+
+    public int hashCode() {
+        return path.hashCode();
+    }
+
+    public boolean equals(Object obj) {
+        return obj instanceof File other && path.equals(other.path);
+    }
+
+    public String toString() {
+        return path;
+    }
+}

--- a/jdk-shim/java/io/FileInputStream.java
+++ b/jdk-shim/java/io/FileInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,16 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
-
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+public class FileInputStream extends InputStream {
+    public FileInputStream(String name) throws FileNotFoundException {
+        this(new File(name));
     }
 
-    public SocketException() {
-    }
+    public FileInputStream(File file) throws FileNotFoundException {}
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    public int read() throws IOException {
+        return -1;
     }
 }

--- a/jdk-shim/java/io/FileNotFoundException.java
+++ b/jdk-shim/java/io/FileNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,27 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
-
-public class SocketException extends IOException {
+/**
+ * Signals that an attempt to open the file denoted by a specified pathname
+ * has failed.
+ *
+ * @since 1.0
+ */
+public class FileNotFoundException extends IOException {
     @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
+    private static final long serialVersionUID = -897856973823710492L;
 
-    public SocketException(String msg) {
-        super(msg);
+    public FileNotFoundException() {
+        super();
     }
 
-    public SocketException() {
+    public FileNotFoundException(String s) {
+        super(s);
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    private FileNotFoundException(String path, String reason) {
+        super(path + ((reason == null) ? "" : " (" + reason + ")"));
     }
 }

--- a/jdk-shim/java/io/FileOutputStream.java
+++ b/jdk-shim/java/io/FileOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,22 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
-
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+public class FileOutputStream extends OutputStream {
+    public FileOutputStream(String name) throws FileNotFoundException {
+        this(new File(name), false);
     }
 
-    public SocketException() {
+    public FileOutputStream(String name, boolean append) throws FileNotFoundException {
+        this(new File(name), append);
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    public FileOutputStream(File file) throws FileNotFoundException {
+        this(file, false);
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
-    }
+    public FileOutputStream(File file, boolean append) throws FileNotFoundException {}
+
+    public void write(int b) throws IOException {}
 }

--- a/jdk-shim/java/io/FileWriter.java
+++ b/jdk-shim/java/io/FileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,22 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
-
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+public class FileWriter extends OutputStreamWriter {
+    public FileWriter(String fileName) throws IOException {
+        super(new FileOutputStream(fileName));
     }
 
-    public SocketException() {
+    public FileWriter(String fileName, boolean append) throws IOException {
+        super(new FileOutputStream(fileName, append));
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    public FileWriter(File file) throws IOException {
+        super(new FileOutputStream(file));
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
+    public FileWriter(File file, boolean append) throws IOException {
+        super(new FileOutputStream(file, append));
     }
 }

--- a/jdk-shim/java/io/InputStreamReader.java
+++ b/jdk-shim/java/io/InputStreamReader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+import java.nio.charset.Charset;
+
+public class InputStreamReader extends Reader {
+    private final InputStream in;
+    private final Charset charset;
+
+    public InputStreamReader(InputStream in) {
+        this(in, Charset.defaultCharset());
+    }
+
+    public InputStreamReader(InputStream in, Charset cs) {
+        super(in);
+        if (in == null) throw new NullPointerException();
+        if (cs == null) throw new NullPointerException();
+        this.in = in;
+        this.charset = cs;
+    }
+
+    public String getEncoding() {
+        return charset.name();
+    }
+
+    public int read() throws IOException {
+        int b = in.read();
+        if (b < 0) return -1;
+        return b & 0xff;
+    }
+
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        if (len == 0) return 0;
+        int count = 0;
+        while (count < len) {
+            int ch = read();
+            if (ch < 0) {
+                return count == 0 ? -1 : count;
+            }
+            cbuf[off + count] = (char) ch;
+            count++;
+        }
+        return count;
+    }
+
+    public boolean ready() throws IOException {
+        return false;
+    }
+
+    public void close() throws IOException {
+        in.close();
+    }
+}

--- a/jdk-shim/java/io/LineNumberReader.java
+++ b/jdk-shim/java/io/LineNumberReader.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+public class LineNumberReader extends Reader {
+    private final Reader in;
+    private int lineNumber;
+
+    public LineNumberReader(Reader in) {
+        this(in, 8192);
+    }
+
+    public LineNumberReader(Reader in, int sz) {
+        super(in);
+        if (in == null) throw new NullPointerException();
+        this.in = in;
+        this.lineNumber = 0;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public int read() throws IOException {
+        int ch = in.read();
+        if (ch == '\n') {
+            lineNumber++;
+        }
+        return ch;
+    }
+
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        if (len == 0) return 0;
+        int count = 0;
+        while (count < len) {
+            int ch = read();
+            if (ch < 0) {
+                return count == 0 ? -1 : count;
+            }
+            cbuf[off + count] = (char) ch;
+            count++;
+        }
+        return count;
+    }
+
+    public String readLine() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (;;) {
+            int ch = read();
+            if (ch < 0) {
+                return sb.length() == 0 ? null : sb.toString();
+            }
+            if (ch == '\n') {
+                return sb.toString();
+            }
+            if (ch == '\r') {
+                int next = in.read();
+                if (next == '\n') {
+                    lineNumber++;
+                } else if (next >= 0 && in instanceof PushbackReader pushback) {
+                    pushback.unread(next);
+                }
+                return sb.toString();
+            }
+            sb.append((char) ch);
+        }
+    }
+
+    public void close() throws IOException {
+        in.close();
+    }
+}

--- a/jdk-shim/java/io/NotSerializableException.java
+++ b/jdk-shim/java/io/NotSerializableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,23 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
+/**
+ * Thrown when an instance is required to have a Serializable interface.
+ *
+ * @since 1.1
+ */
+public class NotSerializableException extends ObjectStreamException {
 
-public class SocketException extends IOException {
     @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
+    private static final long serialVersionUID = 2906642554793891381L;
 
-    public SocketException(String msg) {
-        super(msg);
+    public NotSerializableException(String classname) {
+        super(classname);
     }
 
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    public NotSerializableException() {
+        super();
     }
 }

--- a/jdk-shim/java/io/OutputStreamWriter.java
+++ b/jdk-shim/java/io/OutputStreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,41 @@
  * questions.
  */
 
-package java.net;
+package java.io;
 
-import java.io.IOException;
+import java.nio.charset.Charset;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
+public class OutputStreamWriter extends Writer {
+    private final OutputStream out;
+    private final Charset charset;
 
-    public SocketException(String msg) {
-        super(msg);
+    public OutputStreamWriter(OutputStream out) {
+        this(out, Charset.defaultCharset());
     }
 
-    public SocketException() {
+    public OutputStreamWriter(OutputStream out, Charset cs) {
+        super(out);
+        if (out == null) throw new NullPointerException();
+        if (cs == null) throw new NullPointerException();
+        this.out = out;
+        this.charset = cs;
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    public String getEncoding() {
+        return charset.name();
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        for (int i = 0; i < len; i++) {
+            out.write((byte) cbuf[off + i]);
+        }
+    }
+
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    public void close() throws IOException {
+        out.close();
     }
 }

--- a/jdk-shim/java/io/PrintStream.java
+++ b/jdk-shim/java/io/PrintStream.java
@@ -31,7 +31,7 @@ import java.util.Formatter;
  * Minimal PrintStream stub.
  * println/print are handled natively by the VM.
  */
-public class PrintStream {
+public class PrintStream extends OutputStream {
     public native void println(String s);
     public native void println(Object o);
     public native void println(int i);
@@ -39,6 +39,10 @@ public class PrintStream {
     public native void print(String s);
     public native void print(Object o);
     public native void print(int i);
+
+    public void write(int b) {
+        print(String.valueOf((char) (b & 0xff)));
+    }
 
     public PrintStream format(String format, Object... args) {
         String s = new Formatter().format(format, args).toString();

--- a/jdk-shim/java/io/PrintWriter.java
+++ b/jdk-shim/java/io/PrintWriter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+public class PrintWriter extends Writer {
+    private final Writer out;
+    private final boolean autoFlush;
+
+    public PrintWriter(Writer out) {
+        this(out, false);
+    }
+
+    public PrintWriter(Writer out, boolean autoFlush) {
+        super(out);
+        if (out == null) throw new NullPointerException();
+        this.out = out;
+        this.autoFlush = autoFlush;
+    }
+
+    public void write(char[] cbuf, int off, int len) throws IOException {
+        out.write(cbuf, off, len);
+    }
+
+    public void write(int c) throws IOException {
+        out.write(c);
+    }
+
+    public void write(String s, int off, int len) throws IOException {
+        out.write(s, off, len);
+    }
+
+    public void print(String s) throws IOException {
+        out.write(s == null ? "null" : s);
+    }
+
+    public void print(Object obj) throws IOException {
+        print(String.valueOf(obj));
+    }
+
+    public void println() throws IOException {
+        out.write(System.lineSeparator());
+        if (autoFlush) out.flush();
+    }
+
+    public void println(String s) throws IOException {
+        print(s);
+        println();
+    }
+
+    public void println(Object obj) throws IOException {
+        print(obj);
+        println();
+    }
+
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    public void close() throws IOException {
+        out.close();
+    }
+}

--- a/jdk-shim/java/io/PushbackReader.java
+++ b/jdk-shim/java/io/PushbackReader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+public class PushbackReader extends Reader {
+    protected Reader in;
+    private final char[] buf;
+    private int pos;
+
+    public PushbackReader(Reader in) {
+        this(in, 1);
+    }
+
+    public PushbackReader(Reader in, int size) {
+        super(in);
+        if (in == null) throw new NullPointerException();
+        if (size <= 0) throw new IllegalArgumentException("size <= 0");
+        this.in = in;
+        this.buf = new char[size];
+        this.pos = size;
+    }
+
+    public int read() throws IOException {
+        if (pos < buf.length) {
+            return buf[pos++];
+        }
+        return in.read();
+    }
+
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        if (len == 0) return 0;
+        int count = 0;
+        while (count < len) {
+            int ch = read();
+            if (ch < 0) {
+                return count == 0 ? -1 : count;
+            }
+            cbuf[off + count] = (char) ch;
+            count++;
+        }
+        return count;
+    }
+
+    public void unread(int c) throws IOException {
+        if (pos == 0) throw new IOException("Pushback buffer overflow");
+        buf[--pos] = (char) c;
+    }
+
+    public boolean ready() throws IOException {
+        return pos < buf.length || in.ready();
+    }
+
+    public void close() throws IOException {
+        in.close();
+    }
+}

--- a/jdk-shim/java/lang/Class.java
+++ b/jdk-shim/java/lang/Class.java
@@ -144,18 +144,15 @@ public final class Class<T> implements Type {
     }
 
     private static native Class<?> forName0(String className);
+    private static native Class<?> forName1(String className, boolean initialize, ClassLoader loader);
 
     public static Class<?> forName(String className) throws ClassNotFoundException {
-        Class<?> c = forName0(className);
-        if (c == null) {
-            throw new ClassNotFoundException(className);
-        }
-        return c;
+        return forName1(className, true, ClassLoader.getSystemClassLoader());
     }
 
     public static Class<?> forName(String className, boolean initialize, ClassLoader loader)
             throws ClassNotFoundException {
-        Class<?> c = forName0(className);
+        Class<?> c = forName1(className, initialize, loader);
         if (c == null) {
             throw new ClassNotFoundException(className);
         }

--- a/jdk-shim/java/lang/ClassLoader.java
+++ b/jdk-shim/java/lang/ClassLoader.java
@@ -25,13 +25,108 @@
 
 package java.lang;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+
 public class ClassLoader {
-    protected ClassLoader() {}
+    private final ClassLoader parent;
+
+    protected ClassLoader() {
+        this(null);
+    }
+
+    protected ClassLoader(ClassLoader parent) {
+        this.parent = parent;
+    }
+
+    protected ClassLoader(String name, ClassLoader parent) {
+        this(parent);
+    }
 
     public static native ClassLoader getSystemClassLoader();
 
+    private static native int resourceCount0(String name);
+
+    private static String normalizeResourceName(String name) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        int index = 0;
+        while (index < name.length() && name.charAt(index) == '/') {
+            index++;
+        }
+        return index == 0 ? name : name.substring(index);
+    }
+
+    private static URL newBundleUrl(String name, int index) {
+        try {
+            String suffix = index == 0 ? "" : "?entry=" + index;
+            return new URL("bundle", "", "/" + name + suffix);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    public static URL getSystemResource(String name) {
+        String resourceName = normalizeResourceName(name);
+        return resourceCount0(resourceName) > 0 ? newBundleUrl(resourceName, 0) : null;
+    }
+
+    public static InputStream getSystemResourceAsStream(String name) {
+        URL url = getSystemResource(name);
+        if (url == null) {
+            return null;
+        }
+        try {
+            return url.openStream();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public static Enumeration<URL> getSystemResources(String name) throws IOException {
+        String resourceName = normalizeResourceName(name);
+        int count = resourceCount0(resourceName);
+        if (count == 0) {
+            return Collections.emptyEnumeration();
+        }
+        ArrayList<URL> urls = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            URL url = newBundleUrl(resourceName, i);
+            if (url != null) {
+                urls.add(url);
+            }
+        }
+        return Collections.enumeration(urls);
+    }
+
     public Class<?> loadClass(String name) throws ClassNotFoundException {
         return loadClass(name, false);
+    }
+
+    public URL getResource(String name) {
+        return getSystemResource(name);
+    }
+
+    public InputStream getResourceAsStream(String name) {
+        return getSystemResourceAsStream(name);
+    }
+
+    public Enumeration<URL> getResources(String name) throws IOException {
+        return getSystemResources(name);
+    }
+
+    protected URL findResource(String name) {
+        return getSystemResource(name);
+    }
+
+    protected Enumeration<URL> findResources(String name) throws IOException {
+        return getSystemResources(name);
     }
 
     // Simplified parent-delegation: checks the local registry via native stubs only.
@@ -48,6 +143,12 @@ public class ClassLoader {
     protected native Class<?> findLoadedClass(String name);
 
     protected native Class<?> findClass(String name) throws ClassNotFoundException;
+
+    public final ClassLoader getParent() {
+        return parent;
+    }
+
+    protected final void resolveClass(Class<?> c) {}
 
     protected final Class<?> defineClass(String name, byte[] b, int off, int len) {
         return null;

--- a/jdk-shim/java/lang/StackTraceElement.java
+++ b/jdk-shim/java/lang/StackTraceElement.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+import java.io.Serializable;
+
+public final class StackTraceElement implements Serializable {
+    private String declaringClass;
+    private String methodName;
+    private String fileName;
+    private int lineNumber;
+
+    public StackTraceElement(String declaringClass, String methodName, String fileName, int lineNumber) {
+        if (declaringClass == null || methodName == null) {
+            throw new NullPointerException();
+        }
+        this.declaringClass = declaringClass;
+        this.methodName = methodName;
+        this.fileName = fileName;
+        this.lineNumber = lineNumber;
+    }
+
+    public String getClassName() {
+        return declaringClass;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public boolean isNativeMethod() {
+        return lineNumber == -2;
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(declaringClass).append(".").append(methodName);
+        if (fileName != null) {
+            sb.append("(").append(fileName);
+            if (lineNumber >= 0) {
+                sb.append(":").append(lineNumber);
+            }
+            sb.append(")");
+        } else {
+            sb.append("(Unknown Source)");
+        }
+        return sb.toString();
+    }
+}

--- a/jdk-shim/java/lang/System.java
+++ b/jdk-shim/java/lang/System.java
@@ -25,16 +25,51 @@
 
 package java.lang;
 
+import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.Properties;
 
 public final class System {
     // These are resolved natively by the VM (resolve_static_field).
+    public static InputStream in = InputStream.nullInputStream();
     public static PrintStream out;
     public static PrintStream err;
+    private static final Properties props = initProperties();
 
     private System() {}
 
+    public static String getProperty(String key) {
+        return getProperties().getProperty(key);
+    }
+
+    public static String getProperty(String key, String def) {
+        return getProperties().getProperty(key, def);
+    }
+
+    public static Properties getProperties() {
+        return props;
+    }
+
+    public static String lineSeparator() {
+        return getProperty("line.separator", "\n");
+    }
+
     public static native void arraycopy(Object src, int srcPos, Object dest, int destPos, int length);
     public static native long currentTimeMillis();
+    public static native long nanoTime();
     public static native int identityHashCode(Object x);
+
+    private static Properties initProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("line.separator", "\n");
+        properties.setProperty("file.separator", "/");
+        properties.setProperty("path.separator", ":");
+        properties.setProperty("java.version", "25");
+        properties.setProperty("file.encoding", "UTF-8");
+        properties.setProperty("native.encoding", "UTF-8");
+        properties.setProperty("sun.jnu.encoding", "UTF-8");
+        properties.setProperty("user.dir", ".");
+        properties.setProperty("clojure.read.eval", "true");
+        return properties;
+    }
 }

--- a/jdk-shim/java/lang/Thread.java
+++ b/jdk-shim/java/lang/Thread.java
@@ -126,7 +126,7 @@ public class Thread implements Runnable {
     }
 
     public final ClassLoader getContextClassLoader() {
-        return contextClassLoader;
+        return contextClassLoader != null ? contextClassLoader : ClassLoader.getSystemClassLoader();
     }
 
     public void setContextClassLoader(ClassLoader cl) {

--- a/jdk-shim/java/lang/ThreadLocal.java
+++ b/jdk-shim/java/lang/ThreadLocal.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class ThreadLocal<T> {
+    private final HashMap<Long, T> values = new HashMap<>();
+
+    protected T initialValue() {
+        return null;
+    }
+
+    public static <S> ThreadLocal<S> withInitial(Supplier<? extends S> supplier) {
+        return new SuppliedThreadLocal<>(supplier);
+    }
+
+    public ThreadLocal() {}
+
+    public T get() {
+        Long key = currentThreadKey();
+        if (values.containsKey(key)) {
+            return values.get(key);
+        }
+        T value = initialValue();
+        values.put(key, value);
+        return value;
+    }
+
+    public void set(T value) {
+        values.put(currentThreadKey(), value);
+    }
+
+    public void remove() {
+        values.remove(currentThreadKey());
+    }
+
+    private Long currentThreadKey() {
+        return Long.valueOf(Thread.currentThread().getId());
+    }
+
+    private static final class SuppliedThreadLocal<T> extends ThreadLocal<T> {
+        private final Supplier<? extends T> supplier;
+
+        private SuppliedThreadLocal(Supplier<? extends T> supplier) {
+            this.supplier = Objects.requireNonNull(supplier);
+        }
+
+        protected T initialValue() {
+            return supplier.get();
+        }
+    }
+}

--- a/jdk-shim/java/lang/Throwable.java
+++ b/jdk-shim/java/lang/Throwable.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
 public class Throwable implements Serializable {
     private String detailMessage;
     private Throwable cause = this;
+    private StackTraceElement[] stackTrace = new StackTraceElement[0];
 
     public Throwable() {}
     public Throwable(String message) { this.detailMessage = message; }
@@ -57,6 +58,23 @@ public class Throwable implements Serializable {
     final void setCause(Throwable cause) {
         this.cause = cause;
     }
+
+    public Throwable fillInStackTrace() {
+        stackTrace = new StackTraceElement[0];
+        return this;
+    }
+
+    public StackTraceElement[] getStackTrace() {
+        return stackTrace.clone();
+    }
+
+    public void setStackTrace(StackTraceElement[] stackTrace) {
+        if (stackTrace == null) {
+            throw new NullPointerException();
+        }
+        this.stackTrace = stackTrace.clone();
+    }
+
     public String toString() {
         String s = getClass().getName();
         String message = getMessage();

--- a/jdk-shim/java/net/ServerSocket.java
+++ b/jdk-shim/java/net/ServerSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,22 +27,40 @@ package java.net;
 
 import java.io.IOException;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
+public class ServerSocket {
+    private final int localPort;
+    private final InetAddress bindAddr;
+    private boolean closed;
 
-    public SocketException(String msg) {
-        super(msg);
+    public ServerSocket(int port) throws IOException {
+        this(port, 50, null);
     }
 
-    public SocketException() {
+    public ServerSocket(int port, int backlog, InetAddress bindAddr) throws IOException {
+        this.localPort = port;
+        this.bindAddr = bindAddr == null ? InetAddress.getByName(null) : bindAddr;
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    public Socket accept() throws IOException {
+        if (closed) {
+            throw new SocketException("Socket is closed");
+        }
+        return new Socket();
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
+    public void close() throws IOException {
+        closed = true;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+
+    public int getLocalPort() {
+        return localPort;
+    }
+
+    public InetAddress getInetAddress() {
+        return bindAddr;
     }
 }

--- a/jdk-shim/java/net/Socket.java
+++ b/jdk-shim/java/net/Socket.java
@@ -25,24 +25,37 @@
 
 package java.net;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
+public class Socket implements Closeable {
+    private boolean closed;
 
-    public SocketException(String msg) {
-        super(msg);
+    public Socket() {}
+
+    public Socket(String host, int port) throws IOException {}
+
+    public InputStream getInputStream() throws IOException {
+        if (closed) {
+            throw new SocketException("Socket is closed");
+        }
+        return InputStream.nullInputStream();
     }
 
-    public SocketException() {
+    public OutputStream getOutputStream() throws IOException {
+        if (closed) {
+            throw new SocketException("Socket is closed");
+        }
+        return OutputStream.nullOutputStream();
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    public synchronized void close() throws IOException {
+        closed = true;
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
+    public boolean isClosed() {
+        return closed;
     }
 }

--- a/jdk-shim/java/net/URL.java
+++ b/jdk-shim/java/net/URL.java
@@ -25,6 +25,8 @@
 
 package java.net;
 
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -32,9 +34,9 @@ import java.io.InputStream;
  * Class {@code URL} represents a Uniform Resource Locator, a pointer to a
  * "resource" on the World Wide Web.
  *
- * <p>This shim implementation delegates parsing to {@link URI} and does not
- * support network I/O. {@link #openConnection()} and {@link #openStream()}
- * always throw {@link UnsupportedOperationException}.
+ * <p>This shim implementation delegates parsing to {@link URI}. Network I/O is
+ * not supported, but {@code bundle:} URLs are backed by the 199xVM bundle
+ * resource table.
  *
  * @author  James Gosling
  * @since   1.0
@@ -49,6 +51,32 @@ public final class URL implements java.io.Serializable {
     private final int port;
     private final String file;
     private final String ref;
+
+    private static native byte[] bundleResourceBytes0(String name, int index);
+    private static native long bundleResourceLastModified0(String name, int index);
+
+    private static String bundleResourceName(URL url) {
+        String path = url.getPath();
+        if (path == null || path.isEmpty()) {
+            return "";
+        }
+        return path.charAt(0) == '/' ? path.substring(1) : path;
+    }
+
+    private static int bundleResourceIndex(URL url) {
+        String query = url.getQuery();
+        if (query == null || query.isEmpty()) {
+            return 0;
+        }
+        if (!query.startsWith("entry=")) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(query.substring("entry=".length()));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
 
     /**
      * Creates a {@code URL} object from the {@code String} representation.
@@ -247,23 +275,52 @@ public final class URL implements java.io.Serializable {
     /**
      * Opens a connection to this {@code URL}.
      *
-     * <p>Network I/O is not supported in 199xVM.
-     *
-     * @throws UnsupportedOperationException always.
+     * <p>Network I/O is not supported in 199xVM. {@code bundle:} URLs resolve
+     * against the VM's embedded resource table.
      */
     public java.net.URLConnection openConnection() throws IOException {
+        if ("bundle".equals(protocol)) {
+            final String resourceName = bundleResourceName(this);
+            final int resourceIndex = bundleResourceIndex(this);
+            return new URLConnection(this) {
+                @Override
+                public void connect() throws IOException {}
+
+                @Override
+                public InputStream getInputStream() throws IOException {
+                    byte[] bytes = bundleResourceBytes0(resourceName, resourceIndex);
+                    if (bytes == null) {
+                        throw new FileNotFoundException(resourceName);
+                    }
+                    return new ByteArrayInputStream(bytes);
+                }
+
+                @Override
+                public int getContentLength() {
+                    byte[] bytes = bundleResourceBytes0(resourceName, resourceIndex);
+                    return bytes != null ? bytes.length : -1;
+                }
+
+                @Override
+                public long getContentLengthLong() {
+                    return getContentLength();
+                }
+
+                @Override
+                public long getLastModified() {
+                    return bundleResourceLastModified0(resourceName, resourceIndex);
+                }
+            };
+        }
         throw new UnsupportedOperationException("Network I/O not supported in 199xVM");
     }
 
     /**
      * Opens a connection to this {@code URL} and returns an {@code InputStream}.
      *
-     * <p>Network I/O is not supported in 199xVM.
-     *
-     * @throws UnsupportedOperationException always.
      */
     public InputStream openStream() throws IOException {
-        throw new UnsupportedOperationException("Network I/O not supported in 199xVM");
+        return openConnection().getInputStream();
     }
 
     /**

--- a/jdk-shim/java/net/URLClassLoader.java
+++ b/jdk-shim/java/net/URLClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,24 +25,37 @@
 
 package java.net;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.security.SecureClassLoader;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
+public class URLClassLoader extends SecureClassLoader implements Closeable {
+    private URL[] urls;
 
-    public SocketException(String msg) {
-        super(msg);
+    public URLClassLoader(URL[] urls, ClassLoader parent) {
+        super(parent);
+        this.urls = urls != null ? urls.clone() : new URL[0];
     }
 
-    public SocketException() {
+    public URLClassLoader(URL[] urls) {
+        super();
+        this.urls = urls != null ? urls.clone() : new URL[0];
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
+    protected void addURL(URL url) {
+        if (url == null) {
+            return;
+        }
+        URL[] newUrls = new URL[urls.length + 1];
+        System.arraycopy(urls, 0, newUrls, 0, urls.length);
+        newUrls[urls.length] = url;
+        urls = newUrls;
     }
 
-    public SocketException(Throwable cause) {
-        super(cause);
+    public URL[] getURLs() {
+        return urls.clone();
     }
+
+    @Override
+    public void close() throws IOException {}
 }

--- a/jdk-shim/java/nio/charset/Charset.java
+++ b/jdk-shim/java/nio/charset/Charset.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.nio.charset;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class Charset implements Comparable<Charset> {
+    private static final Charset UTF_8 = new Charset("UTF-8", new String[] { "UTF8", "utf8" });
+
+    private final String name;
+    private final String[] aliases;
+
+    protected Charset(String canonicalName, String[] aliases) {
+        checkName(canonicalName);
+        this.name = canonicalName;
+        this.aliases = aliases == null ? new String[0] : aliases.clone();
+    }
+
+    public static boolean isSupported(String charsetName) {
+        try {
+            forName(charsetName);
+            return true;
+        } catch (IllegalCharsetNameException e) {
+            return false;
+        } catch (UnsupportedCharsetException e) {
+            return false;
+        }
+    }
+
+    public static Charset forName(String charsetName) {
+        String normalized = normalize(charsetName);
+        if ("UTF-8".equals(normalized) || "UTF8".equals(normalized)) {
+            return UTF_8;
+        }
+        throw new UnsupportedCharsetException(charsetName);
+    }
+
+    public static Charset defaultCharset() {
+        return UTF_8;
+    }
+
+    public final String name() {
+        return name;
+    }
+
+    public final Set<String> aliases() {
+        HashSet<String> copy = new HashSet<>();
+        for (String alias : aliases) {
+            copy.add(alias);
+        }
+        return copy;
+    }
+
+    public String displayName() {
+        return name;
+    }
+
+    public final boolean isRegistered() {
+        return !name.startsWith("X-") && !name.startsWith("x-");
+    }
+
+    public boolean contains(Charset cs) {
+        return cs != null && name.equalsIgnoreCase(cs.name());
+    }
+
+    public final int compareTo(Charset that) {
+        return this.name.compareToIgnoreCase(that.name);
+    }
+
+    public final int hashCode() {
+        return name.toUpperCase().hashCode();
+    }
+
+    public final boolean equals(Object ob) {
+        if (!(ob instanceof Charset other)) return false;
+        return name.equalsIgnoreCase(other.name);
+    }
+
+    public final String toString() {
+        return name;
+    }
+
+    private static String normalize(String charsetName) {
+        if (charsetName == null) throw new IllegalArgumentException("Null charset name");
+        checkName(charsetName);
+        return charsetName.toUpperCase();
+    }
+
+    private static void checkName(String charsetName) {
+        if (charsetName == null || charsetName.length() == 0) {
+            throw new IllegalCharsetNameException(charsetName);
+        }
+        for (int i = 0; i < charsetName.length(); i++) {
+            char c = charsetName.charAt(i);
+            boolean ok =
+                (c >= 'A' && c <= 'Z') ||
+                (c >= 'a' && c <= 'z') ||
+                (c >= '0' && c <= '9') ||
+                c == '-' || c == '+' || c == '.' || c == ':' || c == '_';
+            if (!ok || (i == 0 && charsetName.length() == 0)) {
+                throw new IllegalCharsetNameException(charsetName);
+            }
+        }
+    }
+}

--- a/jdk-shim/java/nio/charset/IllegalCharsetNameException.java
+++ b/jdk-shim/java/nio/charset/IllegalCharsetNameException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,17 @@
  * questions.
  */
 
-package java.net;
+package java.nio.charset;
 
-import java.io.IOException;
+public class IllegalCharsetNameException extends IllegalArgumentException {
+    private String charsetName;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+    public IllegalCharsetNameException(String charsetName) {
+        super(String.valueOf(charsetName));
+        this.charsetName = charsetName;
     }
 
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    public String getCharsetName() {
+        return charsetName;
     }
 }

--- a/jdk-shim/java/nio/charset/StandardCharsets.java
+++ b/jdk-shim/java/nio/charset/StandardCharsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,10 @@
  * questions.
  */
 
-package java.net;
+package java.nio.charset;
 
-import java.io.IOException;
+public final class StandardCharsets {
+    public static final Charset UTF_8 = Charset.forName("UTF-8");
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
-    }
-
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
-    }
+    private StandardCharsets() {}
 }

--- a/jdk-shim/java/nio/charset/UnsupportedCharsetException.java
+++ b/jdk-shim/java/nio/charset/UnsupportedCharsetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,17 @@
  * questions.
  */
 
-package java.net;
+package java.nio.charset;
 
-import java.io.IOException;
+public class UnsupportedCharsetException extends IllegalArgumentException {
+    private String charsetName;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+    public UnsupportedCharsetException(String charsetName) {
+        super(String.valueOf(charsetName));
+        this.charsetName = charsetName;
     }
 
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    public String getCharsetName() {
+        return charsetName;
     }
 }

--- a/jdk-shim/java/nio/file/Files.java
+++ b/jdk-shim/java/nio/file/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,19 @@
  * questions.
  */
 
-package java.net;
+package java.nio.file;
 
-import java.io.IOException;
+import java.nio.file.attribute.FileAttribute;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
+public final class Files {
+    private static int tempCounter;
 
-    public SocketException(String msg) {
-        super(msg);
-    }
+    private Files() {}
 
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    public static Path createTempFile(String prefix, String suffix, FileAttribute<?>[] attrs) {
+        String p = prefix == null ? "tmp" : prefix;
+        String s = suffix == null ? ".tmp" : suffix;
+        int id = ++tempCounter;
+        return new SimplePath("/tmp/" + p + id + s);
     }
 }

--- a/jdk-shim/java/nio/file/Path.java
+++ b/jdk-shim/java/nio/file/Path.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,10 @@
  * questions.
  */
 
-package java.net;
+package java.nio.file;
 
-import java.io.IOException;
+import java.io.File;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
-    }
-
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
-    }
+public interface Path {
+    File toFile();
 }

--- a/jdk-shim/java/nio/file/SimplePath.java
+++ b/jdk-shim/java/nio/file/SimplePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,24 @@
  * questions.
  */
 
-package java.net;
+package java.nio.file;
 
-import java.io.IOException;
+import java.io.File;
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
+final class SimplePath implements Path {
+    private final String path;
 
-    public SocketException(String msg) {
-        super(msg);
+    SimplePath(String path) {
+        this.path = path == null ? "" : path;
     }
 
-    public SocketException() {
+    @Override
+    public File toFile() {
+        return new File(path);
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    @Override
+    public String toString() {
+        return path;
     }
 }

--- a/jdk-shim/java/nio/file/attribute/FileAttribute.java
+++ b/jdk-shim/java/nio/file/attribute/FileAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,9 @@
  * questions.
  */
 
-package java.net;
+package java.nio.file.attribute;
 
-import java.io.IOException;
-
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
-    }
-
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
-    }
+public interface FileAttribute<T> {
+    String name();
+    T value();
 }

--- a/jdk-shim/java/security/AccessController.java
+++ b/jdk-shim/java/security/AccessController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,13 @@
  * questions.
  */
 
-package java.net;
+package java.security;
 
-import java.io.IOException;
+@Deprecated(since = "17", forRemoval = true)
+public final class AccessController {
+    private AccessController() {}
 
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
-    }
-
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    public static <T> T doPrivileged(PrivilegedAction<T> action) {
+        return action.run();
     }
 }

--- a/jdk-shim/java/security/PrivilegedAction.java
+++ b/jdk-shim/java/security/PrivilegedAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,9 @@
  * questions.
  */
 
-package java.net;
+package java.security;
 
-import java.io.IOException;
-
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
-    }
-
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
-    }
+@FunctionalInterface
+public interface PrivilegedAction<T> {
+    T run();
 }

--- a/jdk-shim/java/security/SecureClassLoader.java
+++ b/jdk-shim/java/security/SecureClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,18 @@
  * questions.
  */
 
-package java.net;
+package java.security;
 
-import java.io.IOException;
-
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
+public class SecureClassLoader extends ClassLoader {
+    protected SecureClassLoader(ClassLoader parent) {
+        super(parent);
     }
 
-    public SocketException() {
+    protected SecureClassLoader() {
+        super();
     }
 
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
+    protected SecureClassLoader(String name, ClassLoader parent) {
+        super(name, parent);
     }
 }

--- a/jdk-shim/java/util/Arrays.java
+++ b/jdk-shim/java/util/Arrays.java
@@ -789,16 +789,7 @@ public final class Arrays {
      */
     @SuppressWarnings("unchecked")
     public static <T extends Comparable<? super T>> void parallelSort(T[] a) {
-        int n = a.length, p, g;
-        if (n <= MIN_ARRAY_SORT_GRAN ||
-            (p = ForkJoinPool.getCommonPoolParallelism()) == 1)
-            TimSort.sort(a, 0, n, NaturalOrder.INSTANCE, null, 0, 0);
-        else
-            new ArraysParallelSortHelpers.FJObject.Sorter<>
-                (null, a,
-                 (T[]) new Object[n],
-                 0, n, 0, ((g = n / (p << 2)) <= MIN_ARRAY_SORT_GRAN) ?
-                 MIN_ARRAY_SORT_GRAN : g, NaturalOrder.INSTANCE).invoke();
+        sort(a);
     }
 
     /**
@@ -847,17 +838,7 @@ public final class Arrays {
     @SuppressWarnings("unchecked")
     public static <T extends Comparable<? super T>>
     void parallelSort(T[] a, int fromIndex, int toIndex) {
-        rangeCheck(a.length, fromIndex, toIndex);
-        int n = toIndex - fromIndex, p, g;
-        if (n <= MIN_ARRAY_SORT_GRAN ||
-            (p = ForkJoinPool.getCommonPoolParallelism()) == 1)
-            TimSort.sort(a, fromIndex, toIndex, NaturalOrder.INSTANCE, null, 0, 0);
-        else
-            new ArraysParallelSortHelpers.FJObject.Sorter<>
-                (null, a,
-                 (T[]) new Object[n],
-                 fromIndex, n, 0, ((g = n / (p << 2)) <= MIN_ARRAY_SORT_GRAN) ?
-                 MIN_ARRAY_SORT_GRAN : g, NaturalOrder.INSTANCE).invoke();
+        sort(a, fromIndex, toIndex);
     }
 
     /**
@@ -895,18 +876,7 @@ public final class Arrays {
      */
     @SuppressWarnings("unchecked")
     public static <T> void parallelSort(T[] a, Comparator<? super T> cmp) {
-        if (cmp == null)
-            cmp = NaturalOrder.INSTANCE;
-        int n = a.length, p, g;
-        if (n <= MIN_ARRAY_SORT_GRAN ||
-            (p = ForkJoinPool.getCommonPoolParallelism()) == 1)
-            TimSort.sort(a, 0, n, cmp, null, 0, 0);
-        else
-            new ArraysParallelSortHelpers.FJObject.Sorter<>
-                (null, a,
-                 (T[]) new Object[n],
-                 0, n, 0, ((g = n / (p << 2)) <= MIN_ARRAY_SORT_GRAN) ?
-                 MIN_ARRAY_SORT_GRAN : g, cmp).invoke();
+        sort(a, cmp);
     }
 
     /**
@@ -955,19 +925,7 @@ public final class Arrays {
     @SuppressWarnings("unchecked")
     public static <T> void parallelSort(T[] a, int fromIndex, int toIndex,
                                         Comparator<? super T> cmp) {
-        rangeCheck(a.length, fromIndex, toIndex);
-        if (cmp == null)
-            cmp = NaturalOrder.INSTANCE;
-        int n = toIndex - fromIndex, p, g;
-        if (n <= MIN_ARRAY_SORT_GRAN ||
-            (p = ForkJoinPool.getCommonPoolParallelism()) == 1)
-            TimSort.sort(a, fromIndex, toIndex, cmp, null, 0, 0);
-        else
-            new ArraysParallelSortHelpers.FJObject.Sorter<>
-                (null, a,
-                 (T[]) new Object[n],
-                 fromIndex, n, 0, ((g = n / (p << 2)) <= MIN_ARRAY_SORT_GRAN) ?
-                 MIN_ARRAY_SORT_GRAN : g, cmp).invoke();
+        sort(a, fromIndex, toIndex, cmp);
     }
 
     /*
@@ -1028,10 +986,7 @@ public final class Arrays {
      *         {@link Comparable} contract
      */
     public static void sort(Object[] a) {
-        if (LegacyMergeSort.userRequested)
-            legacyMergeSort(a);
-        else
-            ComparableTimSort.sort(a, 0, a.length, null, 0, 0);
+        legacyMergeSort(a);
     }
 
     /** To be removed in a future release. */
@@ -1094,10 +1049,7 @@ public final class Arrays {
      */
     public static void sort(Object[] a, int fromIndex, int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
-        if (LegacyMergeSort.userRequested)
-            legacyMergeSort(a, fromIndex, toIndex);
-        else
-            ComparableTimSort.sort(a, fromIndex, toIndex, null, 0, 0);
+        legacyMergeSort(a, fromIndex, toIndex);
     }
 
     /** To be removed in a future release. */
@@ -1220,10 +1172,7 @@ public final class Arrays {
         if (c == null) {
             sort(a);
         } else {
-            if (LegacyMergeSort.userRequested)
-                legacyMergeSort(a, c);
-            else
-                TimSort.sort(a, 0, a.length, c, null, 0, 0);
+            legacyMergeSort(a, c);
         }
     }
 
@@ -1294,10 +1243,7 @@ public final class Arrays {
             sort(a, fromIndex, toIndex);
         } else {
             rangeCheck(a.length, fromIndex, toIndex);
-            if (LegacyMergeSort.userRequested)
-                legacyMergeSort(a, fromIndex, toIndex, c);
-            else
-                TimSort.sort(a, fromIndex, toIndex, c, null, 0, 0);
+            legacyMergeSort(a, fromIndex, toIndex, c);
         }
     }
 

--- a/jdk-shim/java/util/Properties.java
+++ b/jdk-shim/java/util/Properties.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Properties extends HashMap<Object, Object> {
+    protected Properties defaults;
+
+    public Properties() {
+        this(null);
+    }
+
+    public Properties(Properties defaults) {
+        this.defaults = defaults;
+    }
+
+    public Object setProperty(String key, String value) {
+        return put(key, value);
+    }
+
+    public String getProperty(String key) {
+        Object value = get(key);
+        if (value instanceof String s) {
+            return s;
+        }
+        return defaults == null ? null : defaults.getProperty(key);
+    }
+
+    public String getProperty(String key, String defaultValue) {
+        String value = getProperty(key);
+        return value == null ? defaultValue : value;
+    }
+
+    public java.util.Set<String> stringPropertyNames() {
+        java.util.HashSet<String> names = new java.util.HashSet<>();
+        for (Object key : keySet()) {
+            if (key instanceof String s) {
+                names.add(s);
+            }
+        }
+        if (defaults != null) {
+            names.addAll(defaults.stringPropertyNames());
+        }
+        return names;
+    }
+
+    public synchronized void load(InputStream inStream) throws IOException {
+        if (inStream == null) {
+            throw new NullPointerException();
+        }
+        byte[] bytes = inStream.readAllBytes();
+        String text = new String(bytes);
+        String[] lines = text.split("\n");
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i];
+            if (line.endsWith("\r")) {
+                line = line.substring(0, line.length() - 1);
+            }
+            line = line.trim();
+            if (line.length() == 0 || line.startsWith("#") || line.startsWith("!")) {
+                continue;
+            }
+            int sep = line.indexOf('=');
+            if (sep < 0) {
+                sep = line.indexOf(':');
+            }
+            if (sep < 0) {
+                put(line, "");
+                continue;
+            }
+            String key = line.substring(0, sep).trim();
+            String value = line.substring(sep + 1).trim();
+            put(key, value);
+        }
+    }
+}

--- a/jdk-shim/java/util/RandomAccess.java
+++ b/jdk-shim/java/util/RandomAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,12 @@
  * questions.
  */
 
-package java.net;
+package java.util;
 
-import java.io.IOException;
-
-public class SocketException extends IOException {
-    @java.io.Serial
-    private static final long serialVersionUID = -5935874303556886934L;
-
-    public SocketException(String msg) {
-        super(msg);
-    }
-
-    public SocketException() {
-    }
-
-    public SocketException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
-
-    public SocketException(Throwable cause) {
-        super(cause);
-    }
+/**
+ * Marker interface used by list implementations that support fast indexed access.
+ *
+ * @since 1.4
+ */
+public interface RandomAccess {
 }

--- a/jdk-shim/java/util/UUID.java
+++ b/jdk-shim/java/util/UUID.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.util;
+
+import java.io.Serializable;
+
+public final class UUID implements Serializable, Comparable<UUID> {
+    private static final long serialVersionUID = -4856846361193249489L;
+
+    private final long mostSigBits;
+    private final long leastSigBits;
+
+    public UUID(long mostSigBits, long leastSigBits) {
+        this.mostSigBits = mostSigBits;
+        this.leastSigBits = leastSigBits;
+    }
+
+    public static UUID randomUUID() {
+        long now = System.nanoTime();
+        long mix = (System.currentTimeMillis() << 32) ^ now ^ 0x9e3779b97f4a7c15L;
+        long msb = now ^ Long.rotateLeft(mix, 17);
+        long lsb = mix ^ Long.rotateLeft(now, 29);
+        msb &= 0xffffffffffff0fffL;
+        msb |= 0x0000000000004000L;
+        lsb &= 0x3fffffffffffffffL;
+        lsb |= 0x8000000000000000L;
+        return new UUID(msb, lsb);
+    }
+
+    public static UUID fromString(String name) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        String[] parts = name.split("-");
+        if (parts.length != 5) {
+            throw new IllegalArgumentException("Invalid UUID string: " + name);
+        }
+        long part0 = parseHex(parts[0], 8);
+        long part1 = parseHex(parts[1], 4);
+        long part2 = parseHex(parts[2], 4);
+        long part3 = parseHex(parts[3], 4);
+        long part4 = parseHex(parts[4], 12);
+        long msb = (part0 << 32) | (part1 << 16) | part2;
+        long lsb = (part3 << 48) | part4;
+        return new UUID(msb, lsb);
+    }
+
+    public long getMostSignificantBits() {
+        return mostSigBits;
+    }
+
+    public long getLeastSignificantBits() {
+        return leastSigBits;
+    }
+
+    public int version() {
+        return (int)((mostSigBits >>> 12) & 0x0f);
+    }
+
+    public int variant() {
+        return (int)((leastSigBits >>> 62) & 0x03);
+    }
+
+    public int hashCode() {
+        long hilo = mostSigBits ^ leastSigBits;
+        return (int)(hilo >> 32) ^ (int)hilo;
+    }
+
+    public boolean equals(Object obj) {
+        if (!(obj instanceof UUID other)) {
+            return false;
+        }
+        return mostSigBits == other.mostSigBits && leastSigBits == other.leastSigBits;
+    }
+
+    public int compareTo(UUID other) {
+        int cmp = Long.compare(mostSigBits, other.mostSigBits);
+        if (cmp != 0) {
+            return cmp;
+        }
+        return Long.compare(leastSigBits, other.leastSigBits);
+    }
+
+    public String toString() {
+        return digits(mostSigBits >>> 32, 8) + "-"
+            + digits(mostSigBits >>> 16, 4) + "-"
+            + digits(mostSigBits, 4) + "-"
+            + digits(leastSigBits >>> 48, 4) + "-"
+            + digits(leastSigBits, 12);
+    }
+
+    private static long parseHex(String value, int digits) {
+        if (value.length() != digits) {
+            throw new IllegalArgumentException("Invalid UUID string");
+        }
+        return Long.parseLong(value, 16);
+    }
+
+    private static String digits(long value, int digits) {
+        long mask = digits == 16 ? -1L : (1L << (digits * 4)) - 1L;
+        String text = Long.toHexString(value & mask);
+        if (text.length() >= digits) {
+            return text.substring(text.length() - digits);
+        }
+        StringBuilder sb = new StringBuilder(digits);
+        for (int i = text.length(); i < digits; i++) {
+            sb.append('0');
+        }
+        sb.append(text);
+        return sb.toString();
+    }
+}

--- a/jdk-shim/java/util/concurrent/atomic/AtomicInteger.java
+++ b/jdk-shim/java/util/concurrent/atomic/AtomicInteger.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.util.concurrent.atomic;
+
+import java.io.Serializable;
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntUnaryOperator;
+
+public class AtomicInteger extends Number implements Serializable {
+    private static final long serialVersionUID = 6214790243416807050L;
+
+    private volatile int value;
+
+    public AtomicInteger(int initialValue) {
+        this.value = initialValue;
+    }
+
+    public AtomicInteger() {}
+
+    public final int get() {
+        return value;
+    }
+
+    public final void set(int newValue) {
+        value = newValue;
+    }
+
+    public final void lazySet(int newValue) {
+        value = newValue;
+    }
+
+    public final int getAndSet(int newValue) {
+        int prev = value;
+        value = newValue;
+        return prev;
+    }
+
+    public final boolean compareAndSet(int expectedValue, int newValue) {
+        if (value == expectedValue) {
+            value = newValue;
+            return true;
+        }
+        return false;
+    }
+
+    public final int getAndIncrement() {
+        return getAndAdd(1);
+    }
+
+    public final int incrementAndGet() {
+        return addAndGet(1);
+    }
+
+    public final int getAndDecrement() {
+        return getAndAdd(-1);
+    }
+
+    public final int decrementAndGet() {
+        return addAndGet(-1);
+    }
+
+    public final int getAndAdd(int delta) {
+        int prev = value;
+        value = prev + delta;
+        return prev;
+    }
+
+    public final int addAndGet(int delta) {
+        value = value + delta;
+        return value;
+    }
+
+    public final int getAndUpdate(IntUnaryOperator updateFunction) {
+        int prev = value;
+        int next = updateFunction.applyAsInt(prev);
+        value = next;
+        return prev;
+    }
+
+    public final int updateAndGet(IntUnaryOperator updateFunction) {
+        int prev = value;
+        int next = updateFunction.applyAsInt(prev);
+        value = next;
+        return next;
+    }
+
+    public final int getAndAccumulate(int x, IntBinaryOperator accumulatorFunction) {
+        int prev = value;
+        int next = accumulatorFunction.applyAsInt(prev, x);
+        value = next;
+        return prev;
+    }
+
+    public final int accumulateAndGet(int x, IntBinaryOperator accumulatorFunction) {
+        int prev = value;
+        int next = accumulatorFunction.applyAsInt(prev, x);
+        value = next;
+        return next;
+    }
+
+    public int intValue() {
+        return value;
+    }
+
+    public long longValue() {
+        return value;
+    }
+
+    public float floatValue() {
+        return value;
+    }
+
+    public double doubleValue() {
+        return value;
+    }
+
+    public String toString() {
+        return Integer.toString(value);
+    }
+}

--- a/jdk-shim/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/jdk-shim/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.util.concurrent.locks;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+public class ReentrantReadWriteLock implements Serializable {
+    private static final long serialVersionUID = -6992448646407690164L;
+
+    private final ReadLock readerLock;
+    private final WriteLock writerLock;
+
+    public ReentrantReadWriteLock() {
+        this(false);
+    }
+
+    public ReentrantReadWriteLock(boolean fair) {
+        this.readerLock = new ReadLock(this);
+        this.writerLock = new WriteLock(this);
+    }
+
+    public WriteLock writeLock() {
+        return writerLock;
+    }
+
+    public ReadLock readLock() {
+        return readerLock;
+    }
+
+    public boolean isFair() {
+        return false;
+    }
+
+    public int getReadLockCount() {
+        return 0;
+    }
+
+    public boolean isWriteLocked() {
+        return false;
+    }
+
+    private static Condition newCondition0() {
+        return new Condition() {
+            public void await() throws InterruptedException {}
+            public void awaitUninterruptibly() {}
+            public long awaitNanos(long nanosTimeout) throws InterruptedException { return 0L; }
+            public boolean await(long time, TimeUnit unit) throws InterruptedException { return true; }
+            public boolean awaitUntil(Date deadline) throws InterruptedException { return true; }
+            public void signal() {}
+            public void signalAll() {}
+        };
+    }
+
+    public static class ReadLock implements Lock, Serializable {
+        private static final long serialVersionUID = -5992448646407690164L;
+        private final ReentrantReadWriteLock lock;
+
+        protected ReadLock(ReentrantReadWriteLock lock) {
+            this.lock = lock;
+        }
+
+        public void lock() {}
+
+        public void lockInterruptibly() throws InterruptedException {}
+
+        public boolean tryLock() {
+            return true;
+        }
+
+        public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+            return true;
+        }
+
+        public void unlock() {}
+
+        public Condition newCondition() {
+            return ReentrantReadWriteLock.newCondition0();
+        }
+
+        public String toString() {
+            return super.toString();
+        }
+    }
+
+    public static class WriteLock implements Lock, Serializable {
+        private static final long serialVersionUID = -4992448646407690164L;
+        private final ReentrantReadWriteLock lock;
+
+        protected WriteLock(ReentrantReadWriteLock lock) {
+            this.lock = lock;
+        }
+
+        public void lock() {}
+
+        public void lockInterruptibly() throws InterruptedException {}
+
+        public boolean tryLock() {
+            return true;
+        }
+
+        public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+            return true;
+        }
+
+        public void unlock() {}
+
+        public Condition newCondition() {
+            return ReentrantReadWriteLock.newCondition0();
+        }
+
+        public String toString() {
+            return super.toString();
+        }
+    }
+}

--- a/jdk-shim/java/util/regex/Matcher.java
+++ b/jdk-shim/java/util/regex/Matcher.java
@@ -42,87 +42,31 @@ public final class Matcher {
         return pattern;
     }
 
-    public Matcher reset() {
-        this.searchIndex = 0;
-        this.matchStart = -1;
-        this.matchEnd = -1;
-        return this;
-    }
+    public native Matcher reset();
 
-    public Matcher reset(CharSequence input) {
-        this.input = (input == null) ? "" : input.toString();
-        return reset();
-    }
+    public native Matcher reset(CharSequence input);
 
-    public boolean matches() {
-        boolean result = nativeMatches(pattern.pattern(), input);
-        if (result) {
-            matchStart = 0;
-            matchEnd = input.length();
-        } else {
-            matchStart = -1;
-            matchEnd = -1;
-        }
-        return result;
-    }
+    public native boolean matches();
 
     private static native boolean nativeMatches(String regex, String input);
 
-    public boolean find() {
-        String r = pattern.pattern();
-        if (r.length() == 0) {
-            matchStart = -1;
-            matchEnd = -1;
-            return false;
-        }
-        int at = -1;
-        if (searchIndex <= input.length()) {
-            int rel = input.substring(searchIndex).indexOf(r);
-            if (rel >= 0) {
-                at = searchIndex + rel;
-            }
-        }
-        if (at < 0) {
-            matchStart = -1;
-            matchEnd = -1;
-            return false;
-        }
-        matchStart = at;
-        matchEnd = at + r.length();
-        searchIndex = matchEnd;
-        return true;
-    }
+    public native boolean find();
 
-    public int start() {
-        return matchStart;
-    }
+    public native int start();
 
-    public int start(int group) {
-        return group == 0 ? matchStart : -1;
-    }
+    public native int start(int group);
 
-    public int end() {
-        return matchEnd;
-    }
+    public native int end();
 
-    public int end(int group) {
-        return group == 0 ? matchEnd : -1;
-    }
+    public native int end(int group);
 
-    public String group() {
-        if (matchStart < 0 || matchEnd < 0) {
-            return null;
-        }
-        return input.substring(matchStart, matchEnd);
-    }
+    public native String group();
 
-    public String group(int group) {
-        return group == 0 ? group() : null;
-    }
+    public native String group(int group);
 
-    public String group(String name) {
-        return group();
-    }
+    public native String group(String name);
+
+    public native int groupCount();
 
     public String replaceAll(String replacement) {
         String r = pattern.pattern();

--- a/jvm-core/src/interpreter/bytecode.rs
+++ b/jvm-core/src/interpreter/bytecode.rs
@@ -759,7 +759,7 @@ impl Vm {
                     self.ensure_class_init(&new_class)?;
                     // A ParseError entry means the class was registered but malformed —
                     // surface consistently as ClassFormatError (same as Class.forName0 path).
-                    if matches!(self.classes.get(&new_class), Some(super::LazyClass::ParseError(_))) {
+                    if matches!(self.classes.get(&new_class), Some(super::LazyClass::ParseError { .. })) {
                         self.throw_class_format_error(&new_class);
                         return Err(format!("java/lang/ClassFormatError: malformed class file for {new_class}"));
                     }

--- a/jvm-core/src/interpreter/dispatch.rs
+++ b/jvm-core/src/interpreter/dispatch.rs
@@ -470,8 +470,13 @@ impl Vm {
                         // Substitute argument — call toString() for objects.
                         if let Some(a) = args.get(arg_idx) {
                             let is_bool = arg_types.get(arg_idx) == Some(&'Z');
+                            let is_char = arg_types.get(arg_idx) == Some(&'C');
                             match a {
                                 JValue::Int(v) if is_bool => result.push_str(if *v != 0 { "true" } else { "false" }),
+                                JValue::Int(v) if is_char => {
+                                    let ch = char::from_u32((*v as u32) & 0xffff).unwrap_or('\u{fffd}');
+                                    result.push(ch);
+                                }
                                 JValue::Int(v) => result.push_str(&v.to_string()),
                                 JValue::Long(v) => result.push_str(&v.to_string()),
                                 JValue::Float(v) => result.push_str(&v.to_string()),

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -803,19 +803,51 @@ impl Vm {
         }
     }
 
-    fn pending_exception_err(&self) -> Option<String> {
-        self.scheduler.current_thread().pending_exception.as_ref().map(|r| {
-            let b = r.borrow();
-            let mut s = format!("Exception: {}", b.class_name);
-            if let Some(JValue::Ref(Some(msg_ref))) = b.fields.get("detailMessage") {
-                if let Some(msg) = msg_ref.borrow().as_java_string() {
-                    if !msg.is_empty() {
-                        s.push_str(": ");
-                        s.push_str(msg);
-                    }
+    fn pending_exception_err(&mut self) -> Option<String> {
+        let pending = self.scheduler.current_thread().pending_exception.clone();
+        pending.as_ref().map(|r| {
+            let mut parts = Vec::new();
+            let mut seen = HashSet::new();
+            let mut current = Some(Rc::clone(r));
+            while let Some(exc) = current {
+                let ptr = Rc::as_ptr(&exc) as usize;
+                if !seen.insert(ptr) {
+                    break;
                 }
+                let (class_name, part, direct_cause) = {
+                    let b = exc.borrow();
+                    let mut part = b.class_name.clone();
+                    if let Some(JValue::Ref(Some(msg_ref))) = b.fields.get("detailMessage") {
+                        if let Some(msg) = msg_ref.borrow().as_java_string() {
+                            if !msg.is_empty() {
+                                part.push_str(": ");
+                                part.push_str(msg);
+                            }
+                        }
+                    }
+                    let cause = b
+                        .fields
+                        .get("cause")
+                        .and_then(|v| v.as_ref())
+                        .cloned()
+                        .filter(|cause| Rc::as_ptr(cause) as usize != ptr);
+                    (b.class_name.clone(), part, cause)
+                };
+                parts.push(part);
+                current = direct_cause.or_else(|| {
+                    match self.invoke_virtual(
+                        exc.clone(),
+                        &class_name,
+                        "getCause",
+                        "()Ljava/lang/Throwable;",
+                        vec![],
+                    ) {
+                        Ok(JValue::Ref(Some(cause))) if Rc::as_ptr(&cause) as usize != ptr => Some(cause),
+                        _ => None,
+                    }
+                });
             }
-            s
+            format!("Exception: {}", parts.join(" <- "))
         })
     }
 

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -49,14 +49,28 @@ pub(super) struct MethodExecInfo {
 /// implementing standard ClassLoader lazy-loading semantics.
 pub(in crate::interpreter) enum LazyClass {
     /// Raw bytes not yet parsed.
-    Pending(Vec<u8>),
+    Pending(Rc<Vec<u8>>),
     /// Fully parsed class file.
-    Ready(ClassFile),
+    Ready {
+        class_file: ClassFile,
+        bytes: Option<Rc<Vec<u8>>>,
+    },
     /// Bytes were present but could not be parsed (malformed class).
     /// The entry is preserved so callers can distinguish "never registered"
     /// from "registered but broken", and to avoid repeated parse attempts.
     /// The inner `String` holds the original parse error message.
-    ParseError(String),
+    ParseError {
+        message: String,
+        bytes: Option<Rc<Vec<u8>>>,
+    },
+}
+
+/// A non-class resource registered in the VM's bundle image.
+pub(in crate::interpreter) struct ResourceEntry {
+    /// Resource payload bytes.
+    pub bytes: Vec<u8>,
+    /// Source timestamp exposed via URLConnection#getLastModified.
+    pub last_modified: i64,
 }
 
 mod annotations;
@@ -306,6 +320,12 @@ pub struct Vm {
     /// Static field storage keyed by class name → field name.
     /// Avoids allocating a `"ClassName.fieldName"` string on every getstatic/putstatic.
     pub(in crate::interpreter) static_fields: HashMap<String, HashMap<String, JValue>>,
+    /// Non-class resources keyed by classpath-relative name.
+    pub(in crate::interpreter) resources: HashMap<String, Vec<ResourceEntry>>,
+    /// Stable synthetic timestamp exposed for synthesized `*.class` resources.
+    /// Updated when newer explicit resources are loaded so AOT classes look at
+    /// least as fresh as bundled source resources during bootstrap.
+    synthetic_class_last_modified: i64,
     /// Classes whose `<clinit>` has already been run successfully.
     pub(in crate::interpreter) clinit_done: HashSet<String>,
     /// Classes whose `<clinit>` threw an exception (erroneous state per JVMS §5.5).
@@ -334,6 +354,8 @@ impl Vm {
             classes: HashMap::new(),
             string_pool: HashMap::new(),
             static_fields: HashMap::new(),
+            resources: HashMap::new(),
+            synthetic_class_last_modified: 1,
             clinit_done: HashSet::new(),
             clinit_failed: HashSet::new(),
             class_pool: HashMap::new(),
@@ -641,16 +663,77 @@ impl Vm {
     /// Register a pre-parsed class file (always stored as `Ready`).
     pub fn load_class(&mut self, class_file: ClassFile) {
         let name = class_file.constant_pool.class_name(class_file.this_class).to_owned();
-        self.classes.insert(name, LazyClass::Ready(class_file));
+        self.classes.insert(name, LazyClass::Ready { class_file, bytes: None });
     }
 
     /// Register raw `.class` bytes for lazy parsing.
     /// The class is parsed only when first accessed via [`Self::ensure_class_ready`].
     /// If the class is already registered (e.g., as `Ready`), the existing entry is kept.
     pub fn load_lazy(&mut self, name: String, bytes: Vec<u8>) {
-        self.classes.entry(name).or_insert(LazyClass::Pending(bytes));
+        self.classes.entry(name).or_insert(LazyClass::Pending(Rc::new(bytes)));
     }
 
+    fn normalize_resource_name(name: &str) -> &str {
+        name.trim_start_matches('/')
+    }
+
+    /// Register a non-class resource from a bundle.
+    pub fn load_resource(&mut self, name: String, bytes: Vec<u8>, last_modified: i64) {
+        let normalized = Self::normalize_resource_name(&name).to_owned();
+        self.synthetic_class_last_modified = self
+            .synthetic_class_last_modified
+            .max(last_modified.saturating_add(1));
+        self.resources
+            .entry(normalized)
+            .or_default()
+            .push(ResourceEntry { bytes, last_modified });
+    }
+
+    /// Return how many classpath resources are registered for the given name.
+    pub(in crate::interpreter) fn resource_count(&self, name: &str) -> usize {
+        let normalized = Self::normalize_resource_name(name);
+        if let Some(entries) = self.resources.get(normalized) {
+            entries.len()
+        } else if self.class_resource_bytes(normalized).is_some() {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Clone the bytes for a resource entry by logical name and classpath order index.
+    pub(in crate::interpreter) fn resource_bytes(&self, name: &str, index: usize) -> Option<Vec<u8>> {
+        let normalized = Self::normalize_resource_name(name);
+        if let Some(entries) = self.resources.get(normalized) {
+            entries.get(index).map(|entry| entry.bytes.clone())
+        } else if index == 0 {
+            self.class_resource_bytes(normalized).map(|bytes| bytes.to_vec())
+        } else {
+            None
+        }
+    }
+
+    /// Get the last-modified timestamp for a resource entry by logical name and index.
+    pub(in crate::interpreter) fn resource_last_modified(&self, name: &str, index: usize) -> Option<i64> {
+        let normalized = Self::normalize_resource_name(name);
+        if let Some(entries) = self.resources.get(normalized) {
+            entries.get(index).map(|entry| entry.last_modified)
+        } else if index == 0 && self.class_resource_bytes(normalized).is_some() {
+            Some(self.synthetic_class_last_modified)
+        } else {
+            None
+        }
+    }
+
+    fn class_resource_bytes(&self, resource_name: &str) -> Option<&[u8]> {
+        let class_name = resource_name.strip_suffix(".class")?;
+        match self.classes.get(class_name)? {
+            LazyClass::Pending(bytes) => Some(bytes.as_slice()),
+            LazyClass::Ready { bytes: Some(bytes), .. } => Some(bytes.as_slice()),
+            LazyClass::ParseError { bytes: Some(bytes), .. } => Some(bytes.as_slice()),
+            LazyClass::Ready { bytes: None, .. } | LazyClass::ParseError { bytes: None, .. } => None,
+        }
+    }
     /// Ensure the named class is fully parsed (`Ready`).
     /// If the entry is `Pending`, parses it in place and promotes it to `Ready`.
     /// On parse failure the entry is set to `ParseError` so the failure is
@@ -662,11 +745,19 @@ impl Vm {
             return;
         }
         if let Some(LazyClass::Pending(bytes)) = self.classes.remove(name) {
-            match class_file::parse(&bytes) {
-                Ok(cf) => { self.classes.insert(name.to_owned(), LazyClass::Ready(cf)); }
+            match class_file::parse(bytes.as_slice()) {
+                Ok(cf) => {
+                    self.classes.insert(name.to_owned(), LazyClass::Ready {
+                        class_file: cf,
+                        bytes: Some(bytes),
+                    });
+                }
                 Err(e) => {
                     eprintln!("Warning: failed to parse class '{name}': {e}");
-                    self.classes.insert(name.to_owned(), LazyClass::ParseError(e.to_string()));
+                    self.classes.insert(name.to_owned(), LazyClass::ParseError {
+                        message: e.to_string(),
+                        bytes: Some(bytes),
+                    });
                 }
             }
         }
@@ -676,8 +767,8 @@ impl Vm {
     /// Caller must have called `ensure_class_ready` first (or know the class is already Ready).
     pub(in crate::interpreter) fn get_class(&self, name: &str) -> Option<&ClassFile> {
         match self.classes.get(name)? {
-            LazyClass::Ready(cf) => Some(cf),
-            LazyClass::Pending(_) | LazyClass::ParseError(_) => None,
+            LazyClass::Ready { class_file, .. } => Some(class_file),
+            LazyClass::Pending(_) | LazyClass::ParseError { .. } => None,
         }
     }
 

--- a/jvm-core/src/interpreter/native_static.rs
+++ b/jvm-core/src/interpreter/native_static.rs
@@ -219,9 +219,9 @@ impl super::Vm {
                 }
                 self.ensure_class_ready(&internal);
                 match self.classes.get(&internal) {
-                    Some(super::LazyClass::Ready(_)) => {}
-                    Some(super::LazyClass::ParseError(msg)) => {
-                        let msg = msg.clone();
+                    Some(super::LazyClass::Ready { .. }) => {}
+                    Some(super::LazyClass::ParseError { message, .. }) => {
+                        let msg = message.clone();
                         self.throw_class_format_error(&msg);
                         return Some(JValue::Void);
                     }
@@ -232,9 +232,75 @@ impl super::Vm {
                 }
                 Some(JValue::Ref(Some(self.class_object(internal))))
             }
+            ("java/lang/Class", "forName1", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;") => {
+                let runtime_name = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))?;
+                let initialize = _args.get(1).map(|v| v.as_int() != 0).unwrap_or(false);
+                let internal = Self::class_internal_name_from_runtime_name(&runtime_name);
+                if matches!(
+                    internal.as_str(),
+                    "boolean" | "byte" | "char" | "short" | "int" | "long" | "float" | "double" | "void"
+                ) {
+                    return Some(JValue::Ref(Some(self.class_object(internal))));
+                }
+                if internal.starts_with('[') {
+                    return Some(JValue::Ref(Some(self.class_object(internal))));
+                }
+                self.ensure_class_ready(&internal);
+                match self.classes.get(&internal) {
+                    Some(super::LazyClass::Ready { .. }) => {}
+                    Some(super::LazyClass::ParseError { message, .. }) => {
+                        let msg = message.clone();
+                        self.throw_class_format_error(&msg);
+                        return Some(JValue::Void);
+                    }
+                    _ => {
+                        self.throw_class_not_found(&runtime_name);
+                        return Some(JValue::Void);
+                    }
+                }
+                if initialize && self.ensure_class_init(&internal).is_err() {
+                    return Some(JValue::Void);
+                }
+                Some(JValue::Ref(Some(self.class_object(internal))))
+            }
             ("java/lang/ClassLoader", "getSystemClassLoader", "()Ljava/lang/ClassLoader;") => {
                 let cl = self.get_or_create_system_classloader();
                 Some(JValue::Ref(Some(cl)))
+            }
+            ("java/lang/ClassLoader", "resourceCount0", "(Ljava/lang/String;)I") => {
+                let name = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .unwrap_or_default();
+                Some(JValue::Int(self.resource_count(&name) as i32))
+            }
+            ("java/net/URL", "bundleResourceBytes0", "(Ljava/lang/String;I)[B") => {
+                let name = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .unwrap_or_default();
+                let index = _args.get(1).map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                match self.resource_bytes(&name, index) {
+                    Some(bytes) => {
+                        let elems = bytes.into_iter().map(|b| JValue::Int(i32::from(b))).collect();
+                        Some(JValue::Ref(Some(JObject::new_array("[B", elems))))
+                    }
+                    None => Some(JValue::Ref(None)),
+                }
+            }
+            ("java/net/URL", "bundleResourceLastModified0", "(Ljava/lang/String;I)J") => {
+                let name = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .unwrap_or_default();
+                let index = _args.get(1).map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                Some(JValue::Long(self.resource_last_modified(&name, index).unwrap_or(0)))
             }
             ("java/lang/System", "currentTimeMillis", "()J") => {
                 #[cfg(target_arch = "wasm32")]

--- a/jvm-core/src/interpreter/native_static.rs
+++ b/jvm-core/src/interpreter/native_static.rs
@@ -60,6 +60,9 @@ impl super::Vm {
                 let p = JObject::new("java/util/regex/Pattern");
                 p.borrow_mut().fields.insert("__regex".to_owned(), JValue::Ref(Some(self.intern_string(regex))));
                 p.borrow_mut().fields.insert("__flags".to_owned(), JValue::Int(0));
+                let regex_ref = p.borrow().fields.get("__regex").cloned().unwrap_or(JValue::Ref(None));
+                p.borrow_mut().fields.insert("regex".to_owned(), regex_ref);
+                p.borrow_mut().fields.insert("flags".to_owned(), JValue::Int(0));
                 Some(JValue::Ref(Some(p)))
             }
             ("java/util/regex/Pattern", "compile", "(Ljava/lang/String;I)Ljava/util/regex/Pattern;") => {
@@ -72,6 +75,9 @@ impl super::Vm {
                 let p = JObject::new("java/util/regex/Pattern");
                 p.borrow_mut().fields.insert("__regex".to_owned(), JValue::Ref(Some(self.intern_string(regex))));
                 p.borrow_mut().fields.insert("__flags".to_owned(), JValue::Int(flags));
+                let regex_ref = p.borrow().fields.get("__regex").cloned().unwrap_or(JValue::Ref(None));
+                p.borrow_mut().fields.insert("regex".to_owned(), regex_ref);
+                p.borrow_mut().fields.insert("flags".to_owned(), JValue::Int(flags));
                 Some(JValue::Ref(Some(p)))
             }
             ("java/util/regex/Pattern", "matches", "(Ljava/lang/String;Ljava/lang/CharSequence;)Z") => {
@@ -312,6 +318,17 @@ impl super::Vm {
                     .map(|d| d.as_millis() as i64)
                     .unwrap_or(0);
                 Some(JValue::Long(ms))
+            }
+            ("java/lang/System", "nanoTime", "()J") => {
+                #[cfg(target_arch = "wasm32")]
+                let ns = (js_sys::Date::now() * 1_000_000.0) as i64;
+                #[cfg(not(target_arch = "wasm32"))]
+                let ns = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .ok()
+                    .map(|d| d.as_nanos() as i64)
+                    .unwrap_or(0);
+                Some(JValue::Long(ns))
             }
             ("java/lang/System", "identityHashCode", "(Ljava/lang/Object;)I") => {
                 let hc = _args

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -20,6 +20,10 @@ fn char_to_byte_offset(s: &str, char_idx: usize) -> usize {
     s.char_indices().nth(char_idx).map(|(b, _)| b).unwrap_or(s.len())
 }
 
+fn regex_full_pattern(regex: &str) -> String {
+    format!("^(?:{regex})$")
+}
+
 impl super::Vm {
     /// Extract a Rust `String` from `java/lang/String` constructor arguments based on the method descriptor.
     /// Returns an empty string if the descriptor is not recognized or arguments are invalid.
@@ -252,6 +256,80 @@ impl super::Vm {
         }
     }
 
+    fn matcher_regex_and_input(&self, this: &JRef) -> (String, String, usize) {
+        let mb = this.borrow();
+        let pattern_ref = mb.fields.get("__pattern")
+            .or_else(|| mb.fields.get("pattern"))
+            .and_then(|v| v.as_ref())
+            .cloned();
+        let regex = pattern_ref
+            .as_ref()
+            .and_then(|p| p.borrow().fields.get("__regex").cloned()
+                .or_else(|| p.borrow().fields.get("regex").cloned()))
+            .and_then(|v| v.as_ref().cloned())
+            .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
+            .unwrap_or_default();
+        let input = mb.fields.get("__input")
+            .or_else(|| mb.fields.get("input"))
+            .and_then(|v| v.as_ref())
+            .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
+            .unwrap_or_default();
+        let search_index = mb.fields.get("__search_index")
+            .or_else(|| mb.fields.get("searchIndex"))
+            .map(|v| v.as_int().max(0) as usize)
+            .unwrap_or(0);
+        (regex, input, search_index)
+    }
+
+    fn clear_matcher_state(&mut self, this: &JRef, search_index: usize) {
+        let mut mb = this.borrow_mut();
+        mb.fields.insert("__group_count".to_owned(), JValue::Int(0));
+        mb.fields.insert("__search_index".to_owned(), JValue::Int(search_index as i32));
+        mb.fields.insert("searchIndex".to_owned(), JValue::Int(search_index as i32));
+        mb.fields.insert("matchStart".to_owned(), JValue::Int(-1));
+        mb.fields.insert("matchEnd".to_owned(), JValue::Int(-1));
+    }
+
+    fn store_matcher_captures(
+        &mut self,
+        this: &JRef,
+        input: &str,
+        base_byte: usize,
+        captures: &regex::Captures<'_>,
+        next_search_chars: usize,
+    ) {
+        let group_count = captures.len().saturating_sub(1) as i32;
+        let mut group_values: Vec<(String, JValue, i32, i32)> = Vec::with_capacity(captures.len());
+        for i in 0..captures.len() {
+            let key = format!("__group_{i}");
+            if let Some(m) = captures.get(i) {
+                let start_byte = base_byte + m.start();
+                let end_byte = base_byte + m.end();
+                let start_char = input[..start_byte].chars().count() as i32;
+                let end_char = input[..end_byte].chars().count() as i32;
+                let text = self.intern_string(m.as_str());
+                group_values.push((key, JValue::Ref(Some(text)), start_char, end_char));
+            } else {
+                group_values.push((key, JValue::Ref(None), -1, -1));
+            }
+        }
+        let (match_start, match_end) = group_values
+            .first()
+            .map(|(_, _, s, e)| (*s, *e))
+            .unwrap_or((-1, -1));
+        let mut mb = this.borrow_mut();
+        mb.fields.insert("__group_count".to_owned(), JValue::Int(group_count));
+        mb.fields.insert("__search_index".to_owned(), JValue::Int(next_search_chars as i32));
+        mb.fields.insert("searchIndex".to_owned(), JValue::Int(next_search_chars as i32));
+        mb.fields.insert("matchStart".to_owned(), JValue::Int(match_start));
+        mb.fields.insert("matchEnd".to_owned(), JValue::Int(match_end));
+        for (i, (key, value, start, end)) in group_values.into_iter().enumerate() {
+            mb.fields.insert(key, value);
+            mb.fields.insert(format!("__start_{i}"), JValue::Int(start));
+            mb.fields.insert(format!("__end_{i}"), JValue::Int(end));
+        }
+    }
+
     pub(super) fn native_virtual(
         &mut self,
         this: &JRef,
@@ -337,6 +415,13 @@ impl super::Vm {
         }
         let cn = this.borrow().class_name.clone();
         match (cn.as_str(), method_name) {
+            ("java/util/regex/Pattern", "pattern") => {
+                let regex = this.borrow().fields.get("__regex").cloned().unwrap_or(JValue::Ref(None));
+                Some(regex)
+            }
+            ("java/util/regex/Pattern", "flags") => {
+                Some(this.borrow().fields.get("__flags").cloned().unwrap_or(JValue::Int(0)))
+            }
             ("java/util/regex/Pattern", "matcher") => {
                 let input = _args
                     .first()
@@ -346,7 +431,97 @@ impl super::Vm {
                 let m = JObject::new("java/util/regex/Matcher");
                 m.borrow_mut().fields.insert("__pattern".to_owned(), JValue::Ref(Some(this.clone())));
                 m.borrow_mut().fields.insert("__input".to_owned(), JValue::Ref(Some(self.intern_string(input))));
+                m.borrow_mut().fields.insert("pattern".to_owned(), JValue::Ref(Some(this.clone())));
+                let input_ref = m.borrow().fields.get("__input").cloned().unwrap_or(JValue::Ref(None));
+                m.borrow_mut().fields.insert("input".to_owned(), input_ref);
+                m.borrow_mut().fields.insert("__search_index".to_owned(), JValue::Int(0));
+                m.borrow_mut().fields.insert("searchIndex".to_owned(), JValue::Int(0));
+                m.borrow_mut().fields.insert("matchStart".to_owned(), JValue::Int(-1));
+                m.borrow_mut().fields.insert("matchEnd".to_owned(), JValue::Int(-1));
                 Some(JValue::Ref(Some(m)))
+            }
+            ("java/util/regex/Matcher", "matches") => {
+                let (regex, input, _) = self.matcher_regex_and_input(this);
+                let anchored = regex_full_pattern(&regex);
+                match regex::Regex::new(&anchored).ok().and_then(|re| re.captures(&input)) {
+                    Some(caps) => {
+                        self.store_matcher_captures(this, &input, 0, &caps, input.chars().count());
+                        Some(JValue::Int(1))
+                    }
+                    None => {
+                        self.clear_matcher_state(this, 0);
+                        Some(JValue::Int(0))
+                    }
+                }
+            }
+            ("java/util/regex/Matcher", "find") => {
+                let (regex, input, search_index) = self.matcher_regex_and_input(this);
+                let start_byte = char_to_byte_offset(&input, search_index);
+                match regex::Regex::new(&regex)
+                    .ok()
+                    .and_then(|re| re.captures(&input[start_byte..]))
+                {
+                    Some(caps) => {
+                        let whole = caps.get(0);
+                        let next_chars = whole
+                            .map(|m| input[..start_byte + m.end()].chars().count())
+                            .unwrap_or(search_index);
+                        self.store_matcher_captures(this, &input, start_byte, &caps, next_chars);
+                        Some(JValue::Int(1))
+                    }
+                    None => {
+                        self.clear_matcher_state(this, search_index);
+                        Some(JValue::Int(0))
+                    }
+                }
+            }
+            ("java/util/regex/Matcher", "groupCount") => {
+                Some(this.borrow().fields.get("__group_count").cloned().unwrap_or(JValue::Int(0)))
+            }
+            ("java/util/regex/Matcher", "group") if _descriptor == "()Ljava/lang/String;" => {
+                Some(this.borrow().fields.get("__group_0").cloned().unwrap_or(JValue::Ref(None)))
+            }
+            ("java/util/regex/Matcher", "group") if _descriptor == "(I)Ljava/lang/String;" => {
+                let idx = _args.first().map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                let max = this.borrow().fields.get("__group_count").map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                if idx > max {
+                    Some(JValue::Ref(None))
+                } else {
+                    Some(this.borrow().fields.get(&format!("__group_{idx}")).cloned().unwrap_or(JValue::Ref(None)))
+                }
+            }
+            ("java/util/regex/Matcher", "group") if _descriptor == "(Ljava/lang/String;)Ljava/lang/String;" => {
+                Some(this.borrow().fields.get("__group_0").cloned().unwrap_or(JValue::Ref(None)))
+            }
+            ("java/util/regex/Matcher", "start") if _descriptor == "()I" => {
+                Some(this.borrow().fields.get("__start_0").cloned().unwrap_or(JValue::Int(-1)))
+            }
+            ("java/util/regex/Matcher", "start") if _descriptor == "(I)I" => {
+                let idx = _args.first().map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                Some(this.borrow().fields.get(&format!("__start_{idx}")).cloned().unwrap_or(JValue::Int(-1)))
+            }
+            ("java/util/regex/Matcher", "end") if _descriptor == "()I" => {
+                Some(this.borrow().fields.get("__end_0").cloned().unwrap_or(JValue::Int(-1)))
+            }
+            ("java/util/regex/Matcher", "end") if _descriptor == "(I)I" => {
+                let idx = _args.first().map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                Some(this.borrow().fields.get(&format!("__end_{idx}")).cloned().unwrap_or(JValue::Int(-1)))
+            }
+            ("java/util/regex/Matcher", "reset") if _descriptor == "()Ljava/util/regex/Matcher;" => {
+                self.clear_matcher_state(this, 0);
+                Some(JValue::Ref(Some(this.clone())))
+            }
+            ("java/util/regex/Matcher", "reset") if _descriptor == "(Ljava/lang/CharSequence;)Ljava/util/regex/Matcher;" => {
+                let input = _args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .unwrap_or_default();
+                let input_ref = self.intern_string(input);
+                this.borrow_mut().fields.insert("__input".to_owned(), JValue::Ref(Some(input_ref.clone())));
+                this.borrow_mut().fields.insert("input".to_owned(), JValue::Ref(Some(input_ref)));
+                self.clear_matcher_state(this, 0);
+                Some(JValue::Ref(Some(this.clone())))
             }
             ("java/lang/Class", "getName") => {
                 let internal = self

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -217,9 +217,9 @@ impl super::Vm {
                 let internal = Self::class_internal_name_from_runtime_name(&name_str);
                 self.ensure_class_ready(&internal);
                 match self.classes.get(&internal) {
-                    Some(LazyClass::Ready(_)) => {}
-                    Some(LazyClass::ParseError(msg)) => {
-                        let msg = msg.clone();
+                    Some(LazyClass::Ready { .. }) => {}
+                    Some(LazyClass::ParseError { message, .. }) => {
+                        let msg = message.clone();
                         self.throw_class_format_error(&msg);
                         return Some(JValue::Void);
                     }
@@ -237,7 +237,7 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
                     .unwrap_or_default();
                 let internal = Self::class_internal_name_from_runtime_name(&name_str);
-                if matches!(self.classes.get(&internal), Some(LazyClass::Ready(_))) {
+                if matches!(self.classes.get(&internal), Some(LazyClass::Ready { .. })) {
                     Some(JValue::Ref(Some(self.class_object(internal))))
                 } else {
                     Some(JValue::Ref(None))
@@ -348,29 +348,25 @@ impl super::Vm {
                 m.borrow_mut().fields.insert("__input".to_owned(), JValue::Ref(Some(self.intern_string(input))));
                 Some(JValue::Ref(Some(m)))
             }
-            ("java/util/regex/Matcher", "matches") => {
-                let (regex, input) = {
-                    let mb = this.borrow();
-                    let regex = mb.fields.get("__pattern")
-                        .and_then(|v| v.as_ref())
-                        .and_then(|p| p.borrow().fields.get("__regex").cloned())
-                        .and_then(|v| v.as_ref().cloned())
-                        .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
-                        .unwrap_or_default();
-                    let input = mb.fields.get("__input")
-                        .and_then(|v| v.as_ref())
-                        .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
-                        .unwrap_or_default();
-                    (regex, input)
-                };
-                let ok = super::native_static::regex_full_match(&regex, &input);
-                Some(JValue::Int(if ok { 1 } else { 0 }))
-            }
             ("java/lang/Class", "getName") => {
                 let internal = self
                     .class_internal_name_from_obj(this)
                     .unwrap_or_else(|| "java/lang/Object".to_owned());
                 Some(JValue::Ref(Some(self.intern_string(Self::class_display_name(&internal)))))
+            }
+            ("java/lang/Class", "getClassLoader") => {
+                let target = self
+                    .class_internal_name_from_obj(this)
+                    .unwrap_or_else(|| "java/lang/Object".to_owned());
+                let loader = if matches!(
+                    target.as_str(),
+                    "boolean" | "byte" | "char" | "short" | "int" | "long" | "float" | "double" | "void"
+                ) {
+                    None
+                } else {
+                    Some(self.get_or_create_system_classloader())
+                };
+                Some(JValue::Ref(loader))
             }
             ("java/lang/Class", "getModifiers") => {
                 let target = self

--- a/jvm-core/src/lib.rs
+++ b/jvm-core/src/lib.rs
@@ -14,12 +14,14 @@ use class_file::{parse, parse_class_name};
 use heap::JValue;
 use interpreter::Vm;
 
-/// Load one or more `.class` files and invoke a static method.
+const RESOURCE_MAGIC: &[u8; 4] = b"RSRC";
+
+/// Load a bundle image and invoke a static method.
 ///
 /// # Arguments
 ///
-/// * `class_data` — concatenated raw `.class` bytes (each class preceded by a
-///   4-byte big-endian length).
+/// * `class_data` — concatenated bundle entries (each entry preceded by a
+///   4-byte big-endian payload length).
 /// * `main_class` — internal class name of the entry point (e.g.
 ///   `"net/unit8/raoh/Decoders"`).
 /// * `method_name` — static method to invoke (e.g. `"run"`).
@@ -92,11 +94,13 @@ pub fn run_static_native(
     out
 }
 
-/// Load classes from bundle bytes into a VM using lazy parsing.
+/// Load classes and resources from bundle bytes into a VM using lazy parsing.
 ///
-/// Each class's raw bytes are registered under its internal class name.
-/// The class is not parsed until it is first accessed during execution,
-/// matching standard ClassLoader lazy-loading semantics.
+/// Class entries are raw `.class` bytes registered under their internal class
+/// name. Resource entries use a small `RSRC` envelope carrying path, payload,
+/// and last-modified metadata. Classes are not parsed until first access,
+/// matching standard ClassLoader lazy-loading semantics, and `*.class`
+/// resources are synthesized from the loaded class table.
 pub fn load_bundle(vm: &mut Vm, class_bundle: &[u8]) {
     let mut pos = 0usize;
     while pos + 4 <= class_bundle.len() {
@@ -110,9 +114,15 @@ pub fn load_bundle(vm: &mut Vm, class_bundle: &[u8]) {
         if pos + len > class_bundle.len() { break; }
         let class_bytes = &class_bundle[pos..pos + len];
         pos += len;
+        if let Some((name, last_modified, bytes)) = parse_resource_entry(class_bytes) {
+            vm.load_resource(name, bytes, last_modified);
+            continue;
+        }
         match parse_class_name(class_bytes) {
-            Some(name) => vm.load_lazy(name, class_bytes.to_vec()),
-            None => eprintln!("Warning: skipping class with unreadable name"),
+            Some(name) => {
+                vm.load_lazy(name, class_bytes.to_vec());
+            }
+            None => eprintln!("Warning: skipping bundle entry with unreadable name"),
         }
     }
 }
@@ -139,4 +149,21 @@ fn jvalue_to_string(v: &JValue) -> String {
         }
         JValue::ReturnAddress(a) => format!("ret:{a}"),
     }
+}
+
+fn parse_resource_entry(payload: &[u8]) -> Option<(String, i64, Vec<u8>)> {
+    if payload.len() < 20 || &payload[..4] != RESOURCE_MAGIC {
+        return None;
+    }
+    let path_len = u32::from_be_bytes(payload[4..8].try_into().ok()?) as usize;
+    let last_modified = i64::from_be_bytes(payload[8..16].try_into().ok()?);
+    let data_len = u32::from_be_bytes(payload[16..20].try_into().ok()?) as usize;
+    let expected_len = 20usize.checked_add(path_len)?.checked_add(data_len)?;
+    if payload.len() != expected_len {
+        return None;
+    }
+    let path_bytes = &payload[20..20 + path_len];
+    let data_bytes = payload[20 + path_len..].to_vec();
+    let path = std::str::from_utf8(path_bytes).ok()?.to_owned();
+    Some((path, last_modified, data_bytes))
 }

--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -491,6 +491,30 @@ fn matcher_test() {
     assert_eq!(result, "true|false|true|true|true|false|false");
 }
 
+#[test]
+fn regex_groups_test() {
+    let bundle = combined_bundle(shim_bundle(), test_bundle());
+    let result = jvm_core::run_static_native(
+        &bundle,
+        "RegexGroupsTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "true|gc=5|g0=1.12.0|g1=1|g2=12|g3=0|g4=null|g5=null");
+}
+
+#[test]
+fn clojure_bootstrap_shims_test() {
+    let bundle = combined_bundle(shim_bundle(), test_bundle());
+    let result = jvm_core::run_static_native(
+        &bundle,
+        "ClojureBootstrapShimsTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "true|true|4321|127.0.0.1|false|true");
+}
+
 // ---------------------------------------------------------------------------
 // Stream.filter().map().collect(Collectors.toList())
 // ---------------------------------------------------------------------------

--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -208,6 +208,18 @@ fn classloader_api() {
 }
 
 #[test]
+fn class_resource_lookup() {
+    let bundle = combined_bundle(shim_bundle(), test_bundle());
+    let result = jvm_core::run_static_native(
+        &bundle,
+        "ClassResourceLookupTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "202|254|186|190|true");
+}
+
+#[test]
 fn classloader_missing_class_throws_cnfe() {
     let bundle = combined_bundle(shim_bundle(), test_bundle());
     let result = jvm_core::run_static_native(
@@ -574,4 +586,3 @@ fn priority_queue_poll_order() {
     );
     assert_eq!(result, "10,20,30");
 }
-

--- a/test-sources/ClassResourceLookupTest.java
+++ b/test-sources/ClassResourceLookupTest.java
@@ -1,0 +1,22 @@
+import java.io.InputStream;
+
+public class ClassResourceLookupTest {
+    public static String run() throws Exception {
+        var loader = ClassLoader.getSystemClassLoader();
+        long t1 = loader.getResource("MatcherTest.class").openConnection().getLastModified();
+        long t2 = loader.getResource("MatcherTest.class").openConnection().getLastModified();
+        InputStream in = loader.getResourceAsStream("MatcherTest.class");
+        if (in == null) {
+            return "missing";
+        }
+        byte[] bytes = in.readAllBytes();
+        if (bytes.length < 4) {
+            return "short";
+        }
+        return (bytes[0] & 0xff) + "|"
+                + (bytes[1] & 0xff) + "|"
+                + (bytes[2] & 0xff) + "|"
+                + (bytes[3] & 0xff) + "|"
+                + (t1 == t2 && t1 > 0L);
+    }
+}

--- a/test-sources/ClojureBootstrapShimsTest.java
+++ b/test-sources/ClojureBootstrapShimsTest.java
@@ -1,0 +1,34 @@
+import java.io.File;
+import java.io.FileWriter;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.util.Properties;
+
+public class ClojureBootstrapShimsTest {
+    public static String run() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("alpha", "1");
+        properties.setProperty("beta", "2");
+        boolean propsOk = properties.stringPropertyNames().contains("alpha")
+                && properties.stringPropertyNames().contains("beta");
+
+        Path path = Files.createTempFile("clojure-", ".edn", new FileAttribute[0]);
+        File file = path.toFile();
+        FileWriter writer = new FileWriter(file);
+        writer.close();
+        boolean fileOk = file.getPath().startsWith("/tmp/clojure-") && file.getPath().endsWith(".edn");
+
+        InetAddress address = InetAddress.getByName(null);
+        ServerSocket server = new ServerSocket(4321, 0, address);
+        String net = server.getLocalPort()
+                + "|" + server.getInetAddress().getHostAddress()
+                + "|" + server.isClosed();
+        server.close();
+        net += "|" + server.isClosed();
+
+        return propsOk + "|" + fileOk + "|" + net;
+    }
+}

--- a/test-sources/RegexGroupsTest.java
+++ b/test-sources/RegexGroupsTest.java
@@ -1,0 +1,18 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexGroupsTest {
+    public static String run() {
+        Matcher m = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-([a-zA-Z0-9_]+))?(?:-(SNAPSHOT))?")
+            .matcher("1.12.0");
+        boolean matches = m.matches();
+        return matches
+            + "|gc=" + m.groupCount()
+            + "|g0=" + m.group()
+            + "|g1=" + m.group(1)
+            + "|g2=" + m.group(2)
+            + "|g3=" + m.group(3)
+            + "|g4=" + m.group(4)
+            + "|g5=" + m.group(5);
+    }
+}

--- a/test-sources/clojure/deps.edn
+++ b/test-sources/clojure/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["test-sources/clojure/src"]
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}}}

--- a/test-sources/clojure/src/smoke/core.clj
+++ b/test-sources/clojure/src/smoke/core.clj
@@ -1,0 +1,8 @@
+(ns smoke.core
+  (:gen-class
+    :name ClojureSmokeEntry
+    :methods [^{:static true} [run [] String]]
+    :prefix "entry-"))
+
+(defn entry-run []
+  "ok")

--- a/tools/BundleWriter.java
+++ b/tools/BundleWriter.java
@@ -1,0 +1,146 @@
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+public final class BundleWriter {
+    private static final byte[] RESOURCE_MAGIC = "RSRC".getBytes(StandardCharsets.US_ASCII);
+
+    private BundleWriter() {}
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 3) {
+            usage();
+            System.exit(2);
+        }
+
+        Path output = Path.of(args[0]);
+        List<Path> classRoots = new ArrayList<>();
+        List<Path> resourceRoots = new ArrayList<>();
+
+        for (int i = 1; i < args.length; i += 2) {
+            if (i + 1 >= args.length) {
+                usage();
+                System.exit(2);
+            }
+            switch (args[i]) {
+                case "--class-root" -> classRoots.add(Path.of(args[i + 1]));
+                case "--resource-root" -> resourceRoots.add(Path.of(args[i + 1]));
+                default -> {
+                    usage();
+                    System.exit(2);
+                }
+            }
+        }
+
+        if (classRoots.isEmpty() && resourceRoots.isEmpty()) {
+            System.err.println("BundleWriter: at least one --class-root or --resource-root is required");
+            System.exit(2);
+        }
+
+        if (output.getParent() != null) {
+            Files.createDirectories(output.getParent());
+        }
+
+        int classCount = 0;
+        int resourceCount = 0;
+        try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(output))) {
+            for (Path root : classRoots) {
+                for (Path classFile : sortedFiles(root, path -> path.toString().endsWith(".class"))) {
+                    writeClassEntry(out, classFile);
+                    classCount++;
+                }
+            }
+            for (Path root : resourceRoots) {
+                for (Path resourceFile : sortedFiles(root, path -> !path.toString().endsWith(".class"))) {
+                    writeResourceEntry(out, root, resourceFile);
+                    resourceCount++;
+                }
+            }
+        }
+
+        long totalBytes = Files.size(output);
+        if (resourceCount == 0) {
+            System.out.printf("Bundled %d classes -> %s (%d bytes)%n", classCount, output, totalBytes);
+        } else {
+            System.out.printf(
+                "Bundled %d classes and %d resources -> %s (%d bytes)%n",
+                classCount,
+                resourceCount,
+                output,
+                totalBytes
+            );
+        }
+    }
+
+    private static void usage() {
+        System.err.println(
+            "usage: java tools/BundleWriter.java <out.bin> " +
+            "[--class-root <dir> ...] [--resource-root <dir> ...]"
+        );
+    }
+
+    private static List<Path> sortedFiles(Path root, java.util.function.Predicate<Path> include) throws IOException {
+        if (!Files.isDirectory(root)) {
+            throw new IOException("bundle root is not a directory: " + root);
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            return paths
+                .filter(Files::isRegularFile)
+                .filter(include)
+                .sorted(Comparator.comparing(path -> normalizePath(root.relativize(path))))
+                .toList();
+        }
+    }
+
+    private static void writeClassEntry(OutputStream out, Path classFile) throws IOException {
+        byte[] bytes = Files.readAllBytes(classFile);
+        writeU32(out, bytes.length);
+        out.write(bytes);
+    }
+
+    private static void writeResourceEntry(OutputStream out, Path root, Path resourceFile) throws IOException {
+        byte[] pathBytes = normalizePath(root.relativize(resourceFile)).getBytes(StandardCharsets.UTF_8);
+        byte[] data = Files.readAllBytes(resourceFile);
+        long lastModified = Files.getLastModifiedTime(resourceFile).toMillis();
+        long payloadLength = 4L + 4L + 8L + 4L + pathBytes.length + data.length;
+        if (payloadLength > Integer.MAX_VALUE) {
+            throw new IOException("resource entry too large: " + resourceFile);
+        }
+        writeU32(out, (int) payloadLength);
+        out.write(RESOURCE_MAGIC);
+        writeU32(out, pathBytes.length);
+        writeU64(out, lastModified);
+        writeU32(out, data.length);
+        out.write(pathBytes);
+        out.write(data);
+    }
+
+    private static void writeU32(OutputStream out, int value) throws IOException {
+        out.write((value >>> 24) & 0xff);
+        out.write((value >>> 16) & 0xff);
+        out.write((value >>> 8) & 0xff);
+        out.write(value & 0xff);
+    }
+
+    private static void writeU64(OutputStream out, long value) throws IOException {
+        out.write((int) ((value >>> 56) & 0xff));
+        out.write((int) ((value >>> 48) & 0xff));
+        out.write((int) ((value >>> 40) & 0xff));
+        out.write((int) ((value >>> 32) & 0xff));
+        out.write((int) ((value >>> 24) & 0xff));
+        out.write((int) ((value >>> 16) & 0xff));
+        out.write((int) ((value >>> 8) & 0xff));
+        out.write((int) (value & 0xff));
+    }
+
+    private static String normalizePath(Path relativePath) {
+        return relativePath.toString().replace('\\', '/');
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds the bootstrap-facing pieces needed to get the minimal Clojure smoke test to return `ok`.

It includes:

- the JDK shim families reached during Clojure bootstrap
- the regex capture/native fix needed by that bootstrap path
- shared bundle writing via `tools/BundleWriter.java`
- stable `clj-smoke-test` targets and README updates for maintaining the smoke path

## Stack note
This PR depends on #54 and should be merged after that PR.

Per the project's normal workflow, I am opening this against `develop`. Because GitHub cannot target an upstream PR branch that only exists in my fork, this PR currently contains the earlier foundation changes from #54 as well.

For a cleaner incremental view before #54 merges, the same branch is also available as a stacked comparison in hden/199xVM#1.

## Design note
Some of these shims are intentionally bootstrap-scoped. The goal here is to establish a minimal runtime path for a JVM language like Clojure and to keep the smoke test maintainable, not to claim full file/socket/jar semantics yet.

## Out of scope
- a larger GC/runtime redesign beyond what the smoke path currently needs
- full jar/module emulation
- moving the Clojure smoke path into default `make test` / `cargo test`

## Validation
- `docker-compose run --rm java make shim`
- `docker-compose run --rm java make test-bundle`
- `docker-compose run --rm clj make clj-smoke-bundle`
- `docker-compose run --rm rust cargo test --package jvm-core`
- `docker-compose run --rm rust make clj-smoke-test`

Refs #53
