### PR TITLE
compiler: resolve implicit java.lang simple names during codegen

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -485,7 +485,7 @@
 
   <script type="module">
     const _javacVer = (typeof "__BUILD_TIMESTAMP__" === "string" && "__BUILD_TIMESTAMP__".startsWith("__")) ? Date.now() : "__BUILD_TIMESTAMP__";
-    const { compile, disassemble, parseBundleMeta, buildMethodRegistry, buildClassInterfaces, setMethodRegistry, setClassInterfaces, readJar, classFilesToBundle, getKnownClassNames, getKnownClassesByPackage, getMethodsForClass, hasKnownMethodOwnerPrefix } = await import(`./javac.js?v=${_javacVer}`);
+    const { compile, disassemble, parseBundleMeta, buildMethodRegistry, buildClassInterfaces, setMethodRegistry, setKnownClassOwners, setClassInterfaces, readJar, classFilesToBundle, getKnownClassNames, getKnownClassesByPackage, getMethodsForClass, hasKnownMethodOwnerPrefix } = await import(`./javac.js?v=${_javacVer}`);
     const { launchClasspathMain } = await import(`./launcher.js?v=${_javacVer}`);
 
     // CodeMirror 6
@@ -1699,6 +1699,7 @@ public class JvmInterfaceDefault implements Describable {
         shimBundleLoadError = null;
         classBundle = shimBundleBytes;
         const classMetas = parseBundleMeta(classBundle);
+        setKnownClassOwners(classMetas.map((meta) => meta.name));
         const registry = buildMethodRegistry(classMetas);
         setMethodRegistry(registry);
         setClassInterfaces(buildClassInterfaces(classMetas));
@@ -1752,6 +1753,7 @@ public class JvmInterfaceDefault implements Describable {
         ? jvmModule.jar_to_bundle(jarBytes)
         : classFilesToBundle(await readJar(jarBytes));
       const metas = parseBundleMeta(jarBundle);
+      setKnownClassOwners(metas.map((meta) => meta.name));
       const reg = buildMethodRegistry(metas);
       setMethodRegistry(reg);
       setClassInterfaces(buildClassInterfaces(metas));

--- a/web/javac.test.ts
+++ b/web/javac.test.ts
@@ -1596,6 +1596,25 @@ describe("Code generator", () => {
       "no java/lang/ prefix on DateTimeFormatter");
   });
 
+  test("implicit java.lang simple names resolve during code generation", async () => {
+    const src = `
+      public class ThrowableSimpleName {
+        public static String run() {
+          Throwable t = new Throwable();
+          return t.getClass().getName();
+        }
+      }
+    `;
+    const bytes = compile(src);
+    const output = disassemble(bytes);
+    assert.ok(
+      output.includes("java.lang.Throwable.<init>:()V"),
+      "must resolve Throwable constructor to java/lang/Throwable",
+    );
+    const result = await runSnippet(src, "ThrowableSimpleName");
+    assert.equal(result, "java.lang.Throwable");
+  });
+
   test("named import resolves class reference", () => {
     const bytes = compile(`
       import net.unit8.raoh.Ok;

--- a/web/javac.test.ts
+++ b/web/javac.test.ts
@@ -11,7 +11,7 @@ import { test, describe } from "node:test";
 import * as assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import initJvm, { run_static } from "../jvm-core/pkg/jvm_core.js";
-import { lex, parseAll, compile, generateClassFile, TokenKind, parseClassMeta, parseBundleMeta, buildMethodRegistry, buildClassInterfaces, disassemble, setMethodRegistry, setClassInterfaces, resetMethodRegistry } from "./javac.js";
+import { lex, parseAll, compile, generateClassFile, TokenKind, parseClassMeta, parseBundleMeta, buildMethodRegistry, buildClassInterfaces, disassemble, setMethodRegistry, setKnownClassOwners, setClassInterfaces, resetMethodRegistry } from "./javac.js";
 import type { MethodSig } from "./javac/method-registry.js";
 
 // Pre-load shim method registry so compiler tests work without bundle.bin being
@@ -20,12 +20,13 @@ import type { MethodSig } from "./javac/method-registry.js";
 // Note: bundle.bin must exist before running tests — run `make shim` first.
 // If it is missing, all suites fail immediately with a clear message rather than
 // failing silently on individual "unknown method" errors later.
-let _shimRegistryCache: { reg: Record<string, MethodSig>; ifaces: Record<string, string[]> } | null = null;
+let _shimRegistryCache: { reg: Record<string, MethodSig>; ifaces: Record<string, string[]>; owners: string[] } | null = null;
 // Keep the raw bytes so ensureRuntimeReady() can reuse them for shimBundle without re-reading.
 let _shimBundleBytes: Uint8Array | null = null;
 
 function reloadShimRegistry(): void {
   if (_shimRegistryCache) {
+    setKnownClassOwners(_shimRegistryCache.owners);
     setMethodRegistry(_shimRegistryCache.reg);
     setClassInterfaces(_shimRegistryCache.ifaces);
   }
@@ -36,7 +37,11 @@ function reloadShimRegistry(): void {
   try {
     _shimBundleBytes = new Uint8Array(await readFile(shimPath));
     const metas = parseBundleMeta(_shimBundleBytes);
-    _shimRegistryCache = { reg: buildMethodRegistry(metas), ifaces: buildClassInterfaces(metas) };
+    _shimRegistryCache = {
+      reg: buildMethodRegistry(metas),
+      ifaces: buildClassInterfaces(metas),
+      owners: metas.map((meta) => meta.name),
+    };
     reloadShimRegistry();
   } catch (e: unknown) {
     throw new Error(
@@ -1596,11 +1601,11 @@ describe("Code generator", () => {
       "no java/lang/ prefix on DateTimeFormatter");
   });
 
-  test("implicit java.lang simple names resolve during code generation", async () => {
+  test("implicit java.lang simple names resolve from loaded shim owners", async () => {
     const src = `
-      public class ThrowableSimpleName {
+      public class ThreadSimpleName {
         public static String run() {
-          Throwable t = new Throwable();
+          Thread t = Thread.currentThread();
           return t.getClass().getName();
         }
       }
@@ -1608,11 +1613,11 @@ describe("Code generator", () => {
     const bytes = compile(src);
     const output = disassemble(bytes);
     assert.ok(
-      output.includes("java.lang.Throwable.<init>:()V"),
-      "must resolve Throwable constructor to java/lang/Throwable",
+      output.includes("java.lang.Thread.currentThread:()Ljava/lang/Thread;"),
+      "must resolve Thread through loaded shim owners",
     );
-    const result = await runSnippet(src, "ThrowableSimpleName");
-    assert.equal(result, "java.lang.Throwable");
+    const result = await runSnippet(src, "ThreadSimpleName");
+    assert.equal(result, "java.lang.Thread");
   });
 
   test("named import resolves class reference", () => {

--- a/web/javac.ts
+++ b/web/javac.ts
@@ -18,5 +18,5 @@ export type {
 
 export { parseAll } from "./javac/parser.js";
 export { compile, generateClassFile, setMethodRegistry } from "./javac/compiler.js";
-export { resetMethodRegistry, setClassInterfaces, getKnownClassNames, getKnownClassesByPackage, getMethodsForClass, hasKnownMethodOwnerPrefix } from "./javac/method-registry.js";
+export { resetMethodRegistry, setKnownClassOwners, setClassInterfaces, getKnownClassNames, getKnownClassesByPackage, getMethodsForClass, hasKnownMethodOwnerPrefix } from "./javac/method-registry.js";
 export { disassemble } from "./javac/disasm.js";

--- a/web/javac/compiler.ts
+++ b/web/javac/compiler.ts
@@ -555,26 +555,6 @@ function resolveWildcardImport(name: string, packageImports: string[]): string |
   return matches.size === 1 ? matches.values().next().value! : undefined;
 }
 
-const JAVA_LANG_SIMPLE_NAMES = new Set([
-  "Object",
-  "Class",
-  "System",
-  "Throwable",
-  "Exception",
-  "RuntimeException",
-  "Integer",
-  "Long",
-  "Short",
-  "Byte",
-  "Character",
-  "Boolean",
-  "Float",
-  "Double",
-  "StringBuilder",
-  "Math",
-  "IO",
-]);
-
 function resolveClassName(ctx: CompileContext, name: string): string {
   // Already internal (contains '/') or fully qualified (contains '.')
   if (name.includes("/")) return name;
@@ -582,8 +562,9 @@ function resolveClassName(ctx: CompileContext, name: string): string {
   const explicit = ctx.importMap.get(name);
   if (explicit) return explicit;
   if (ctx.classDecls.has(name)) return name;
-  if (ctx.packageImports.includes("java/lang") && JAVA_LANG_SIMPLE_NAMES.has(name)) {
-    return `java/lang/${name}`;
+  const javaLangCandidate = `java/lang/${name}`;
+  if (ctx.packageImports.includes("java/lang") && hasKnownMethodOwnerPrefix(javaLangCandidate)) {
+    return javaLangCandidate;
   }
   return resolveWildcardImport(name, ctx.packageImports) ?? name;
 }

--- a/web/javac/compiler.ts
+++ b/web/javac/compiler.ts
@@ -555,6 +555,26 @@ function resolveWildcardImport(name: string, packageImports: string[]): string |
   return matches.size === 1 ? matches.values().next().value! : undefined;
 }
 
+const JAVA_LANG_SIMPLE_NAMES = new Set([
+  "Object",
+  "Class",
+  "System",
+  "Throwable",
+  "Exception",
+  "RuntimeException",
+  "Integer",
+  "Long",
+  "Short",
+  "Byte",
+  "Character",
+  "Boolean",
+  "Float",
+  "Double",
+  "StringBuilder",
+  "Math",
+  "IO",
+]);
+
 function resolveClassName(ctx: CompileContext, name: string): string {
   // Already internal (contains '/') or fully qualified (contains '.')
   if (name.includes("/")) return name;
@@ -562,6 +582,9 @@ function resolveClassName(ctx: CompileContext, name: string): string {
   const explicit = ctx.importMap.get(name);
   if (explicit) return explicit;
   if (ctx.classDecls.has(name)) return name;
+  if (ctx.packageImports.includes("java/lang") && JAVA_LANG_SIMPLE_NAMES.has(name)) {
+    return `java/lang/${name}`;
+  }
   return resolveWildcardImport(name, ctx.packageImports) ?? name;
 }
 

--- a/web/javac/method-registry.ts
+++ b/web/javac/method-registry.ts
@@ -10,8 +10,10 @@ export interface MethodSig {
 }
 
 // VM-specific methods that are not in jdk-shim/bundle.bin.
-// All standard JDK methods (String, Integer, StringBuilder, etc.) must be registered
-// dynamically via setMethodRegistry() before calling compile().
+// Standard JDK classes are registered dynamically before calling compile():
+// method signatures via setMethodRegistry(), and owner class names via
+// setKnownClassOwners(). The latter lets wildcard import resolution recognize
+// shim classes even when a class contributes no callable methods.
 // In the browser this happens in loadClassBundle() (index.html).
 // In tests this happens at module init (javac.test.ts top-level block).
 // Without a loaded shim registry, compile() will fail to resolve JDK method calls.
@@ -57,6 +59,12 @@ function addToIndexes(entries: Record<string, MethodSig>): void {
   }
 }
 
+function addKnownOwners(owners: Iterable<string>): void {
+  for (const owner of owners) {
+    ownerSet.add(owner);
+  }
+}
+
 // Build initial indexes
 rebuildIndexes();
 
@@ -67,6 +75,11 @@ let knownClassInterfaces: Record<string, string[]> = {};
 export function setMethodRegistry(reg: Record<string, MethodSig>): void {
   knownMethods = { ...knownMethods, ...reg };
   addToIndexes(reg);
+}
+
+/** Merge known owner class names into the lookup set. */
+export function setKnownClassOwners(owners: Iterable<string>): void {
+  addKnownOwners(owners);
 }
 
 /** Merge class→interfaces mappings built from loaded JARs. */

--- a/web/javac/parser.ts
+++ b/web/javac/parser.ts
@@ -1,25 +1,6 @@
 import { TokenKind, type Token } from "./lexer.js";
 import type { ClassDecl, Expr, FieldDecl, MethodDecl, Stmt, Type } from "./ast.js";
-
-const JAVA_LANG_SIMPLE_NAMES = new Set([
-  "Object",
-  "Class",
-  "System",
-  "Throwable",
-  "Exception",
-  "RuntimeException",
-  "Integer",
-  "Long",
-  "Short",
-  "Byte",
-  "Character",
-  "Boolean",
-  "Float",
-  "Double",
-  "StringBuilder",
-  "Math",
-  "IO",
-]);
+import { hasKnownMethodOwnerPrefix } from "./method-registry.js";
 
 export function parseAll(tokens: Token[], implicitClassName?: string): ClassDecl[] {
   let pos = 0;
@@ -94,8 +75,9 @@ export function parseAll(tokens: Token[], implicitClassName?: string): ClassDecl
     if (name.includes(".")) return name.replace(/\./g, "/");
     const explicit = importMap.get(name);
     if (explicit) return explicit;
-    if (packageImports.includes("java/lang") && JAVA_LANG_SIMPLE_NAMES.has(name)) {
-      return `java/lang/${name}`;
+    const javaLangCandidate = `java/lang/${name}`;
+    if (packageImports.includes("java/lang") && hasKnownMethodOwnerPrefix(javaLangCandidate)) {
+      return javaLangCandidate;
     }
     return name;
   }


### PR DESCRIPTION
## Summary
- resolve implicit java.lang simple names during code generation
- add a regression test covering unqualified Throwable references

## Testing
- docker-compose run --rm node npm test
