### PR TITLE
Add process-style JVM launcher API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ JAR_NAMES := $(RAOH_JAR) $(RAOH_JSON_JAR) $(JACKSON_ANN_JAR) \
 
 WEB_JARS := $(addprefix web/,$(JAR_NAMES))
 
-.PHONY: all dev-jars shim test-bundle clj-smoke-bundle clj-smoke-test javac wasm dist test clean deploy docker-playground dist-docker
+.PHONY: all dev-jars shim test-bundle clj-smoke-bundle clj-smoke-test javac wasm dist test launcher-test clean deploy docker-playground dist-docker
 
 # ============================================================
 # all — build everything needed for local development
@@ -103,6 +103,9 @@ wasm: jvm-core/pkg/jvm_core_bg.wasm
 test: web/javac.js
 	node --experimental-strip-types --test web/javac.test.ts
 
+launcher-test: jdk-shim/bundle.bin test-classes/bundle.bin jvm-core/pkg/jvm_core_bg.wasm
+	node --experimental-strip-types --test web/launcher.test.ts
+
 # ============================================================
 # dist — assemble deployable static files in dist/
 # ============================================================
@@ -115,6 +118,7 @@ dist: web/javac.js jdk-shim/bundle.bin jvm-core/pkg/jvm_core_bg.wasm $(WEB_JARS)
 	  -e 's|\.\./jdk-shim/bundle\.bin|./bundle/shim.bin|g' \
 	  web/index.html > dist/index.html
 	cp web/javac.js                       dist/javac.js
+	cp web/launcher.js                    dist/launcher.js
 	cp jvm-core/pkg/jvm_core.js          dist/pkg/jvm_core.js
 	cp jvm-core/pkg/jvm_core_bg.wasm     dist/pkg/jvm_core_bg.wasm
 	cp jdk-shim/bundle.bin               dist/bundle/shim.bin

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It is **not** a full implementation of `javac` or HotSpot, and it should not cur
 │   ├── index.html               # playground UI
 │   ├── class-reader.ts          # class/JAR reader for method registry
 │   ├── javac.ts                 # compiler entrypoint
+│   ├── launcher.js              # process-style JVM launcher API
 │   ├── javac/                   # modularized compiler core
 │   │   ├── lexer.ts
 │   │   ├── parser.ts
@@ -101,6 +102,34 @@ Status labels:
 
 The frontend also exposes a `jar_to_bundle()` WASM export that converts JAR bytes to the flat bundle format, falling back to the JS-side `readJar()` when WASM is not available.
 
+## Launcher API
+
+199xVM now exposes a process-style launcher layer on top of the low-level VM primitives.
+
+- Public JS API: `launchClasspathMain({ classpath, mainClass, args, stdio })`
+- Return value: `ProcessHandle`
+- `ProcessHandle.stdin`: writable byte stream
+- `ProcessHandle.stdout`: readable byte stream
+- `ProcessHandle.stderr`: readable byte stream
+- `ProcessHandle.wait()`: resolves to `{ exitCode, uncaughtException? }`
+- `ProcessHandle.kill()`: terminates the in-VM process
+
+Design notes:
+
+- The VM is responsible only for Unix-like process I/O (`stdin`/`stdout`/`stderr`)
+- REPL/readline/autocomplete remain userland concerns
+- Low-level `run_static()` / `run_with_jars()` remain available
+- Browser `inherit` for stdout/stderr is implemented by forwarding process chunks to `console.log` / `console.error`
+- Stream granularity is chunk/byte-based, not line-based
+
+Current scope:
+
+- `launchClasspathMain()` is implemented
+- `classpath` currently accepts an array of JAR byte arrays
+- `stdio.stdin: "inherit"` is not implemented yet; use `"pipe"` or `"ignore"`
+- `launchJar()` is intentionally deferred
+- Manifest `Class-Path` and TTY-specific behavior are out of scope for now
+
 ## JVM language support
 
 199xVM supports running JVM languages beyond Java. **Clojure 1.12.0** has been validated via an AOT-compiled smoke test:
@@ -150,8 +179,11 @@ npx serve .
 # Compiler tests
 npm test                    # or: make test
 
-# VM integration tests (42 fast tests, ~0.1s)
+# VM integration tests
 cargo test --package jvm-core
+
+# Launcher API tests
+make launcher-test
 
 # Clojure smoke test (separate, ~44s)
 make clj-smoke-test
@@ -171,6 +203,7 @@ Use Docker or OrbStack with the project’s `docker-compose.yml`. Only the **web
 ```sh
 docker-compose run rust make wasm
 docker-compose run rust cargo test --package jvm-core --lib
+docker-compose run rust cargo fmt --all
 ```
 
 The `--lib` flag runs only unit tests. For full integration tests (which need `test-classes/bundle.bin`), build the test bundle first:  

--- a/build-shim.sh
+++ b/build-shim.sh
@@ -99,6 +99,7 @@ ENTRY_POINTS=(
   "$SHIM_SRC/java/io/ObjectOutput.java"
   "$SHIM_SRC/java/io/Externalizable.java"
   "$SHIM_SRC/java/io/InputStream.java"
+  "$SHIM_SRC/java/io/ProcessPipeInputStream.java"
   "$SHIM_SRC/java/io/ByteArrayInputStream.java"
   "$SHIM_SRC/java/io/ByteArrayOutputStream.java"
   "$SHIM_SRC/java/io/OutputStream.java"

--- a/docker/Dockerfile.rust
+++ b/docker/Dockerfile.rust
@@ -1,7 +1,9 @@
 # 199xVM — Rust/WASM build (VM only). Use for: make wasm, cargo test --package jvm-core
 FROM rust:1-bookworm
 
-RUN rustup target add wasm32-unknown-unknown && cargo install wasm-pack
+RUN rustup target add wasm32-unknown-unknown \
+    && rustup component add rustfmt \
+    && cargo install wasm-pack
 
 WORKDIR /app
 

--- a/jdk-shim/java/io/PrintStream.java
+++ b/jdk-shim/java/io/PrintStream.java
@@ -400,6 +400,10 @@ public class PrintStream extends FilterOutputStream
      */
     @Override
     public void flush() {
+        if (usesNativeBridge()) {
+            nativeFlush();
+            return;
+        }
         synchronized (this) {
             try {
                 ensureOpen();
@@ -423,6 +427,11 @@ public class PrintStream extends FilterOutputStream
     public void close() {
         synchronized (this) {
             if (!closing) {
+                if (usesNativeBridge()) {
+                    closing = true;
+                    nativeFlush();
+                    return;
+                }
                 closing = true;
                 try {
                     textOut.close();
@@ -446,7 +455,7 @@ public class PrintStream extends FilterOutputStream
      *         invoked
      */
     public boolean checkError() {
-        if (out != null)
+        if (out != null || usesNativeBridge())
             flush();
         if (out instanceof PrintStream ps) {
             return ps.checkError();
@@ -480,6 +489,56 @@ public class PrintStream extends FilterOutputStream
         trouble = false;
     }
 
+    private boolean usesNativeBridge() {
+        return !closing && nativeBridgeEnabled();
+    }
+
+    private native boolean nativeBridgeEnabled();
+
+    private native void nativeWriteByte(int b);
+
+    private native void nativeWriteBytes(byte[] buf, int off, int len);
+
+    private native void nativeFlush();
+
+    private void writeString(String s, boolean newline) {
+        try {
+            synchronized (this) {
+                if (usesNativeBridge()) {
+                    byte[] bytes = s.getBytes(charset);
+                    nativeWriteBytes(bytes, 0, bytes.length);
+                    if (newline) {
+                        byte[] lineSeparator = System.lineSeparator().getBytes(charset);
+                        nativeWriteBytes(lineSeparator, 0, lineSeparator.length);
+                        if (autoFlush) {
+                            nativeFlush();
+                        }
+                    } else if (autoFlush && s.indexOf('\n') >= 0) {
+                        nativeFlush();
+                    }
+                    return;
+                }
+
+                ensureOpen();
+                textOut.write(s);
+                if (newline) {
+                    textOut.newLine();
+                }
+                textOut.flushBuffer();
+                charOut.flushBuffer();
+                if (autoFlush && (newline || s.indexOf('\n') >= 0)) {
+                    out.flush();
+                }
+            }
+        }
+        catch (InterruptedIOException x) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException x) {
+            trouble = true;
+        }
+    }
+
     /*
      * Exception-catching, synchronized output operations,
      * which also implement the write() methods of OutputStream
@@ -500,6 +559,12 @@ public class PrintStream extends FilterOutputStream
      */
     @Override
     public void write(int b) {
+        if (usesNativeBridge()) {
+            nativeWriteByte(b);
+            if ((b == '\n') && autoFlush)
+                nativeFlush();
+            return;
+        }
         try {
             synchronized (this) {
                 ensureOpen();
@@ -533,6 +598,12 @@ public class PrintStream extends FilterOutputStream
      */
     @Override
     public void write(byte[] buf, int off, int len) {
+        if (usesNativeBridge()) {
+            nativeWriteBytes(buf, off, len);
+            if (autoFlush)
+                nativeFlush();
+            return;
+        }
         try {
             synchronized (this) {
                 ensureOpen();
@@ -617,9 +688,9 @@ public class PrintStream extends FilterOutputStream
      * @param      b   The {@code boolean} to be printed
      * @see Charset#defaultCharset()
      */
-    // 199xVM: print/println are handled by the VM's native PrintStream bridge.
-    // Declaring them native prevents bytecode dispatch from bypassing the bridge.
-    public native void print(boolean b);
+    public void print(boolean b) {
+        writeString(String.valueOf(b), false);
+    }
 
     /**
      * Prints a character.  The character is translated into one or more bytes
@@ -630,7 +701,9 @@ public class PrintStream extends FilterOutputStream
      * @param      c   The {@code char} to be printed
      * @see Charset#defaultCharset()
      */
-    public native void print(char c);
+    public void print(char c) {
+        writeString(String.valueOf(c), false);
+    }
 
     /**
      * Prints an integer.  The string produced by {@link
@@ -643,7 +716,9 @@ public class PrintStream extends FilterOutputStream
      * @see        java.lang.Integer#toString(int)
      * @see Charset#defaultCharset()
      */
-    public native void print(int i);
+    public void print(int i) {
+        writeString(String.valueOf(i), false);
+    }
 
     /**
      * Prints a long integer.  The string produced by {@link
@@ -656,7 +731,9 @@ public class PrintStream extends FilterOutputStream
      * @see        java.lang.Long#toString(long)
      * @see Charset#defaultCharset()
      */
-    public native void print(long l);
+    public void print(long l) {
+        writeString(String.valueOf(l), false);
+    }
 
     /**
      * Prints a floating-point number.  The string produced by {@link
@@ -669,7 +746,9 @@ public class PrintStream extends FilterOutputStream
      * @see        java.lang.Float#toString(float)
      * @see Charset#defaultCharset()
      */
-    public native void print(float f);
+    public void print(float f) {
+        writeString(String.valueOf(f), false);
+    }
 
     /**
      * Prints a double-precision floating-point number.  The string produced by
@@ -682,7 +761,9 @@ public class PrintStream extends FilterOutputStream
      * @see        java.lang.Double#toString(double)
      * @see Charset#defaultCharset()
      */
-    public native void print(double d);
+    public void print(double d) {
+        writeString(String.valueOf(d), false);
+    }
 
     /**
      * Prints an array of characters.  The characters are converted into bytes
@@ -695,7 +776,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @throws  NullPointerException  If {@code s} is {@code null}
      */
-    public native void print(char[] s);
+    public void print(char[] s) {
+        writeString(new String(s), false);
+    }
 
     /**
      * Prints a string.  If the argument is {@code null} then the string
@@ -708,7 +791,9 @@ public class PrintStream extends FilterOutputStream
      * @param      s   The {@code String} to be printed
      * @see Charset#defaultCharset()
      */
-    public native void print(String s);
+    public void print(String s) {
+        writeString(String.valueOf(s), false);
+    }
 
     /**
      * Prints an object.  The string produced by the {@link
@@ -721,7 +806,9 @@ public class PrintStream extends FilterOutputStream
      * @see        java.lang.Object#toString()
      * @see Charset#defaultCharset()
      */
-    public native void print(Object obj);
+    public void print(Object obj) {
+        writeString(String.valueOf(obj), false);
+    }
 
 
     /* Methods that do terminate lines */
@@ -732,7 +819,9 @@ public class PrintStream extends FilterOutputStream
      * {@code line.separator}, and is not necessarily a single newline
      * character ({@code '\n'}).
      */
-    public native void println();
+    public void println() {
+        writeString("", true);
+    }
 
     /**
      * Prints a boolean and then terminates the line.  This method behaves as
@@ -741,7 +830,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code boolean} to be printed
      */
-    public native void println(boolean x);
+    public void println(boolean x) {
+        writeString(String.valueOf(x), true);
+    }
 
     /**
      * Prints a character and then terminates the line.  This method behaves as
@@ -750,7 +841,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code char} to be printed.
      */
-    public native void println(char x);
+    public void println(char x) {
+        writeString(String.valueOf(x), true);
+    }
 
     /**
      * Prints an integer and then terminates the line.  This method behaves as
@@ -759,7 +852,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code int} to be printed.
      */
-    public native void println(int x);
+    public void println(int x) {
+        writeString(String.valueOf(x), true);
+    }
 
     /**
      * Prints a long and then terminates the line.  This method behaves as
@@ -768,7 +863,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  a The {@code long} to be printed.
      */
-    public native void println(long x);
+    public void println(long x) {
+        writeString(String.valueOf(x), true);
+    }
 
     /**
      * Prints a float and then terminates the line.  This method behaves as
@@ -777,7 +874,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code float} to be printed.
      */
-    public native void println(float x);
+    public void println(float x) {
+        writeString(String.valueOf(x), true);
+    }
 
     /**
      * Prints a double and then terminates the line.  This method behaves as
@@ -786,7 +885,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code double} to be printed.
      */
-    public native void println(double x);
+    public void println(double x) {
+        writeString(String.valueOf(x), true);
+    }
 
     /**
      * Prints an array of characters and then terminates the line.  This method
@@ -795,7 +896,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  an array of chars to print.
      */
-    public native void println(char[] x);
+    public void println(char[] x) {
+        writeString(new String(x), true);
+    }
 
     /**
      * Prints a String and then terminates the line.  This method behaves as
@@ -804,7 +907,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code String} to be printed.
      */
-    public native void println(String x);
+    public void println(String x) {
+        writeString(String.valueOf(x), true);
+    }
 
     /**
      * Prints an Object and then terminates the line.  This method calls
@@ -815,7 +920,9 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code Object} to be printed.
      */
-    public native void println(Object x);
+    public void println(Object x) {
+        writeString(String.valueOf(x), true);
+    }
 
 
     /**

--- a/jdk-shim/java/io/ProcessPipeInputStream.java
+++ b/jdk-shim/java/io/ProcessPipeInputStream.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+/**
+ * Host-backed stdin pipe used by the launcher API.
+ */
+public final class ProcessPipeInputStream extends InputStream {
+    private boolean closed;
+
+    public ProcessPipeInputStream() {}
+
+    private native int read0();
+
+    private native int available0();
+
+    private native void close0();
+
+    private void ensureOpen() throws IOException {
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        synchronized (this) {
+            while (true) {
+                ensureOpen();
+                int value = read0();
+                if (value != -2) {
+                    return value;
+                }
+                try {
+                    wait();
+                } catch (InterruptedException e) {
+                    throw new IOException("Interrupted while waiting for stdin");
+                }
+            }
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        synchronized (this) {
+            ensureOpen();
+            return available0();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (this) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            close0();
+            notifyAll();
+        }
+    }
+}

--- a/jvm-core/src/heap.rs
+++ b/jvm-core/src/heap.rs
@@ -4,9 +4,9 @@
 //! This avoids a full GC implementation while being sufficient for short-lived
 //! decoder invocations like Raoh.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::cell::RefCell;
 
 /// A Java value that can appear on the operand stack or in a local variable slot.
 #[derive(Debug, Clone)]
@@ -100,6 +100,8 @@ pub enum NativePayload {
     LongArray(Vec<i64>),
     /// `java.io.PrintStream` marker (`false` => stdout, `true` => stderr).
     PrintStream(bool),
+    /// `java.io.ProcessPipeInputStream` marker for launcher stdin.
+    ProcessPipeInputStream,
     /// A Rust closure captured as a lambda stand-in.
     Lambda(Rc<dyn Fn(Vec<JValue>) -> JValue>),
     /// A lambda backed by a bytecode method handle.
@@ -144,11 +146,20 @@ impl std::fmt::Debug for NativePayload {
             NativePayload::IntArray(v) => write!(f, "IntArray(len={})", v.len()),
             NativePayload::LongArray(v) => write!(f, "LongArray(len={})", v.len()),
             NativePayload::PrintStream(is_err) => write!(f, "PrintStream(err={is_err})"),
+            NativePayload::ProcessPipeInputStream => write!(f, "ProcessPipeInputStream"),
             NativePayload::Lambda(_) => write!(f, "Lambda(...)"),
-            NativePayload::BytecodeLambda { impl_class, impl_method, .. } => {
+            NativePayload::BytecodeLambda {
+                impl_class,
+                impl_method,
+                ..
+            } => {
                 write!(f, "BytecodeLambda({impl_class}::{impl_method})")
             }
-            NativePayload::RecordMethod { method, class_simple_name, .. } => {
+            NativePayload::RecordMethod {
+                method,
+                class_simple_name,
+                ..
+            } => {
                 write!(f, "RecordMethod({class_simple_name}::{method})")
             }
         }
@@ -198,6 +209,15 @@ impl JObject {
             class_name: "java/io/PrintStream".to_owned(),
             fields: HashMap::new(),
             native: NativePayload::PrintStream(is_err),
+        }))
+    }
+
+    /// Create a `java.io.ProcessPipeInputStream` marker object.
+    pub fn new_process_pipe_input_stream() -> JRef {
+        Rc::new(RefCell::new(JObject {
+            class_name: "java/io/ProcessPipeInputStream".to_owned(),
+            fields: HashMap::new(),
+            native: NativePayload::ProcessPipeInputStream,
         }))
     }
 

--- a/jvm-core/src/interpreter/bytecode.rs
+++ b/jvm-core/src/interpreter/bytecode.rs
@@ -1038,18 +1038,14 @@ impl Vm {
             }
             ("java/lang/System", "in") => {
                 if let Some(v) = self.static_fields.get("java/lang/System").and_then(|m| m.get("in")) {
+                    if let Some(r) = v.as_ref() {
+                        self.system_stdin = Some(r.clone());
+                    }
                     return Ok(v.clone());
                 }
-                // System.in is an empty InputStream (no stdin in 199xVM)
-                let v = JValue::Ref(Some(JObject::new("java/io/ByteArrayInputStream")));
-                {
-                    let empty_arr = JObject::new_array("[B", vec![]);
-                    let obj = v.as_ref().unwrap();
-                    obj.borrow_mut().fields.insert("buf".to_owned(), JValue::Ref(Some(empty_arr)));
-                    obj.borrow_mut().fields.insert("pos".to_owned(), JValue::Int(0));
-                    obj.borrow_mut().fields.insert("count".to_owned(), JValue::Int(0));
-                    obj.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
-                }
+                let stdin = JObject::new_process_pipe_input_stream();
+                let v = JValue::Ref(Some(stdin.clone()));
+                self.system_stdin = Some(stdin);
                 self.static_fields.entry(class_name).or_default().insert(field_name, v.clone());
                 Ok(v)
             }

--- a/jvm-core/src/interpreter/launcher.rs
+++ b/jvm-core/src/interpreter/launcher.rs
@@ -1,0 +1,224 @@
+use crate::heap::{JObject, JValue};
+
+use super::{StdioMode, ThreadState, Vm, TIME_SLICE};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessExit {
+    pub exit_code: i32,
+    pub uncaught_exception: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessState {
+    Running,
+    WaitingForInput,
+    Exited,
+}
+
+pub struct JvmProcess {
+    vm: Vm,
+    exit: Option<ProcessExit>,
+}
+
+impl JvmProcess {
+    pub fn launch_classpath_main(
+        shim_bundle: &[u8],
+        jar_data: &[u8],
+        main_class: &str,
+        args: &[String],
+        stdin: StdioMode,
+        stdout: StdioMode,
+        stderr: StdioMode,
+    ) -> Result<Self, String> {
+        let mut vm = Vm::new();
+        crate::load_bundle(&mut vm, shim_bundle);
+        crate::load_jars(&mut vm, jar_data)
+            .map_err(|e| format!("launchClasspathMain failed during classpath load: {e}"))?;
+        vm.set_stdio_modes(stdin, stdout, stderr);
+        vm.scheduler = super::Scheduler::new();
+        vm.monitors.clear();
+
+        let arg_values = args
+            .iter()
+            .map(|arg| JValue::Ref(Some(vm.intern_string(arg.clone()))))
+            .collect();
+        let args_array = JObject::new_array("[Ljava/lang/String;", arg_values);
+        let main_args = vec![JValue::Ref(Some(args_array))];
+
+        let exit = match vm.build_static_frame(
+            main_class,
+            "main",
+            "([Ljava/lang/String;)V",
+            main_args.clone(),
+            true,
+        )? {
+            Some(frame) => {
+                vm.scheduler.current_thread_mut().call_stack.push(frame);
+                None
+            }
+            None => {
+                if vm
+                    .native_static(main_class, "main", "([Ljava/lang/String;)V", &main_args)
+                    .is_some()
+                {
+                    if let Some(err) = vm.pending_exception_err() {
+                        Some(ProcessExit {
+                            exit_code: 1,
+                            uncaught_exception: Some(err),
+                        })
+                    } else {
+                        Some(ProcessExit {
+                            exit_code: 0,
+                            uncaught_exception: None,
+                        })
+                    }
+                } else {
+                    return Err(format!(
+                        "Method not found: {main_class}.main([Ljava/lang/String;)V"
+                    ));
+                }
+            }
+        };
+
+        if exit.is_some() {
+            vm.flush_printstreams();
+        }
+
+        Ok(Self { vm, exit })
+    }
+
+    pub fn pump(&mut self, max_rounds: usize) -> ProcessState {
+        if self.exit.is_some() {
+            return ProcessState::Exited;
+        }
+        if max_rounds == 0 {
+            return ProcessState::Running;
+        }
+
+        let mut rounds = 0usize;
+        while rounds < max_rounds {
+            rounds += 1;
+            let current_id = self.vm.scheduler.current_thread().id;
+            let state = self.vm.scheduler.current_thread().state;
+
+            match state {
+                ThreadState::Runnable => {
+                    let mut call_stack =
+                        std::mem::take(&mut self.vm.scheduler.current_thread_mut().call_stack);
+                    let result = self.vm.run_trampoline_steps(&mut call_stack, TIME_SLICE);
+                    self.vm.scheduler.current_thread_mut().call_stack = call_stack;
+
+                    match result {
+                        Ok(Some(_)) => {
+                            self.vm.scheduler.current_thread_mut().state = ThreadState::Terminated;
+                        }
+                        Ok(None) => {
+                            let thread = self.vm.scheduler.current_thread_mut();
+                            match thread.state {
+                                ThreadState::Yielded | ThreadState::Sleeping => {
+                                    thread.state = ThreadState::Runnable;
+                                }
+                                _ => {}
+                            }
+                        }
+                        Err(e) => {
+                            self.vm.scheduler.current_thread_mut().state = ThreadState::Terminated;
+                            if current_id == 0 {
+                                self.finish(ProcessExit {
+                                    exit_code: 1,
+                                    uncaught_exception: Some(e),
+                                });
+                                return ProcessState::Exited;
+                            }
+                        }
+                    }
+                }
+                ThreadState::Terminated => {}
+                ThreadState::Yielded | ThreadState::Sleeping => {
+                    self.vm.scheduler.current_thread_mut().state = ThreadState::Runnable;
+                }
+                ThreadState::Joining(_)
+                | ThreadState::WaitingOnMonitor(_)
+                | ThreadState::WaitingOnCondition(_) => {}
+            }
+
+            self.vm.scheduler.wake_joiners();
+
+            if self.vm.scheduler.all_terminated() {
+                self.finish(ProcessExit {
+                    exit_code: 0,
+                    uncaught_exception: None,
+                });
+                return ProcessState::Exited;
+            }
+
+            if !self.vm.scheduler.advance() {
+                if self.vm.scheduler.all_terminated() {
+                    self.finish(ProcessExit {
+                        exit_code: 0,
+                        uncaught_exception: None,
+                    });
+                    return ProcessState::Exited;
+                }
+                if self.vm.scheduler.runnable_count() == 0 {
+                    if self.vm.is_waiting_on_stdin() {
+                        return ProcessState::WaitingForInput;
+                    }
+                    self.finish(ProcessExit {
+                        exit_code: 1,
+                        uncaught_exception: Some(format!(
+                            "Deadlock: no runnable threads ({})",
+                            self.vm.scheduler.alive_thread_summary()
+                        )),
+                    });
+                    return ProcessState::Exited;
+                }
+            }
+        }
+
+        ProcessState::Running
+    }
+
+    pub fn write_stdin(&mut self, bytes: &[u8]) {
+        if self.exit.is_none() {
+            self.vm.write_stdin(bytes);
+        }
+    }
+
+    pub fn close_stdin(&mut self) {
+        if self.exit.is_none() {
+            self.vm.close_stdin();
+        }
+    }
+
+    pub fn take_stdout(&mut self) -> Vec<u8> {
+        self.vm.take_stdout()
+    }
+
+    pub fn take_stderr(&mut self) -> Vec<u8> {
+        self.vm.take_stderr()
+    }
+
+    pub fn kill(&mut self) {
+        if self.exit.is_none() {
+            self.finish(ProcessExit {
+                exit_code: 137,
+                uncaught_exception: Some("Process killed".to_owned()),
+            });
+        }
+    }
+
+    pub fn exit(&self) -> Option<&ProcessExit> {
+        self.exit.as_ref()
+    }
+
+    pub fn is_exited(&self) -> bool {
+        self.exit.is_some()
+    }
+
+    fn finish(&mut self, exit: ProcessExit) {
+        self.vm.flush_printstreams();
+        self.vm.scheduler.reset_to_main();
+        self.exit = Some(exit);
+    }
+}

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -65,6 +65,7 @@ mod descriptors;
 mod dispatch;
 mod frame;
 mod invoke;
+pub(crate) mod launcher;
 mod native_static;
 mod native_virtual;
 mod reflection;
@@ -86,6 +87,25 @@ extern "C" {
 // ---------------------------------------------------------------------------
 
 pub type ThreadId = u64;
+
+/// Process-style stdio handling exposed by the launcher layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StdioMode {
+    Pipe,
+    Ignore,
+    Inherit,
+}
+
+impl StdioMode {
+    pub fn from_spec(spec: &str) -> Result<Self, String> {
+        match spec {
+            "pipe" => Ok(Self::Pipe),
+            "ignore" => Ok(Self::Ignore),
+            "inherit" => Ok(Self::Inherit),
+            _ => Err(format!("Unsupported stdio mode: {spec}")),
+        }
+    }
+}
 
 /// The execution state of a green thread.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -316,6 +336,22 @@ pub struct Vm {
     pub(in crate::interpreter) stdout_buffer: String,
     /// Buffered `System.err.print` content until newline/println.
     pub(in crate::interpreter) stderr_buffer: String,
+    /// Process stdin mode.
+    pub(in crate::interpreter) stdin_mode: StdioMode,
+    /// Process stdout mode.
+    pub(in crate::interpreter) stdout_mode: StdioMode,
+    /// Process stderr mode.
+    pub(in crate::interpreter) stderr_mode: StdioMode,
+    /// Pending bytes for `System.out` when stdout is piped.
+    pub(in crate::interpreter) stdout_chunks: VecDeque<Vec<u8>>,
+    /// Pending bytes for `System.err` when stderr is piped.
+    pub(in crate::interpreter) stderr_chunks: VecDeque<Vec<u8>>,
+    /// Buffered bytes supplied to the process stdin pipe.
+    pub(in crate::interpreter) stdin_bytes: VecDeque<u8>,
+    /// Whether the process stdin pipe has reached EOF.
+    pub(in crate::interpreter) stdin_closed: bool,
+    /// Cached `System.in` object for host-side wakeups.
+    pub(in crate::interpreter) system_stdin: Option<JRef>,
     /// Singleton system ClassLoader instance (created on first access).
     pub(in crate::interpreter) system_classloader: Option<JRef>,
     /// Green thread scheduler.
@@ -341,6 +377,14 @@ impl Vm {
             class_pool: HashMap::new(),
             stdout_buffer: String::new(),
             stderr_buffer: String::new(),
+            stdin_mode: StdioMode::Pipe,
+            stdout_mode: StdioMode::Inherit,
+            stderr_mode: StdioMode::Inherit,
+            stdout_chunks: VecDeque::new(),
+            stderr_chunks: VecDeque::new(),
+            stdin_bytes: VecDeque::new(),
+            stdin_closed: false,
+            system_stdin: None,
             system_classloader: None,
             scheduler: Scheduler::new(),
             monitors: HashMap::new(),
@@ -545,6 +589,42 @@ impl Vm {
         Ok(())
     }
 
+    /// Host-side notifyAll for process pipes.
+    ///
+    /// Unlike `Object.notifyAll()`, this has no Java monitor ownership check.
+    /// It exists so the host can wake `System.in` readers after appending bytes
+    /// or closing stdin.
+    pub(in crate::interpreter) fn host_notify_all(&mut self, obj: &JRef) {
+        let id = Self::object_id(obj);
+        let mut wake_thread: Option<ThreadId> = None;
+        if let Some(monitor) = self.monitors.get_mut(&id) {
+            while let Some(waiter_id) = monitor.wait_queue.pop_front() {
+                monitor.entry_queue.push_back(waiter_id);
+            }
+            if monitor.owner.is_none() {
+                if let Some(waiting_id) = monitor.entry_queue.pop_front() {
+                    monitor.owner = Some(waiting_id);
+                    let restore_count = self.scheduler.thread(waiting_id).and_then(|t| match t.state {
+                        ThreadState::WaitingOnCondition(wait_obj_id)
+                            if wait_obj_id == id && t.saved_monitor_count > 0 =>
+                        {
+                            Some(t.saved_monitor_count)
+                        }
+                        _ => None,
+                    });
+                    monitor.count = restore_count.unwrap_or(1);
+                    wake_thread = Some(waiting_id);
+                }
+            }
+        }
+        if let Some(wid) = wake_thread {
+            if let Some(t) = self.scheduler.thread_mut(wid) {
+                t.saved_monitor_count = 0;
+                t.state = ThreadState::Runnable;
+            }
+        }
+    }
+
     /// Set a pending IllegalMonitorStateException from an error message.
     pub(in crate::interpreter) fn throw_illegal_monitor_state(&mut self, err_msg: &str) {
         let msg = self.intern_string(err_msg);
@@ -721,14 +801,87 @@ impl Vm {
 
     /// Flush buffered PrintStream output (`print` without trailing `println`).
     pub fn flush_printstreams(&mut self) {
-        if !self.stdout_buffer.is_empty() {
+        if self.stdout_mode == StdioMode::Inherit && !self.stdout_buffer.is_empty() {
             Self::emit_host_line(false, &self.stdout_buffer);
             self.stdout_buffer.clear();
         }
-        if !self.stderr_buffer.is_empty() {
+        if self.stderr_mode == StdioMode::Inherit && !self.stderr_buffer.is_empty() {
             Self::emit_host_line(true, &self.stderr_buffer);
             self.stderr_buffer.clear();
         }
+    }
+
+    pub fn set_stdio_modes(&mut self, stdin: StdioMode, stdout: StdioMode, stderr: StdioMode) {
+        self.stdin_mode = stdin;
+        self.stdout_mode = stdout;
+        self.stderr_mode = stderr;
+        self.stdin_closed = matches!(stdin, StdioMode::Ignore);
+        self.stdin_bytes.clear();
+        self.stdout_chunks.clear();
+        self.stderr_chunks.clear();
+        self.stdout_buffer.clear();
+        self.stderr_buffer.clear();
+    }
+
+    pub fn write_stdin(&mut self, bytes: &[u8]) {
+        if matches!(self.stdin_mode, StdioMode::Ignore) || self.stdin_closed {
+            return;
+        }
+        self.stdin_bytes.extend(bytes.iter().copied());
+        if let Some(stdin) = self.system_stdin.clone() {
+            self.host_notify_all(&stdin);
+        }
+    }
+
+    pub fn close_stdin(&mut self) {
+        self.stdin_closed = true;
+        if let Some(stdin) = self.system_stdin.clone() {
+            self.host_notify_all(&stdin);
+        }
+    }
+
+    pub fn take_stdout(&mut self) -> Vec<u8> {
+        let total: usize = self.stdout_chunks.iter().map(|chunk| chunk.len()).sum();
+        let mut out = Vec::with_capacity(total);
+        while let Some(chunk) = self.stdout_chunks.pop_front() {
+            out.extend_from_slice(&chunk);
+        }
+        out
+    }
+
+    pub fn take_stderr(&mut self) -> Vec<u8> {
+        let total: usize = self.stderr_chunks.iter().map(|chunk| chunk.len()).sum();
+        let mut out = Vec::with_capacity(total);
+        while let Some(chunk) = self.stderr_chunks.pop_front() {
+            out.extend_from_slice(&chunk);
+        }
+        out
+    }
+
+    pub(in crate::interpreter) fn stdin_read_byte(&mut self) -> i32 {
+        if let Some(byte) = self.stdin_bytes.pop_front() {
+            return i32::from(byte);
+        }
+        if self.stdin_closed {
+            -1
+        } else {
+            -2
+        }
+    }
+
+    pub(in crate::interpreter) fn stdin_available(&self) -> i32 {
+        self.stdin_bytes.len().min(i32::MAX as usize) as i32
+    }
+
+    pub(in crate::interpreter) fn is_waiting_on_stdin(&self) -> bool {
+        let Some(stdin) = &self.system_stdin else {
+            return false;
+        };
+        let stdin_id = Self::object_id(stdin);
+        self.scheduler
+            .threads
+            .iter()
+            .any(|t| matches!(t.state, ThreadState::WaitingOnCondition(id) if id == stdin_id))
     }
 
     /// Intern a Java string (returns same `JRef` for equal content).

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -105,28 +105,6 @@ impl super::Vm {
         }
     }
 
-    pub(super) fn printstream_text_for(&mut self, value: &JValue) -> String {
-        match value {
-            JValue::Void => "void".to_owned(),
-            JValue::Int(i) => i.to_string(),
-            JValue::Long(l) => l.to_string(),
-            JValue::Float(f) => f.to_string(),
-            JValue::Double(d) => d.to_string(),
-            JValue::Ref(None) => "null".to_owned(),
-            JValue::Ref(Some(r)) => {
-                if let Some(s) = r.borrow().as_java_string() {
-                    return s.to_owned();
-                }
-                let class_name = r.borrow().class_name.clone();
-                match self.invoke_virtual(r.clone(), &class_name, "toString", "()Ljava/lang/String;", vec![]) {
-                    Ok(JValue::Ref(Some(sref))) => sref.borrow().as_java_string().unwrap_or("").to_owned(),
-                    _ => format!("{class_name}@obj"),
-                }
-            }
-            JValue::ReturnAddress(a) => format!("ret:{a}"),
-        }
-    }
-
     pub(super) fn emit_host_line(is_err: bool, line: &str) {
         #[cfg(target_arch = "wasm32")]
         {
@@ -146,21 +124,41 @@ impl super::Vm {
         }
     }
 
-    pub(super) fn write_printstream(&mut self, is_err: bool, text: &str, newline: bool) {
-        let buf = if is_err {
-            &mut self.stderr_buffer
+    pub(super) fn write_printstream_bytes(&mut self, is_err: bool, bytes: &[u8]) {
+        let mode = if is_err {
+            self.stderr_mode
         } else {
-            &mut self.stdout_buffer
+            self.stdout_mode
         };
-        buf.push_str(text);
-        while let Some(pos) = buf.find('\n') {
-            let line = buf[..pos].to_owned();
-            Self::emit_host_line(is_err, &line);
-            buf.drain(..=pos);
-        }
-        if newline {
-            Self::emit_host_line(is_err, buf);
-            buf.clear();
+        match mode {
+            super::StdioMode::Ignore => {}
+            super::StdioMode::Pipe => {
+                if !bytes.is_empty() {
+                    let chunks = if is_err {
+                        &mut self.stderr_chunks
+                    } else {
+                        &mut self.stdout_chunks
+                    };
+                    chunks.push_back(bytes.to_vec());
+                }
+            }
+            super::StdioMode::Inherit => {
+                if bytes.is_empty() {
+                    return;
+                }
+                let text = String::from_utf8_lossy(bytes);
+                let buf = if is_err {
+                    &mut self.stderr_buffer
+                } else {
+                    &mut self.stdout_buffer
+                };
+                buf.push_str(&text);
+                while let Some(pos) = buf.find('\n') {
+                    let line = buf[..pos].to_owned();
+                    Self::emit_host_line(is_err, &line);
+                    buf.drain(..=pos);
+                }
+            }
         }
     }
 
@@ -395,6 +393,72 @@ impl super::Vm {
                 }
                 return Some(JValue::Void);
             }
+        }
+        if matches!(this.borrow().native, NativePayload::PrintStream(_)) {
+            let is_err = matches!(this.borrow().native, NativePayload::PrintStream(true));
+            match (method_name, _descriptor) {
+                ("nativeBridgeEnabled", "()Z") => return Some(JValue::Int(1)),
+                ("nativeFlush", "()V") => {
+                    if matches!(
+                        if is_err { self.stderr_mode } else { self.stdout_mode },
+                        super::StdioMode::Inherit
+                    ) {
+                        self.flush_printstreams();
+                    }
+                    return Some(JValue::Void);
+                }
+                ("nativeWriteByte", "(I)V") => {
+                    let byte = _args.first().map(JValue::as_int).unwrap_or(0) as u8;
+                    self.write_printstream_bytes(is_err, &[byte]);
+                    return Some(JValue::Void);
+                }
+                ("nativeWriteBytes", "([BII)V") => {
+                    let array_ref = match _args.first().and_then(JValue::as_ref) {
+                        Some(array_ref) => array_ref,
+                        None => {
+                            self.throw_null_pointer("PrintStream.write: buf is null");
+                            return Some(JValue::Void);
+                        }
+                    };
+                    let bytes = {
+                        let array = array_ref.borrow();
+                        match &array.native {
+                            NativePayload::ByteArray(bytes) => bytes.clone(),
+                            NativePayload::Array(values) => {
+                                values.iter().map(|value| value.as_int() as u8).collect()
+                            }
+                            _ => {
+                                self.throw_null_pointer("PrintStream.write: buf is null");
+                                return Some(JValue::Void);
+                            }
+                        }
+                    };
+                    let off = _args.get(1).map(JValue::as_int).unwrap_or(0);
+                    let len = _args.get(2).map(JValue::as_int).unwrap_or(0);
+                    if off < 0 || len < 0 || (off as usize).saturating_add(len as usize) > bytes.len() {
+                        let exc = JObject::new("java/lang/IndexOutOfBoundsException");
+                        let msg = self.intern_string(format!(
+                            "PrintStream.write: off={off}, len={len}, array length={}",
+                            bytes.len()
+                        ));
+                        exc.borrow_mut().fields.insert(
+                            "detailMessage".to_owned(),
+                            JValue::Ref(Some(msg)),
+                        );
+                        *self.pending_exception_mut() = Some(exc);
+                        return Some(JValue::Void);
+                    }
+                    self.write_printstream_bytes(
+                        is_err,
+                        &bytes[off as usize..off as usize + len as usize],
+                    );
+                    return Some(JValue::Void);
+                }
+                _ => {}
+            }
+        }
+        if _class_name == "java/io/PrintStream" && method_name == "nativeBridgeEnabled" {
+            return Some(JValue::Int(0));
         }
         // ----- java.lang.Thread native methods -----
         if this.borrow().class_name == "java/lang/Thread"
@@ -1445,6 +1509,7 @@ impl super::Vm {
                     NativePayload::IntArray(v) => NativePayload::IntArray(v.clone()),
                     NativePayload::LongArray(v) => NativePayload::LongArray(v.clone()),
                     NativePayload::PrintStream(is_err) => NativePayload::PrintStream(*is_err),
+                    NativePayload::ProcessPipeInputStream => NativePayload::ProcessPipeInputStream,
                     NativePayload::Lambda(f) => NativePayload::Lambda(f.clone()),
                     NativePayload::BytecodeLambda {
                         sam_method,
@@ -1479,11 +1544,14 @@ impl super::Vm {
                 }));
                 Some(JValue::Ref(Some(cloned)))
             }
-            // PrintStream native bridge.
-            ("java/io/PrintStream", "println") | ("java/io/PrintStream", "print") => {
-                let is_err = matches!(this.borrow().native, NativePayload::PrintStream(true));
-                let text = _args.first().map(|v| self.printstream_text_for(v)).unwrap_or_default();
-                self.write_printstream(is_err, &text, method_name == "println");
+            ("java/io/ProcessPipeInputStream", "read0") if _descriptor == "()I" => {
+                Some(JValue::Int(self.stdin_read_byte()))
+            }
+            ("java/io/ProcessPipeInputStream", "available0") if _descriptor == "()I" => {
+                Some(JValue::Int(self.stdin_available()))
+            }
+            ("java/io/ProcessPipeInputStream", "close0") if _descriptor == "()V" => {
+                self.close_stdin();
                 Some(JValue::Void)
             }
             _ => None,

--- a/jvm-core/src/lib.rs
+++ b/jvm-core/src/lib.rs
@@ -8,10 +8,14 @@ mod class_file;
 pub mod heap;
 pub mod interpreter;
 
+#[cfg(target_arch = "wasm32")]
+use js_sys::Array;
 use wasm_bindgen::prelude::*;
 
 use class_file::{parse, parse_class_name};
 use heap::JValue;
+pub use interpreter::launcher::{JvmProcess, ProcessExit, ProcessState};
+pub use interpreter::StdioMode;
 use interpreter::Vm;
 
 /// Load one or more `.class` files and invoke a static method.
@@ -107,8 +111,30 @@ pub fn run_with_jars_native(
 ) -> String {
     let mut vm = Vm::new();
     load_bundle(&mut vm, shim_bundle);
-    load_jars(&mut vm, jar_data);
+    if let Err(e) = load_jars(&mut vm, jar_data) {
+        return format!("ERROR: {e}");
+    }
     invoke_and_collect(&mut vm, main_class, method_name, descriptor)
+}
+
+pub fn launch_classpath_main_native(
+    shim_bundle: &[u8],
+    jar_data: &[u8],
+    main_class: &str,
+    args: &[String],
+    stdin: StdioMode,
+    stdout: StdioMode,
+    stderr: StdioMode,
+) -> Result<JvmProcess, String> {
+    interpreter::launcher::JvmProcess::launch_classpath_main(
+        shim_bundle,
+        jar_data,
+        &normalize_main_class(main_class),
+        args,
+        stdin,
+        stdout,
+        stderr,
+    )
 }
 
 /// Convert a single JAR to flat bundle format.
@@ -142,9 +168,13 @@ pub fn jar_to_bundle_native(jar_bytes: &[u8]) -> Vec<u8> {
 /// Load JARs from a framed byte array into a VM.
 ///
 /// Each JAR is preceded by a 4-byte big-endian length: `[u32 len][jar bytes] × N`.
-pub fn load_jars(vm: &mut Vm, jar_data: &[u8]) {
+pub fn load_jars(vm: &mut Vm, jar_data: &[u8]) -> Result<(), String> {
     let mut pos = 0usize;
-    while pos + 4 <= jar_data.len() {
+    let mut jar_index = 0usize;
+    while pos < jar_data.len() {
+        if pos + 4 > jar_data.len() {
+            return Err(format!("Truncated JAR frame header at byte offset {pos}"));
+        }
         let len = u32::from_be_bytes([
             jar_data[pos],
             jar_data[pos + 1],
@@ -152,24 +182,153 @@ pub fn load_jars(vm: &mut Vm, jar_data: &[u8]) {
             jar_data[pos + 3],
         ]) as usize;
         pos += 4;
-        if pos + len > jar_data.len() { break; }
+        if pos + len > jar_data.len() {
+            return Err(format!(
+                "Truncated JAR frame payload for entry #{jar_index} at byte offset {}",
+                pos - 4
+            ));
+        }
         let jar_bytes = &jar_data[pos..pos + len];
         pos += len;
-        if let Err(e) = vm.load_jar(jar_bytes) {
-            eprintln!("Warning: failed to load JAR: {e}");
-        }
+        vm.load_jar(jar_bytes)
+            .map_err(|e| format!("Failed to load classpath JAR #{jar_index}: {e}"))?;
+        jar_index += 1;
+    }
+    Ok(())
+}
+
+fn normalize_main_class(main_class: &str) -> String {
+    if main_class.contains('/') {
+        main_class.to_owned()
+    } else {
+        main_class.replace('.', "/")
     }
 }
 
-fn invoke_and_collect(vm: &mut Vm, main_class: &str, method_name: &str, descriptor: &str) -> String {
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub struct JvmProcessHandle {
+    inner: JvmProcess,
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_low_level_stdio(spec: &str, name: &str) -> Result<StdioMode, JsValue> {
+    match spec {
+        "pipe" => Ok(StdioMode::Pipe),
+        "ignore" => Ok(StdioMode::Ignore),
+        "inherit" => Err(JsValue::from_str(&format!(
+            "launchClasspathMainLowLevel does not accept stdio.{name}=\"inherit\"; normalize it in the caller"
+        ))),
+        _ => Err(JsValue::from_str(&format!(
+            "launchClasspathMainLowLevel stdio.{name} must be \"pipe\" or \"ignore\""
+        ))),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = launchClasspathMainLowLevel)]
+pub fn launch_classpath_main_low_level(
+    shim_bundle: &[u8],
+    jar_data: &[u8],
+    main_class: &str,
+    args: Array,
+    stdin: &str,
+    stdout: &str,
+    stderr: &str,
+) -> Result<JvmProcessHandle, JsValue> {
+    // This low-level export operates on concrete VM stdio modes only.
+    // Higher-level launcher policy such as public `"inherit"` handling lives in web/launcher.js.
+    let args = args
+        .iter()
+        .map(|value| {
+            value.as_string().ok_or_else(|| {
+                JsValue::from_str("launchClasspathMainLowLevel args must be strings")
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let stdin = parse_low_level_stdio(stdin, "stdin")?;
+    let stdout = parse_low_level_stdio(stdout, "stdout")?;
+    let stderr = parse_low_level_stdio(stderr, "stderr")?;
+    let inner = launch_classpath_main_native(
+        shim_bundle,
+        jar_data,
+        main_class,
+        &args,
+        stdin,
+        stdout,
+        stderr,
+    )
+    .map_err(|e| JsValue::from_str(&e))?;
+    Ok(JvmProcessHandle { inner })
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl JvmProcessHandle {
+    pub fn pump(&mut self, max_rounds: usize) -> String {
+        match self.inner.pump(max_rounds) {
+            ProcessState::Running => "running".to_owned(),
+            ProcessState::WaitingForInput => "waiting".to_owned(),
+            ProcessState::Exited => "exited".to_owned(),
+        }
+    }
+
+    pub fn write_stdin(&mut self, bytes: &[u8]) {
+        self.inner.write_stdin(bytes);
+    }
+
+    pub fn close_stdin(&mut self) {
+        self.inner.close_stdin();
+    }
+
+    pub fn take_stdout(&mut self) -> Vec<u8> {
+        self.inner.take_stdout()
+    }
+
+    pub fn take_stderr(&mut self) -> Vec<u8> {
+        self.inner.take_stderr()
+    }
+
+    pub fn is_exited(&self) -> bool {
+        self.inner.is_exited()
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        self.inner.exit().map(|exit| exit.exit_code).unwrap_or(-1)
+    }
+
+    pub fn uncaught_exception(&self) -> Option<String> {
+        self.inner
+            .exit()
+            .and_then(|exit| exit.uncaught_exception.clone())
+    }
+
+    pub fn kill(&mut self) {
+        self.inner.kill();
+    }
+}
+
+fn invoke_and_collect(
+    vm: &mut Vm,
+    main_class: &str,
+    method_name: &str,
+    descriptor: &str,
+) -> String {
     let out = match vm.invoke_static_threaded(main_class, method_name, descriptor, vec![]) {
         Ok(result) => {
             // If the result is a non-String object, call toString() on it.
             if let JValue::Ref(Some(ref r)) = result {
-                let is_java_string = matches!(r.borrow().native, heap::NativePayload::JavaString(_));
+                let is_java_string =
+                    matches!(r.borrow().native, heap::NativePayload::JavaString(_));
                 if !is_java_string {
                     let class_name = r.borrow().class_name.clone();
-                    if let Ok(s) = vm.invoke_virtual(r.clone(), &class_name, "toString", "()Ljava/lang/String;", vec![]) {
+                    if let Ok(s) = vm.invoke_virtual(
+                        r.clone(),
+                        &class_name,
+                        "toString",
+                        "()Ljava/lang/String;",
+                        vec![],
+                    ) {
                         jvalue_to_string(&s)
                     } else {
                         jvalue_to_string(&result)
@@ -202,7 +361,9 @@ pub fn load_bundle(vm: &mut Vm, class_bundle: &[u8]) {
             class_bundle[pos + 3],
         ]) as usize;
         pos += 4;
-        if pos + len > class_bundle.len() { break; }
+        if pos + len > class_bundle.len() {
+            break;
+        }
         let class_bytes = &class_bundle[pos..pos + len];
         pos += len;
         match parse_class_name(class_bytes) {
@@ -228,7 +389,13 @@ fn jvalue_to_string(v: &JValue) -> String {
             let obj = r.borrow();
             match &obj.native {
                 heap::NativePayload::JavaString(s) => s.clone(),
-                heap::NativePayload::Array(v) => format!("[{}]", v.iter().map(jvalue_to_string).collect::<Vec<_>>().join(", ")),
+                heap::NativePayload::Array(v) => format!(
+                    "[{}]",
+                    v.iter()
+                        .map(jvalue_to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
                 _ => format!("{}@obj", obj.class_name),
             }
         }

--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -19,6 +19,16 @@ fn jar_loader_test_jar() -> &'static [u8] {
     include_bytes!("test.jar")
 }
 
+fn framed_jars(jars: &[&[u8]]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for jar in jars {
+        let len = jar.len() as u32;
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(jar);
+    }
+    out
+}
+
 /// Run a test class from the test JAR via the JAR loader.
 fn run_jar_test(class: &str, method: &str, descriptor: &str) -> String {
     let mut vm = jvm_core::interpreter::Vm::new();
@@ -612,6 +622,215 @@ fn jar_to_bundle_roundtrip() {
     assert_eq!(result, "jar-ok");
 }
 
+#[test]
+fn launcher_process_pipe_roundtrip() {
+    let jar_data = framed_jars(&[test_jar()]);
+    let mut process = jvm_core::launch_classpath_main_native(
+        shim_bundle(),
+        &jar_data,
+        "ProcessLauncherEchoMain",
+        &["pipe".to_owned()],
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+    )
+    .expect("launch classpath main");
+
+    let mut state = "running";
+    for _ in 0..128 {
+        match process.pump(64) {
+            jvm_core::ProcessState::Running => {}
+            jvm_core::ProcessState::WaitingForInput => {
+                state = "waiting";
+                break;
+            }
+            jvm_core::ProcessState::Exited => {
+                state = "exited";
+                break;
+            }
+        }
+    }
+    assert_eq!(state, "waiting", "process did not block on stdin");
+    assert_eq!(String::from_utf8(process.take_stdout()).unwrap(), "pipe>");
+    assert!(process.take_stderr().is_empty());
+
+    process.write_stdin(b"abc!");
+
+    state = "running";
+    for _ in 0..128 {
+        match process.pump(64) {
+            jvm_core::ProcessState::Running | jvm_core::ProcessState::WaitingForInput => {}
+            jvm_core::ProcessState::Exited => {
+                state = "exited";
+                break;
+            }
+        }
+    }
+    assert_eq!(state, "exited", "process did not exit after stdin payload");
+    assert_eq!(String::from_utf8(process.take_stdout()).unwrap(), "abc");
+    assert_eq!(String::from_utf8(process.take_stderr()).unwrap(), "bang");
+
+    let exit = process.exit().expect("process exit");
+    assert_eq!(exit.exit_code, 0);
+    assert_eq!(exit.uncaught_exception, None);
+}
+
+#[test]
+fn launcher_process_pipe_eof() {
+    let jar_data = framed_jars(&[test_jar()]);
+    let mut process = jvm_core::launch_classpath_main_native(
+        shim_bundle(),
+        &jar_data,
+        "ProcessLauncherEchoMain",
+        &["eof".to_owned()],
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+    )
+    .expect("launch classpath main");
+
+    for _ in 0..128 {
+        if matches!(process.pump(64), jvm_core::ProcessState::WaitingForInput) {
+            break;
+        }
+    }
+    assert_eq!(String::from_utf8(process.take_stdout()).unwrap(), "eof>");
+
+    process.close_stdin();
+
+    let mut exited = false;
+    for _ in 0..128 {
+        if matches!(process.pump(64), jvm_core::ProcessState::Exited) {
+            exited = true;
+            break;
+        }
+    }
+    assert!(exited, "process did not exit after stdin EOF");
+    assert_eq!(String::from_utf8(process.take_stdout()).unwrap(), "<eof>");
+    assert!(process.take_stderr().is_empty());
+
+    let exit = process.exit().expect("process exit");
+    assert_eq!(exit.exit_code, 0);
+    assert_eq!(exit.uncaught_exception, None);
+}
+
+#[test]
+fn launcher_process_pipe_byte_writes() {
+    let jar_data = framed_jars(&[test_jar()]);
+    let mut process = jvm_core::launch_classpath_main_native(
+        shim_bundle(),
+        &jar_data,
+        "ProcessLauncherEchoMain",
+        &["bytes".to_owned()],
+        jvm_core::StdioMode::Ignore,
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+    )
+    .expect("launch classpath main");
+
+    let mut exited = false;
+    for _ in 0..128 {
+        if matches!(process.pump(64), jvm_core::ProcessState::Exited) {
+            exited = true;
+            break;
+        }
+    }
+    assert!(exited, "process did not exit after raw byte writes");
+    assert_eq!(String::from_utf8(process.take_stdout()).unwrap(), "ABC");
+    assert_eq!(String::from_utf8(process.take_stderr()).unwrap(), "DEF");
+
+    let exit = process.exit().expect("process exit");
+    assert_eq!(exit.exit_code, 0);
+    assert_eq!(exit.uncaught_exception, None);
+}
+
+#[test]
+fn launcher_process_pipe_close_system_streams() {
+    let jar_data = framed_jars(&[test_jar()]);
+    let mut process = jvm_core::launch_classpath_main_native(
+        shim_bundle(),
+        &jar_data,
+        "ProcessLauncherEchoMain",
+        &["close".to_owned()],
+        jvm_core::StdioMode::Ignore,
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+    )
+    .expect("launch classpath main");
+
+    let mut exited = false;
+    for _ in 0..128 {
+        if matches!(process.pump(64), jvm_core::ProcessState::Exited) {
+            exited = true;
+            break;
+        }
+    }
+    assert!(exited, "process did not exit after closing system streams");
+    assert_eq!(String::from_utf8(process.take_stdout()).unwrap(), "A");
+    assert_eq!(String::from_utf8(process.take_stderr()).unwrap(), "B");
+
+    let exit = process.exit().expect("process exit");
+    assert_eq!(exit.exit_code, 0);
+    assert_eq!(exit.uncaught_exception, None);
+}
+
+#[test]
+fn launcher_process_pipe_write_after_close_is_ignored() {
+    let jar_data = framed_jars(&[test_jar()]);
+    let mut process = jvm_core::launch_classpath_main_native(
+        shim_bundle(),
+        &jar_data,
+        "ProcessLauncherEchoMain",
+        &["write-after-close".to_owned()],
+        jvm_core::StdioMode::Ignore,
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+    )
+    .expect("launch classpath main");
+
+    let mut exited = false;
+    for _ in 0..128 {
+        if matches!(process.pump(64), jvm_core::ProcessState::Exited) {
+            exited = true;
+            break;
+        }
+    }
+    assert!(exited, "process did not exit after writing to closed system streams");
+    assert_eq!(String::from_utf8(process.take_stdout()).unwrap(), "A");
+    assert_eq!(String::from_utf8(process.take_stderr()).unwrap(), "B");
+
+    let exit = process.exit().expect("process exit");
+    assert_eq!(exit.exit_code, 0);
+    assert_eq!(exit.uncaught_exception, None);
+}
+
+#[test]
+fn launcher_process_rejects_invalid_classpath_jar() {
+    let jar_data = framed_jars(&[b"not-a-jar"]);
+    let err = match jvm_core::launch_classpath_main_native(
+        shim_bundle(),
+        &jar_data,
+        "ProcessLauncherEchoMain",
+        &[],
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+        jvm_core::StdioMode::Pipe,
+    ) {
+        Ok(_) => panic!("launch should fail for invalid classpath jar"),
+        Err(err) => err,
+    };
+    assert!(
+        err.contains("launchClasspathMain failed during classpath load: Failed to load classpath JAR #0"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn printstream_non_marker_still_uses_underlying_stream() {
+    let result = run_jar_test("PrintStreamNonMarkerTest", "run", "()Ljava/lang/String;");
+    assert_eq!(result, "AB\\n|true");
+}
+
 // ---------------------------------------------------------------------------
 // Clojure smoke: AOT-compiled ClojureSmokeEntry.run() → "ok"
 // Requires: ./build-clj-smoke.sh (builds clj-smoke/smoke.jar)
@@ -624,7 +843,6 @@ fn clojure_smoke() {
     let jars_list = std::path::Path::new("../clj-smoke/clojure-jars.txt");
     if !smoke_jar.exists() || !jars_list.exists() {
         panic!("Run ./build-clj-smoke.sh first");
-        return;
     }
 
     let mut vm = jvm_core::interpreter::Vm::new();

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./web/javac.js",
     "./javac": "./web/javac.js",
+    "./launcher": "./web/launcher.js",
     "./jvm": "./jvm-core/pkg/jvm_core.js",
     "./jvm-wasm": "./jvm-core/pkg/jvm_core_bg.wasm",
     "./shim-bundle": "./jdk-shim/bundle.bin"
@@ -14,6 +15,7 @@
     "README.md",
     "LICENSE",
     "web/javac.js",
+    "web/launcher.js",
     "jvm-core/pkg/jvm_core.js",
     "jvm-core/pkg/jvm_core.d.ts",
     "jvm-core/pkg/jvm_core_bg.wasm",
@@ -25,7 +27,8 @@
     "watch:javac": "esbuild web/javac.ts --bundle --format=esm --outfile=web/javac.js --target=es2020 --watch",
     "build:dist": "npm run build:javac && mkdir -p dist && cp web/javac.js dist/ && sed \"s/__BUILD_TIMESTAMP__/$(date +%s)/g\" web/index.html > dist/index.html",
     "fetch:jars": "mvn dependency:copy -Dartifact=net.unit8.raoh:raoh:0.4.0 -DoutputDirectory=web -Dmdep.stripVersion=false && mvn dependency:copy -Dartifact=net.unit8.raoh:raoh-json:0.4.0 -DoutputDirectory=web -Dmdep.stripVersion=false && mvn dependency:copy -Dartifact=com.fasterxml.jackson.core:jackson-annotations:3.0-rc5 -DoutputDirectory=web -Dmdep.stripVersion=false && mvn dependency:copy -Dartifact=tools.jackson.core:jackson-core:3.1.0 -DoutputDirectory=web -Dmdep.stripVersion=false && mvn dependency:copy -Dartifact=tools.jackson.core:jackson-databind:3.1.0 -DoutputDirectory=web -Dmdep.stripVersion=false",
-    "test": "npm run build:javac && node --experimental-strip-types --test web/javac.test.ts"
+    "test": "npm run build:javac && node --experimental-strip-types --test web/javac.test.ts",
+    "test:launcher": "node --experimental-strip-types --test web/launcher.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/test-sources/PrintStreamNonMarkerTest.java
+++ b/test-sources/PrintStreamNonMarkerTest.java
@@ -1,0 +1,14 @@
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class PrintStreamNonMarkerTest {
+    public static String run() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(out, true);
+        ps.print("A");
+        ps.println("B");
+        ps.close();
+        ps.print("C");
+        return out.toString().replace("\n", "\\n") + "|" + ps.checkError();
+    }
+}

--- a/test-sources/ProcessLauncherEchoMain.java
+++ b/test-sources/ProcessLauncherEchoMain.java
@@ -1,0 +1,56 @@
+public class ProcessLauncherEchoMain {
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0 && "bytes".equals(args[0])) {
+            System.out.write((int) 'A');
+            System.out.write(new byte[] { 'x', 'B', 'C', 'y' }, 1, 2);
+            System.out.flush();
+            System.err.write((int) 'D');
+            System.err.write(new byte[] { 'x', 'E', 'F', 'y' }, 1, 2);
+            System.err.flush();
+            return;
+        }
+
+        if (args.length > 0 && "close".equals(args[0])) {
+            System.out.write((int) 'A');
+            System.out.close();
+            System.err.write((int) 'B');
+            System.err.close();
+            return;
+        }
+
+        if (args.length > 0 && "write-after-close".equals(args[0])) {
+            System.out.write((int) 'A');
+            System.out.close();
+            System.out.write((int) 'Z');
+            System.out.flush();
+            System.err.write((int) 'B');
+            System.err.close();
+            System.err.write((int) 'Y');
+            System.err.flush();
+            return;
+        }
+
+        if (args.length > 0 && "check-error-flush".equals(args[0])) {
+            System.out.print("A");
+            System.err.print("B");
+            System.out.checkError();
+            System.err.checkError();
+            System.in.read();
+            return;
+        }
+
+        System.out.print(args.length > 0 ? args[0] : "ready");
+        System.out.print(">");
+
+        int ch;
+        while ((ch = System.in.read()) != -1) {
+            if (ch == '!') {
+                System.err.print("bang");
+                return;
+            }
+            System.out.print(new String(new char[] { (char) ch }));
+        }
+
+        System.out.print("<eof>");
+    }
+}

--- a/web/launcher.js
+++ b/web/launcher.js
@@ -1,0 +1,342 @@
+const JVM_MODULE_CANDIDATES = [
+  "../jvm-core/pkg/jvm_core.js",
+  "./pkg/jvm_core.js",
+];
+
+const WASM_CANDIDATES = [
+  "../jvm-core/pkg/jvm_core_bg.wasm",
+  "./pkg/jvm_core_bg.wasm",
+];
+
+const SHIM_BUNDLE_CANDIDATES = [
+  "../jdk-shim/bundle.bin",
+  "./bundle/shim.bin",
+];
+
+let jvmModulePromise = null;
+let defaultShimBundlePromise = null;
+
+function normalizeChunk(chunk) {
+  if (chunk instanceof Uint8Array) {
+    return chunk;
+  }
+  if (chunk instanceof ArrayBuffer) {
+    return new Uint8Array(chunk);
+  }
+  if (ArrayBuffer.isView(chunk)) {
+    return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  }
+  throw new TypeError("Expected Uint8Array-compatible chunk");
+}
+
+function frameClasspathJars(classpath) {
+  const jars = (classpath ?? []).map(normalizeChunk);
+  const total = jars.reduce((sum, jar) => sum + 4 + jar.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const jar of jars) {
+    const size = jar.length >>> 0;
+    out[offset++] = (size >>> 24) & 0xff;
+    out[offset++] = (size >>> 16) & 0xff;
+    out[offset++] = (size >>> 8) & 0xff;
+    out[offset++] = size & 0xff;
+    out.set(jar, offset);
+    offset += jar.length;
+  }
+  return out;
+}
+
+async function readBytes(url) {
+  if (url.protocol === "file:") {
+    const { readFile } = await import("node:fs/promises");
+    return new Uint8Array(await readFile(url));
+  }
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function firstAvailableBytes(specs) {
+  let lastError = null;
+  for (const spec of specs) {
+    const url = new URL(spec, import.meta.url);
+    try {
+      return await readBytes(url);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error("No candidate asset could be loaded");
+}
+
+async function loadJvmModule() {
+  if (!jvmModulePromise) {
+    jvmModulePromise = (async () => {
+      let lastError = null;
+      for (const spec of JVM_MODULE_CANDIDATES) {
+        const url = new URL(spec, import.meta.url);
+        try {
+          const mod = await import(url.href);
+          const wasmBytes = await firstAvailableBytes(WASM_CANDIDATES);
+          await mod.default({ module_or_path: wasmBytes });
+          return mod;
+        } catch (error) {
+          lastError = error;
+        }
+      }
+      throw lastError ?? new Error("Failed to load jvm_core.js");
+    })();
+  }
+  return jvmModulePromise;
+}
+
+async function loadShimBundle(explicitShimBundle) {
+  if (explicitShimBundle) {
+    return normalizeChunk(explicitShimBundle);
+  }
+  if (!defaultShimBundlePromise) {
+    defaultShimBundlePromise = firstAvailableBytes(SHIM_BUNDLE_CANDIDATES);
+  }
+  return defaultShimBundlePromise;
+}
+
+function normalizeStdioMode(value, name) {
+  if (value === "pipe" || value === "ignore" || value === "inherit") {
+    return value;
+  }
+  throw new TypeError(`launchClasspathMain stdio.${name} must be "pipe", "ignore", or "inherit"`);
+}
+
+function resolveLauncherStdio(stdio = {}) {
+  const publicStdio = {
+    stdin: normalizeStdioMode(stdio.stdin ?? "pipe", "stdin"),
+    stdout: normalizeStdioMode(stdio.stdout ?? "pipe", "stdout"),
+    stderr: normalizeStdioMode(stdio.stderr ?? "pipe", "stderr"),
+  };
+  if (publicStdio.stdin === "inherit") {
+    throw new Error(
+      'launchClasspathMain does not support stdio.stdin="inherit" yet; use "pipe" or "ignore"',
+    );
+  }
+  return {
+    publicStdio,
+    lowLevelStdio: {
+      stdin: publicStdio.stdin,
+      stdout: publicStdio.stdout === "inherit" ? "pipe" : publicStdio.stdout,
+      stderr: publicStdio.stderr === "inherit" ? "pipe" : publicStdio.stderr,
+    },
+  };
+}
+
+class LauncherProcessHandle {
+  #inner;
+  #stdio;
+  #stdoutDecoder = new TextDecoder();
+  #stderrDecoder = new TextDecoder();
+  #stdoutController;
+  #stderrController;
+  #waitPromise;
+  #resolveWait;
+  #pumpScheduled = false;
+  #settled = false;
+
+  constructor(inner, stdio) {
+    this.#inner = inner;
+    this.#stdio = stdio;
+    this.stdin = new WritableStream({
+      write: async (chunk) => {
+        if (stdio.stdin === "ignore") {
+          return;
+        }
+        this.#inner.write_stdin(normalizeChunk(chunk));
+        this.#schedulePump();
+      },
+      close: async () => {
+        if (stdio.stdin !== "ignore") {
+          this.#inner.close_stdin();
+          this.#schedulePump();
+        }
+      },
+      abort: async () => {
+        if (stdio.stdin !== "ignore") {
+          this.#inner.close_stdin();
+          this.#schedulePump();
+        }
+      },
+    });
+    this.stdout = new ReadableStream({
+      start: (controller) => {
+        this.#stdoutController = controller;
+      },
+    });
+    this.stderr = new ReadableStream({
+      start: (controller) => {
+        this.#stderrController = controller;
+      },
+    });
+    this.#waitPromise = new Promise((resolve) => {
+      this.#resolveWait = resolve;
+    });
+    this.#schedulePump();
+  }
+
+  wait() {
+    return this.#waitPromise;
+  }
+
+  kill() {
+    if (this.#settled) {
+      return;
+    }
+    this.#inner.kill();
+    this.#schedulePump();
+  }
+
+  #schedulePump() {
+    if (this.#pumpScheduled || this.#settled) {
+      return;
+    }
+    this.#pumpScheduled = true;
+    setTimeout(() => {
+      this.#pumpScheduled = false;
+      this.#pumpLoop();
+    }, 0);
+  }
+
+  #pumpLoop() {
+    if (this.#settled) {
+      return;
+    }
+
+    let status = "running";
+    for (let i = 0; i < 32 && status === "running"; i++) {
+      status = this.#inner.pump(64);
+    }
+
+    this.#drainOutput();
+
+    if (status === "running") {
+      this.#schedulePump();
+      return;
+    }
+
+    if (status === "waiting" && !this.#inner.is_exited()) {
+      return;
+    }
+
+    this.#finalize();
+  }
+
+  #drainOutput() {
+    const stdout = this.#inner.take_stdout();
+    if (stdout.length > 0) {
+      if (this.#stdio.stdout === "pipe") {
+        this.#stdoutController.enqueue(stdout);
+      } else if (this.#stdio.stdout === "inherit") {
+        this.#forwardInheritedChunk(false, stdout);
+      }
+    }
+    const stderr = this.#inner.take_stderr();
+    if (stderr.length > 0) {
+      if (this.#stdio.stderr === "pipe") {
+        this.#stderrController.enqueue(stderr);
+      } else if (this.#stdio.stderr === "inherit") {
+        this.#forwardInheritedChunk(true, stderr);
+      }
+    }
+  }
+
+  #finalize() {
+    if (this.#settled) {
+      return;
+    }
+    this.#settled = true;
+    this.#drainOutput();
+    this.#flushInheritedDecoder(false);
+    this.#flushInheritedDecoder(true);
+    this.#stdoutController.close();
+    this.#stderrController.close();
+    this.#resolveWait({
+      exitCode: this.#inner.exit_code(),
+      uncaughtException: this.#inner.uncaught_exception() ?? undefined,
+    });
+  }
+
+  #forwardInheritedChunk(isErr, chunk) {
+    const decoder = isErr ? this.#stderrDecoder : this.#stdoutDecoder;
+    const text = decoder.decode(chunk, { stream: true });
+    if (text.length === 0) {
+      return;
+    }
+    if (isErr) {
+      console.error(text);
+    } else {
+      console.log(text);
+    }
+  }
+
+  #flushInheritedDecoder(isErr) {
+    const mode = isErr ? this.#stdio.stderr : this.#stdio.stdout;
+    if (mode !== "inherit") {
+      return;
+    }
+    const decoder = isErr ? this.#stderrDecoder : this.#stdoutDecoder;
+    const text = decoder.decode();
+    if (text.length === 0) {
+      return;
+    }
+    if (isErr) {
+      console.error(text);
+    } else {
+      console.log(text);
+    }
+  }
+}
+
+/**
+ * Launch `main(String[])` from a classpath of JAR bytes.
+ *
+ * `classpath` currently accepts an array of JAR byte arrays. Exploded directory
+ * classpath entries are out of scope for this first launcher slice.
+ */
+export async function launchClasspathMain({
+  classpath,
+  mainClass,
+  args = [],
+  stdio,
+  shimBundle,
+} = {}) {
+  if (!Array.isArray(classpath) || classpath.length === 0) {
+    throw new TypeError("launchClasspathMain requires a non-empty classpath array");
+  }
+  if (!mainClass) {
+    throw new TypeError("launchClasspathMain requires mainClass");
+  }
+
+  const [jvmModule, resolvedShimBundle] = await Promise.all([
+    loadJvmModule(),
+    loadShimBundle(shimBundle),
+  ]);
+
+  const { publicStdio, lowLevelStdio } = resolveLauncherStdio(stdio);
+  const framedClasspath = frameClasspathJars(classpath);
+  const inner = jvmModule.launchClasspathMainLowLevel(
+    resolvedShimBundle,
+    framedClasspath,
+    mainClass,
+    args,
+    lowLevelStdio.stdin,
+    lowLevelStdio.stdout,
+    lowLevelStdio.stderr,
+  );
+  return new LauncherProcessHandle(inner, publicStdio);
+}
+
+export async function launchJar({ jar, args = [], stdio, shimBundle } = {}) {
+  if (!jar) {
+    throw new TypeError("launchJar requires jar");
+  }
+  throw new Error("launchJar is not implemented yet; use launchClasspathMain for now.");
+}

--- a/web/launcher.test.ts
+++ b/web/launcher.test.ts
@@ -1,0 +1,250 @@
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+import { launchClasspathMain } from "./launcher.js";
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(value);
+  }
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return decoder.decode(out);
+}
+
+test("launchClasspathMain exposes process-style stdio", async () => {
+  const [shimBundle, testJar] = await Promise.all([
+    readFile(new URL("../jdk-shim/bundle.bin", import.meta.url)),
+    readFile(new URL("../test-classes/test.jar", import.meta.url)),
+  ]);
+
+  const process = await launchClasspathMain({
+    classpath: [new Uint8Array(testJar)],
+    mainClass: "ProcessLauncherEchoMain",
+    args: ["js"],
+    stdio: {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    shimBundle: new Uint8Array(shimBundle),
+  });
+
+  const stdoutPromise = collect(process.stdout);
+  const stderrPromise = collect(process.stderr);
+  const writer = process.stdin.getWriter();
+  await writer.write(encoder.encode("abc!"));
+  await writer.close();
+
+  const [result, stdout, stderr] = await Promise.all([
+    process.wait(),
+    stdoutPromise,
+    stderrPromise,
+  ]);
+
+  assert.equal(stdout, "js>abc");
+  assert.equal(stderr, "bang");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.uncaughtException, undefined);
+});
+
+test("launchClasspathMain forwards inherited stdout/stderr chunks to console", async () => {
+  const [shimBundle, testJar] = await Promise.all([
+    readFile(new URL("../jdk-shim/bundle.bin", import.meta.url)),
+    readFile(new URL("../test-classes/test.jar", import.meta.url)),
+  ]);
+
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (chunk: unknown) => {
+    stdoutChunks.push(String(chunk));
+  };
+  console.error = (chunk: unknown) => {
+    stderrChunks.push(String(chunk));
+  };
+
+  try {
+    const process = await launchClasspathMain({
+      classpath: [new Uint8Array(testJar)],
+      mainClass: "ProcessLauncherEchoMain",
+      args: ["bytes"],
+      stdio: {
+        stdin: "ignore",
+        stdout: "inherit",
+        stderr: "inherit",
+      },
+      shimBundle: new Uint8Array(shimBundle),
+    });
+
+    const result = await process.wait();
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.uncaughtException, undefined);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+
+  assert.equal(stdoutChunks.join(""), "ABC");
+  assert.equal(stderrChunks.join(""), "DEF");
+});
+
+test("launchClasspathMain rejects stdin inherit until host wiring exists", async () => {
+  const [shimBundle, testJar] = await Promise.all([
+    readFile(new URL("../jdk-shim/bundle.bin", import.meta.url)),
+    readFile(new URL("../test-classes/test.jar", import.meta.url)),
+  ]);
+
+  await assert.rejects(
+    launchClasspathMain({
+      classpath: [new Uint8Array(testJar)],
+      mainClass: "ProcessLauncherEchoMain",
+      stdio: {
+        stdin: "inherit",
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+      shimBundle: new Uint8Array(shimBundle),
+    }),
+    /stdin="inherit" yet; use "pipe" or "ignore"/,
+  );
+});
+
+test("launchClasspathMain tolerates closing System.out/System.err", async () => {
+  const [shimBundle, testJar] = await Promise.all([
+    readFile(new URL("../jdk-shim/bundle.bin", import.meta.url)),
+    readFile(new URL("../test-classes/test.jar", import.meta.url)),
+  ]);
+
+  const process = await launchClasspathMain({
+    classpath: [new Uint8Array(testJar)],
+    mainClass: "ProcessLauncherEchoMain",
+    args: ["close"],
+    stdio: {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    shimBundle: new Uint8Array(shimBundle),
+  });
+
+  const [result, stdout, stderr] = await Promise.all([
+    process.wait(),
+    collect(process.stdout),
+    collect(process.stderr),
+  ]);
+
+  assert.equal(stdout, "A");
+  assert.equal(stderr, "B");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.uncaughtException, undefined);
+});
+
+test("launchClasspathMain does not emit writes after System.out/System.err close", async () => {
+  const [shimBundle, testJar] = await Promise.all([
+    readFile(new URL("../jdk-shim/bundle.bin", import.meta.url)),
+    readFile(new URL("../test-classes/test.jar", import.meta.url)),
+  ]);
+
+  const process = await launchClasspathMain({
+    classpath: [new Uint8Array(testJar)],
+    mainClass: "ProcessLauncherEchoMain",
+    args: ["write-after-close"],
+    stdio: {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    shimBundle: new Uint8Array(shimBundle),
+  });
+
+  const [result, stdout, stderr] = await Promise.all([
+    process.wait(),
+    collect(process.stdout),
+    collect(process.stderr),
+  ]);
+
+  assert.equal(stdout, "A");
+  assert.equal(stderr, "B");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.uncaughtException, undefined);
+});
+
+test("launchClasspathMain rejects invalid classpath JARs", async () => {
+  const shimBundle = await readFile(new URL("../jdk-shim/bundle.bin", import.meta.url));
+
+  await assert.rejects(
+    launchClasspathMain({
+      classpath: [new Uint8Array([0x6e, 0x6f, 0x74, 0x2d, 0x61, 0x2d, 0x6a, 0x61, 0x72])],
+      mainClass: "ProcessLauncherEchoMain",
+      stdio: {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+      shimBundle: new Uint8Array(shimBundle),
+    }),
+    /launchClasspathMain failed during classpath load: Failed to load classpath JAR #0/,
+  );
+});
+
+test("launchClasspathMain flushes inherited marker streams on checkError", async () => {
+  const [shimBundle, testJar] = await Promise.all([
+    readFile(new URL("../jdk-shim/bundle.bin", import.meta.url)),
+    readFile(new URL("../test-classes/test.jar", import.meta.url)),
+  ]);
+
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (chunk: unknown) => {
+    stdoutChunks.push(String(chunk));
+  };
+  console.error = (chunk: unknown) => {
+    stderrChunks.push(String(chunk));
+  };
+
+  try {
+    const process = await launchClasspathMain({
+      classpath: [new Uint8Array(testJar)],
+      mainClass: "ProcessLauncherEchoMain",
+      args: ["check-error-flush"],
+      stdio: {
+        stdin: "pipe",
+        stdout: "inherit",
+        stderr: "inherit",
+      },
+      shimBundle: new Uint8Array(shimBundle),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(stdoutChunks.join(""), "A");
+    assert.equal(stderrChunks.join(""), "B");
+
+    const writer = process.stdin.getWriter();
+    await writer.close();
+    const result = await process.wait();
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.uncaughtException, undefined);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+});


### PR DESCRIPTION
## Why

As 199xVM grows beyond simple static-method execution, it seemed useful to try a slightly higher-level launching interface for JVM applications.

One use case I had in mind is interactive JVM language tooling, including Clojure-style REPL workflows. In that setting, a `run_static(...)`-style API feels a bit too low-level, while a REPL-specific API would likely bake too much policy into the VM itself.

This PR tries a middle layer instead: a process-style launcher API.

## Use cases

The main use cases I had in mind were userland experiences such as:

- REPLs
- readline-style interactive input
- autocomplete or editor integrations
- Figwheel-like development workflows
- non-interactive JVM entrypoints

The VM would only be responsible for process-like I/O (`stdin`, `stdout`, `stderr`), while higher-level interaction behavior remains outside the VM.

My hope is that this keeps the runtime surface more general-purpose, while still making REPL-oriented workflows possible on top.

## Design

This PR adds a process-style launcher API:

- `launchClasspathMain({ classpath, mainClass, args, stdio })`
- returns a `ProcessHandle`
- `stdin`: writable stream
- `stdout`: readable stream
- `stderr`: readable stream
- `wait()`
- `kill()`

Internally this is implemented with queues and scheduler state, but the public surface is intentionally shaped like a process / child-process API rather than a VM-internal control API.

The low-level primitives remain available:

- `run_static()`
- `run_with_jars()`

So this is meant as an additional layer, not a replacement.

## Scope in this PR

Included here:

- `launchClasspathMain`
- process-style stdio handling
- browser-side `inherit` forwarding for stdout/stderr
- tests for piped stdio, close semantics, and invalid classpath JARs
- documentation updates for the launcher surface and Docker `rustfmt`

Still out of scope:

- `launchJar()`
- manifest `Class-Path`
- `stdio.stdin = "inherit"`
- TTY-specific behavior

## Testing

- `docker-compose run --rm java make shim test-bundle`
- `docker-compose run --rm rust cargo test --package jvm-core`
- `docker-compose run --rm rust make wasm`
- `docker-compose run --rm node make launcher-test`
- `docker-compose run --rm rust cargo test --package jvm-core clojure_smoke -- --ignored`
- `git diff --check`

## Notes

This is one possible direction for the public API, mainly motivated by the use cases above. If this feels like the wrong abstraction layer for 199xVM, I’d be happy to adjust the approach.
