### PR TITLE
fix: lazy JAR entry decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Status labels:
 
 ## JAR loader
 
-199xVM can load classes directly from JAR files at runtime via `Vm::load_jar()`. The Rust `zip` crate (WASM-compatible) handles ZIP decompression. Non-class resources in JARs are stored in a resource map and accessible via `ClassLoader.getResourceAsStream()`.
+199xVM can load classes directly from JAR files at runtime via `Vm::load_jar()`. The Rust `zip` crate (WASM-compatible) parses the ZIP central directory up front, but individual class/resource entries are decompressed only on first access. Non-class resources remain addressable through `ClassLoader.getResourceAsStream()`.
 
 The frontend also exposes a `jar_to_bundle()` WASM export that converts JAR bytes to the flat bundle format, falling back to the JS-side `readJar()` when WASM is not available.
 

--- a/jvm-core/benches/interpreter.rs
+++ b/jvm-core/benches/interpreter.rs
@@ -24,6 +24,10 @@ fn bench_bundle() -> &'static [u8] {
     include_bytes!("../../test-classes/bench-bundle.bin")
 }
 
+fn jar_loader_test_jar() -> &'static [u8] {
+    include_bytes!("../tests/test.jar")
+}
+
 /// Measures O(n) method lookup + constant pool clone per static call.
 /// BenchMethodCall.run() calls add(s, i) 1000 times.
 fn bench_method_call(c: &mut Criterion) {
@@ -62,11 +66,45 @@ fn bench_virtual_call(c: &mut Criterion) {
     });
 }
 
+/// Measures lazy JAR registration plus first execution of a class loaded from the JAR.
+fn bench_lazy_jar_load_and_run(c: &mut Criterion) {
+    c.bench_function("lazy_jar_load_and_run_entry", |b| {
+        b.iter(|| {
+            let mut vm = jvm_core::interpreter::Vm::new();
+            jvm_core::load_bundle(&mut vm, shim_bundle());
+            vm.load_jar(jar_loader_test_jar()).expect("load test jar");
+            let result = vm.invoke_static_threaded("JarTestEntry", "run", "()Ljava/lang/String;", vec![]);
+            match result {
+                Ok(jvm_core::heap::JValue::Ref(Some(r))) => {
+                    assert_eq!(r.borrow().as_java_string().unwrap_or_default(), "jar-ok");
+                }
+                other => panic!("unexpected result: {other:?}"),
+            }
+        })
+    });
+}
+
+/// Measures lazy JAR registration plus first resource inflate from the JAR.
+fn bench_lazy_jar_load_and_read_resource(c: &mut Criterion) {
+    c.bench_function("lazy_jar_load_and_read_resource", |b| {
+        b.iter(|| {
+            let mut vm = jvm_core::interpreter::Vm::new();
+            vm.load_jar(jar_loader_test_jar()).expect("load test jar");
+            let data = vm.read_resource("resource.txt")
+                .expect("read resource")
+                .expect("resource.txt missing");
+            assert_eq!(std::str::from_utf8(&data).expect("utf8").trim(), "hello from jar resource");
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_method_call,
     bench_static_field,
     bench_string_ldc,
-    bench_virtual_call
+    bench_virtual_call,
+    bench_lazy_jar_load_and_run,
+    bench_lazy_jar_load_and_read_resource
 );
 criterion_main!(benches);

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -19,6 +19,8 @@ use crate::class_file::{
 };
 use crate::heap::{JObject, JRef, JValue};
 
+type OwnedJarArchive = zip::ZipArchive<std::io::Cursor<Vec<u8>>>;
+
 /// All execution-time data extracted from a resolved method in a single pass.
 /// Returned by [`Vm::resolve_method_exec_info`] to avoid repeated `find_method`
 /// calls and to give each field a self-documenting name.
@@ -43,13 +45,128 @@ pub(super) struct MethodExecInfo {
     pub access_flags: u16,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{LazyClass, Vm};
+    use std::io::{Cursor, Write};
+
+    fn build_misnamed_jar() -> Vec<u8> {
+        let mut archive = zip::ZipArchive::new(Cursor::new(include_bytes!("../../tests/test.jar").as_slice()))
+            .expect("open test jar");
+        let mut class_file = archive.by_name("JarTestEntry.class").expect("JarTestEntry.class");
+        let mut class_bytes = Vec::new();
+        std::io::Read::read_to_end(&mut class_file, &mut class_bytes).expect("read class bytes");
+
+        let mut jar_bytes = Vec::new();
+        {
+            let cursor = Cursor::new(&mut jar_bytes);
+            let mut writer = zip::ZipWriter::new(cursor);
+            let options = zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            writer.start_file("wrong/Path.class", options).expect("start class entry");
+            writer.write_all(&class_bytes).expect("write class entry");
+            writer.finish().expect("finish jar");
+        }
+        jar_bytes
+    }
+
+    fn class_entries_in_test_jar() -> Vec<(String, Vec<u8>)> {
+        let mut archive = zip::ZipArchive::new(Cursor::new(include_bytes!("../../tests/test.jar").as_slice()))
+            .expect("open test jar");
+        let mut classes = Vec::new();
+        for i in 0..archive.len() {
+            let mut file = archive.by_index(i).expect("test jar entry");
+            let name = file.name().to_owned();
+            let Some(class_name) = name.strip_suffix(".class") else {
+                continue;
+            };
+            if class_name.is_empty() {
+                continue;
+            }
+            let mut bytes = Vec::new();
+            std::io::Read::read_to_end(&mut file, &mut bytes).expect("read class bytes");
+            classes.push((class_name.to_owned(), bytes));
+        }
+        classes
+    }
+
+    #[test]
+    fn jar_classes_stay_pending_until_first_access() {
+        let mut vm = Vm::new();
+        let count = vm.load_jar(include_bytes!("../../tests/test.jar")).expect("load_jar failed");
+        assert!(count > 0, "expected at least one class in test JAR");
+        assert!(matches!(vm.classes.get("JarTestEntry"), Some(LazyClass::PendingJarEntry(_))));
+
+        vm.ensure_class_ready("JarTestEntry");
+
+        assert!(matches!(vm.classes.get("JarTestEntry"), Some(LazyClass::Ready(_))));
+    }
+
+    #[test]
+    fn misnamed_jar_class_uses_entry_path_and_fails_on_parse() {
+        let mut vm = Vm::new();
+        let count = vm.load_jar(&build_misnamed_jar()).expect("load_jar failed");
+        assert_eq!(count, 1, "expected one class in misnamed jar");
+        assert!(matches!(vm.classes.get("wrong/Path"), Some(LazyClass::PendingJarEntry(_))));
+        assert!(vm.resolve_class("JarTestEntry").is_none(), "must not recover by internal name");
+
+        vm.ensure_class_ready("wrong/Path");
+
+        match vm.classes.get("wrong/Path") {
+            Some(LazyClass::ParseError(err)) => {
+                assert!(err.contains("Class name mismatch"), "unexpected error: {err}");
+                assert!(err.contains("wrong/Path"), "unexpected error: {err}");
+                assert!(err.contains("JarTestEntry"), "unexpected error: {err}");
+            }
+            _ => panic!("expected ParseError for misnamed JAR entry"),
+        }
+    }
+
+    #[test]
+    fn missing_packaged_lookup_leaves_pending_jar_entries_untouched() {
+        let class_names: Vec<String> = class_entries_in_test_jar()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        let mut vm = Vm::new();
+        vm.load_jar(include_bytes!("../../tests/test.jar")).expect("load test jar");
+
+        for class_name in &class_names {
+            assert!(
+                matches!(vm.classes.get(class_name), Some(LazyClass::PendingJarEntry(_))),
+                "expected pending jar entry before miss: {class_name}"
+            );
+        }
+
+        vm.ensure_class_ready("missing/Type");
+
+        for class_name in &class_names {
+            assert!(
+                matches!(vm.classes.get(class_name), Some(LazyClass::PendingJarEntry(_))),
+                "packaged miss must not parse or rewrite pending entry: {class_name}"
+            );
+        }
+        assert!(vm.resolve_class("missing/Type").is_none(), "missing class must remain unresolved");
+    }
+}
+
 /// A class entry in the VM's class registry.
 ///
-/// `Pending` holds the raw `.class` bytes and is promoted to `Ready` on first access,
-/// implementing standard ClassLoader lazy-loading semantics.
+/// `PendingBytes` and `PendingJarEntry` are promoted to `Ready` on first access,
+/// implementing standard ClassLoader lazy-loading semantics for both flat bundles
+/// and JAR-backed classes.
+#[derive(Debug, Clone)]
+pub(in crate::interpreter) struct JarEntryRef {
+    pub jar_id: usize,
+    pub entry_index: usize,
+    pub entry_name: String,
+}
+
 pub(in crate::interpreter) enum LazyClass {
     /// Raw bytes not yet parsed.
-    Pending(Vec<u8>),
+    PendingBytes(Vec<u8>),
+    /// JAR entry that should be decompressed only when first accessed.
+    PendingJarEntry(JarEntryRef),
     /// Fully parsed class file.
     Ready(ClassFile),
     /// Bytes were present but could not be parsed (malformed class).
@@ -318,7 +435,7 @@ impl Scheduler {
 /// The central virtual machine that holds loaded classes and drives execution.
 pub struct Vm {
     /// Class registry: keyed by internal name (`net/unit8/raoh/Result`).
-    /// Entries start as `LazyClass::Pending` (raw bytes) and are promoted to
+    /// Entries start as `LazyClass::PendingBytes`/`PendingJarEntry` and are promoted to
     /// `LazyClass::Ready` (parsed `ClassFile`) on first access.
     pub(in crate::interpreter) classes: HashMap<String, LazyClass>,
     /// Interned strings cache (not strictly required but saves allocations).
@@ -361,8 +478,12 @@ pub struct Vm {
     /// Method resolution cache: (class, method_name, descriptor) → owner class name.
     /// Avoids repeated super-chain walks for the same method lookup.
     method_owner_cache: HashMap<(String, String, String), Option<String>>,
-    /// Non-class resources from loaded JARs, keyed by path (e.g. "clojure/core.clj").
+    /// Materialized non-class resources from loaded JARs, keyed by path.
     pub resources: HashMap<String, Vec<u8>>,
+    /// Non-class resources that still point at compressed JAR entries.
+    pending_resources: HashMap<String, JarEntryRef>,
+    /// Parsed ZIP archives kept alive so lazy entry reads do not re-scan the central directory.
+    jar_archives: Vec<OwnedJarArchive>,
 }
 
 impl Vm {
@@ -390,7 +511,28 @@ impl Vm {
             monitors: HashMap::new(),
             method_owner_cache: HashMap::new(),
             resources: HashMap::new(),
+            pending_resources: HashMap::new(),
+            jar_archives: Vec::new(),
         }
+    }
+
+    fn read_jar_entry(&mut self, entry: &JarEntryRef) -> Result<Vec<u8>, String> {
+        let archive = self.jar_archives.get_mut(entry.jar_id)
+            .ok_or_else(|| format!("Missing JAR backing store for {}", entry.entry_name))?;
+        let mut file = archive.by_index(entry.entry_index)
+            .map_err(|e| format!("ZIP entry error for {}: {e}", entry.entry_name))?;
+        if file.name() != entry.entry_name {
+            return Err(format!(
+                "ZIP entry mismatch at index {}: expected {}, found {}",
+                entry.entry_index,
+                entry.entry_name,
+                file.name()
+            ));
+        }
+        let mut buf = Vec::with_capacity(file.size() as usize);
+        std::io::Read::read_to_end(&mut file, &mut buf)
+            .map_err(|e| format!("Read error for {}: {e}", entry.entry_name))?;
+        Ok(buf)
     }
 
     /// Get the object identity key for monitor operations.
@@ -758,57 +900,123 @@ impl Vm {
     /// The class is parsed only when first accessed via [`Self::ensure_class_ready`].
     /// If the class is already registered (e.g., as `Ready`), the existing entry is kept.
     pub fn load_lazy(&mut self, name: String, bytes: Vec<u8>) {
-        self.classes.entry(name).or_insert(LazyClass::Pending(bytes));
+        self.classes.entry(name).or_insert(LazyClass::PendingBytes(bytes));
+    }
+
+    fn load_lazy_jar_entry(&mut self, name: String, entry: JarEntryRef) {
+        self.classes.entry(name).or_insert(LazyClass::PendingJarEntry(entry));
     }
 
     /// Load classes and resources from a JAR (ZIP) byte array.
-    /// `.class` entries are registered via [`Self::load_lazy`]; all other
-    /// non-directory entries are stored in the resource map.
+    /// `.class` entries are registered lazily from their ZIP entry metadata; all other
+    /// non-directory entries are recorded and decompressed only on first access.
+    ///
+    /// The ZIP entry path is treated as the canonical class name (`pkg/Foo.class` -> `pkg/Foo`).
+    /// We intentionally do not scan class bodies to recover mismatched internal names:
+    /// such JARs are nonstandard, and keeping that fallback would add decompression and
+    /// parsing work to ordinary lazy-loading paths.
     /// Returns the number of classes loaded.
     pub fn load_jar(&mut self, jar_bytes: &[u8]) -> Result<usize, String> {
         use std::io::Cursor;
-        let reader = Cursor::new(jar_bytes);
+        let reader = Cursor::new(jar_bytes.to_vec());
         let mut archive = zip::ZipArchive::new(reader)
             .map_err(|e| format!("Invalid JAR/ZIP: {e}"))?;
+        let jar_id = self.jar_archives.len();
+        let mut class_entries = Vec::new();
+        let mut resource_entries = Vec::new();
         let mut count = 0;
         for i in 0..archive.len() {
-            let mut file = archive.by_index(i)
+            let file = archive.by_index(i)
                 .map_err(|e| format!("ZIP entry error: {e}"))?;
             let name = file.name().to_owned();
-            let mut buf = Vec::with_capacity(file.size() as usize);
-            std::io::Read::read_to_end(&mut file, &mut buf)
-                .map_err(|e| format!("Read error for {name}: {e}"))?;
-            if name.ends_with(".class") {
-                if let Some(class_name) = crate::class_file::parse_class_name(&buf) {
-                    self.load_lazy(class_name, buf);
+            let entry = JarEntryRef { jar_id, entry_index: i, entry_name: name.clone() };
+            if let Some(class_name) = name.strip_suffix(".class") {
+                if !class_name.is_empty() {
+                    class_entries.push((class_name.to_owned(), entry));
                     count += 1;
                 }
             } else if !name.ends_with('/') {
-                self.resources.insert(name, buf);
+                resource_entries.push((name, entry));
             }
+        }
+        self.jar_archives.push(archive);
+        for (class_name, entry) in class_entries {
+            self.load_lazy_jar_entry(class_name, entry);
+        }
+        for (name, entry) in resource_entries {
+            self.resources.remove(&name);
+            self.pending_resources.insert(name, entry);
         }
         Ok(count)
     }
 
     /// Ensure the named class is fully parsed (`Ready`).
-    /// If the entry is `Pending`, parses it in place and promotes it to `Ready`.
+    /// If the entry is pending, parses it in place and promotes it to `Ready`.
     /// On parse failure the entry is set to `ParseError` so the failure is
     /// diagnosable and repeated parse attempts are avoided.
     /// Does nothing if the class is already `Ready`, `ParseError`, or not registered.
     pub(in crate::interpreter) fn ensure_class_ready(&mut self, name: &str) {
-        // Only act when the entry is Pending; skip Ready / ParseError / missing.
-        if !matches!(self.classes.get(name), Some(LazyClass::Pending(_))) {
+        if !matches!(
+            self.classes.get(name),
+            Some(LazyClass::PendingBytes(_) | LazyClass::PendingJarEntry(_))
+        ) {
             return;
         }
-        if let Some(LazyClass::Pending(bytes)) = self.classes.remove(name) {
-            match class_file::parse(&bytes) {
-                Ok(cf) => { self.classes.insert(name.to_owned(), LazyClass::Ready(cf)); }
-                Err(e) => {
-                    eprintln!("Warning: failed to parse class '{name}': {e}");
-                    self.classes.insert(name.to_owned(), LazyClass::ParseError(e.to_string()));
-                }
+        let pending = self.classes.remove(name);
+        let result = match pending {
+            Some(LazyClass::PendingBytes(bytes)) => class_file::parse(&bytes).map_err(|e| e.to_string()),
+            Some(LazyClass::PendingJarEntry(entry)) => match self.read_jar_entry(&entry) {
+                Ok(bytes) => match class_file::parse(&bytes) {
+                    Ok(cf) => {
+                        let actual_name = cf.constant_pool.class_name(cf.this_class);
+                        if actual_name == name {
+                            Ok(cf)
+                        } else {
+                            // We deliberately reject classes whose internal name disagrees with
+                            // the ZIP entry path. Recovering them would require a fallback scan
+                            // that penalizes the normal lazy-loading hot path for a nonstandard JAR.
+                            Err(format!(
+                                "Class name mismatch for {}: expected {}, found {}",
+                                entry.entry_name, name, actual_name
+                            ))
+                        }
+                    }
+                    Err(e) => Err(e.to_string()),
+                },
+                Err(e) => Err(e),
+            },
+            Some(other) => {
+                self.classes.insert(name.to_owned(), other);
+                return;
+            }
+            None => return,
+        };
+        match result {
+            Ok(cf) => { self.classes.insert(name.to_owned(), LazyClass::Ready(cf)); }
+            Err(e) => {
+                eprintln!("Warning: failed to parse class '{name}': {e}");
+                self.classes.insert(name.to_owned(), LazyClass::ParseError(e));
             }
         }
+    }
+
+    pub fn has_resource(&self, name: &str) -> bool {
+        let normalized = name.strip_prefix('/').unwrap_or(name);
+        self.resources.contains_key(normalized) || self.pending_resources.contains_key(normalized)
+    }
+
+    pub fn read_resource(&mut self, name: &str) -> Result<Option<Vec<u8>>, String> {
+        let normalized = name.strip_prefix('/').unwrap_or(name);
+        if let Some(data) = self.resources.get(normalized) {
+            return Ok(Some(data.clone()));
+        }
+        let Some(entry) = self.pending_resources.get(normalized).cloned() else {
+            return Ok(None);
+        };
+        let data = self.read_jar_entry(&entry)?;
+        self.pending_resources.remove(normalized);
+        self.resources.insert(normalized.to_owned(), data.clone());
+        Ok(Some(data))
     }
 
     /// Return a reference to a parsed class.
@@ -816,7 +1024,7 @@ impl Vm {
     pub(in crate::interpreter) fn get_class(&self, name: &str) -> Option<&ClassFile> {
         match self.classes.get(name)? {
             LazyClass::Ready(cf) => Some(cf),
-            LazyClass::Pending(_) | LazyClass::ParseError(_) => None,
+            LazyClass::PendingBytes(_) | LazyClass::PendingJarEntry(_) | LazyClass::ParseError(_) => None,
         }
     }
 
@@ -1007,6 +1215,14 @@ impl Vm {
     /// Set `pending_exception` to a `BootstrapMethodError` with a detail message.
     pub(in crate::interpreter) fn throw_bootstrap_method_error(&mut self, detail: &str) {
         let exc = self.new_vm_exception_message("java/lang/BootstrapMethodError", detail);
+        *self.pending_exception_mut() = Some(exc);
+    }
+
+    /// Set `pending_exception` to a `RuntimeException` with a detail message.
+    pub(in crate::interpreter) fn throw_runtime_exception(&mut self, detail: &str) {
+        let exc = JObject::new("java/lang/RuntimeException");
+        let msg = self.intern_string(detail.to_owned());
+        exc.borrow_mut().fields.insert("detailMessage".to_owned(), JValue::Ref(Some(msg)));
         *self.pending_exception_mut() = Some(exc);
     }
 

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -296,7 +296,7 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
                     .unwrap_or_default();
                 let normalized = name.strip_prefix('/').unwrap_or(&name);
-                if self.resources.contains_key(normalized) {
+                if self.has_resource(normalized) {
                     let url = JObject::new("java/net/URL");
                     url.borrow_mut().fields.insert("protocol".to_owned(),
                         JValue::Ref(Some(self.intern_string("bundle"))));
@@ -318,19 +318,26 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
                     .unwrap_or_default();
                 let normalized = name.strip_prefix('/').unwrap_or(&name);
-                if let Some(data) = self.resources.get(normalized).cloned() {
-                    // Create a [B array with the resource bytes
-                    let elems: Vec<JValue> = data.iter().map(|&b| JValue::Int(b as i8 as i32)).collect();
-                    let byte_array = JObject::new_array("[B", elems);
-                    // Create ByteArrayInputStream via its constructor logic
-                    let bais = JObject::new("java/io/ByteArrayInputStream");
-                    bais.borrow_mut().fields.insert("buf".to_owned(), JValue::Ref(Some(byte_array)));
-                    bais.borrow_mut().fields.insert("pos".to_owned(), JValue::Int(0));
-                    bais.borrow_mut().fields.insert("count".to_owned(), JValue::Int(data.len() as i32));
-                    bais.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
-                    Some(JValue::Ref(Some(bais)))
-                } else {
-                    Some(JValue::Ref(None))
+                match self.read_resource(normalized) {
+                    Ok(Some(data)) => {
+                        // Create a [B array with the resource bytes
+                        let elems: Vec<JValue> = data.iter().map(|&b| JValue::Int(b as i8 as i32)).collect();
+                        let byte_array = JObject::new_array("[B", elems);
+                        // Create ByteArrayInputStream via its constructor logic
+                        let bais = JObject::new("java/io/ByteArrayInputStream");
+                        bais.borrow_mut().fields.insert("buf".to_owned(), JValue::Ref(Some(byte_array)));
+                        bais.borrow_mut().fields.insert("pos".to_owned(), JValue::Int(0));
+                        bais.borrow_mut().fields.insert("count".to_owned(), JValue::Int(data.len() as i32));
+                        bais.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
+                        Some(JValue::Ref(Some(bais)))
+                    }
+                    Ok(None) => Some(JValue::Ref(None)),
+                    Err(err) => {
+                        self.throw_runtime_exception(&format!(
+                            "getResourceAsStream({normalized}): {err}"
+                        ));
+                        Some(JValue::Void)
+                    }
                 }
             }
             "findResource" => {
@@ -1567,5 +1574,33 @@ impl super::Vm {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{JarEntryRef, Vm};
+    use crate::heap::{JObject, JValue};
+
+    #[test]
+    fn get_resource_as_stream_raises_runtime_exception_on_lazy_read_error() {
+        let mut vm = Vm::new();
+        vm.load_jar(include_bytes!("../../tests/test.jar")).expect("load test jar");
+        vm.pending_resources.insert(
+            "broken.txt".to_owned(),
+            JarEntryRef {
+                jar_id: 0,
+                entry_index: 999,
+                entry_name: "broken.txt".to_owned(),
+            },
+        );
+
+        let arg = JValue::Ref(Some(JObject::new_string("broken.txt")));
+        let result = vm.native_classloader("getResourceAsStream", &[arg]);
+
+        assert!(matches!(result, Some(JValue::Void)));
+        let err = vm.pending_exception_err().expect("pending exception");
+        assert!(err.contains("java/lang/RuntimeException"), "unexpected error: {err}");
+        assert!(err.contains("broken.txt"), "unexpected error: {err}");
     }
 }

--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -676,9 +676,15 @@ fn load_jar_resource() {
     let mut vm = jvm_core::interpreter::Vm::new();
     jvm_core::load_bundle(&mut vm, shim_bundle());
     vm.load_jar(jar_loader_test_jar()).expect("load_jar failed");
-    assert!(vm.resources.contains_key("resource.txt"), "resource.txt not found");
-    let data = vm.resources.get("resource.txt").unwrap();
-    let text = std::str::from_utf8(data).unwrap().trim();
+    assert!(vm.has_resource("resource.txt"), "resource.txt not found");
+    assert!(!vm.resources.contains_key("resource.txt"),
+        "resource.txt should remain compressed until first access");
+    let data = vm.read_resource("resource.txt")
+        .expect("read_resource failed")
+        .expect("resource.txt missing");
+    assert!(vm.resources.contains_key("resource.txt"),
+        "resource.txt should be cached after first access");
+    let text = std::str::from_utf8(&data).unwrap().trim();
     assert_eq!(text, "hello from jar resource");
 }
 


### PR DESCRIPTION
## Summary
- switch the JAR loader to register class and resource ZIP entries lazily while keeping the parsed ZIP archive alive for first-access decompression
- lazy-load non-class resources and surface lazy resource read failures as RuntimeException instead of silently returning null
- treat ZIP entry paths as the canonical class names, document why the misnamed-class fallback was removed, and keep structural regression coverage in default-on tests
- move timing-based perf checks into Criterion benches so regular cargo test stays deterministic

## Testing
- docker-compose run --rm rust cargo test --package jvm-core
- docker-compose run --rm rust cargo bench --package jvm-core --bench interpreter --no-run
- docker-compose run --rm -w /app/jvm-core rust cargo test --package jvm-core clojure_smoke -- --ignored --exact

Fixes #57