### PR TITLE
Clean up Makefile: unify JAR management and fix dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ dist: web/javac.js jdk-shim/bundle.bin jvm-core/pkg/jvm_core_bg.wasm $(WEB_JARS)
 	cp jvm-core/pkg/jvm_core.js          dist/pkg/jvm_core.js
 	cp jvm-core/pkg/jvm_core_bg.wasm     dist/pkg/jvm_core_bg.wasm
 	cp jdk-shim/bundle.bin               dist/bundle/shim.bin
-	$(foreach jar,$(ALL_JAR_NAMES),cp web/$(jar) dist/$(jar);)
+	set -e; for jar in $(ALL_JAR_NAMES); do cp web/$$jar dist/$$jar; done
 	@echo ""
 	@echo "==> dist/ contents:"
 	@find dist -type f | sort
@@ -213,7 +213,7 @@ endif
 	upload_if_changed dist/pkg/jvm_core.js             "$(GCS)/pkg/jvm_core.js"             --cache-control="public,max-age=31536000"; \
 	upload_if_changed dist/pkg/jvm_core_bg.wasm        "$(GCS)/pkg/jvm_core_bg.wasm"        --cache-control="public,max-age=31536000" --content-type="application/wasm"; \
 	upload_if_changed dist/bundle/shim.bin             "$(GCS)/bundle/shim.bin"             --cache-control="public,max-age=31536000" --content-type="application/octet-stream"; \
-	$(foreach jar,$(ALL_JAR_NAMES),upload_if_changed dist/$(jar) "$(GCS)/$(jar)" --cache-control="public,max-age=31536000" --content-type="application/java-archive"; ) \
+	for jar in $(ALL_JAR_NAMES); do upload_if_changed dist/$$jar "$(GCS)/$$jar" --cache-control="public,max-age=31536000" --content-type="application/java-archive"; done; \
 	echo "  upload: index.html (always)"; \
 	gcloud storage cp dist/index.html "$(GCS)/index.html" --cache-control="no-cache" --content-type="text/html; charset=utf-8"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,14 @@ CLOJURE_CORE_SPEC_JAR := core.specs.alpha-0.4.74.jar
 JAR_NAMES := $(RAOH_JAR) $(RAOH_JSON_JAR) $(JACKSON_ANN_JAR) \
              $(JACKSON_CORE_JAR) $(JACKSON_DATABIND_JAR)
 CLOJURE_JAR_NAMES := $(CLOJURE_JAR) $(CLOJURE_SPEC_JAR) $(CLOJURE_CORE_SPEC_JAR)
+ALL_JAR_NAMES := $(JAR_NAMES) $(CLOJURE_JAR_NAMES)
 
-WEB_JARS := $(addprefix web/,$(JAR_NAMES))
-CLOJURE_DIST_JARS := $(addprefix clj-smoke/jars/,$(CLOJURE_JAR_NAMES))
+WEB_JARS := $(addprefix web/,$(ALL_JAR_NAMES))
 
-.PHONY: all dev-jars shim test-bundle clj-smoke-bundle clj-smoke-test clj-upstream-test clj-upstream-coverage clj-smoke-bundle-docker clj-smoke-test-docker clj-upstream-test-docker clj-upstream-coverage-docker javac wasm dist test launcher-test clean deploy docker-playground dist-docker
+.PHONY: all dev-jars shim test-bundle javac wasm test launcher-test \
+        dist deploy docker-playground dist-docker clean \
+        clj-smoke-bundle clj-smoke-test clj-upstream-test clj-upstream-coverage \
+        clj-smoke-bundle-docker clj-smoke-test-docker clj-upstream-test-docker clj-upstream-coverage-docker
 
 # ============================================================
 # all — build everything needed for local development
@@ -56,6 +59,24 @@ web/$(JACKSON_CORE_JAR):
 web/$(JACKSON_DATABIND_JAR):
 	mvn dependency:copy \
 	  -Dartifact=tools.jackson.core:jackson-databind:3.1.0 \
+	  -DoutputDirectory=web \
+	  -Dmdep.stripVersion=false
+
+web/$(CLOJURE_JAR):
+	mvn dependency:copy \
+	  -Dartifact=org.clojure:clojure:1.12.0 \
+	  -DoutputDirectory=web \
+	  -Dmdep.stripVersion=false
+
+web/$(CLOJURE_SPEC_JAR):
+	mvn dependency:copy \
+	  -Dartifact=org.clojure:spec.alpha:0.5.238 \
+	  -DoutputDirectory=web \
+	  -Dmdep.stripVersion=false
+
+web/$(CLOJURE_CORE_SPEC_JAR):
+	mvn dependency:copy \
+	  -Dartifact=org.clojure:core.specs.alpha:0.4.74 \
 	  -DoutputDirectory=web \
 	  -Dmdep.stripVersion=false
 
@@ -137,7 +158,7 @@ launcher-test: jdk-shim/bundle.bin test-classes/bundle.bin jvm-core/pkg/jvm_core
 # ============================================================
 # dist — assemble deployable static files in dist/
 # ============================================================
-dist: web/javac.js jdk-shim/bundle.bin jvm-core/pkg/jvm_core_bg.wasm $(WEB_JARS) $(CLOJURE_DIST_JARS)
+dist: web/javac.js jdk-shim/bundle.bin jvm-core/pkg/jvm_core_bg.wasm $(WEB_JARS)
 	rm -rf dist
 	mkdir -p dist/pkg dist/bundle
 	sed \
@@ -150,14 +171,7 @@ dist: web/javac.js jdk-shim/bundle.bin jvm-core/pkg/jvm_core_bg.wasm $(WEB_JARS)
 	cp jvm-core/pkg/jvm_core.js          dist/pkg/jvm_core.js
 	cp jvm-core/pkg/jvm_core_bg.wasm     dist/pkg/jvm_core_bg.wasm
 	cp jdk-shim/bundle.bin               dist/bundle/shim.bin
-	cp web/$(RAOH_JAR)                   dist/$(RAOH_JAR)
-	cp web/$(RAOH_JSON_JAR)              dist/$(RAOH_JSON_JAR)
-	cp web/$(JACKSON_ANN_JAR)            dist/$(JACKSON_ANN_JAR)
-	cp web/$(JACKSON_CORE_JAR)           dist/$(JACKSON_CORE_JAR)
-	cp web/$(JACKSON_DATABIND_JAR)       dist/$(JACKSON_DATABIND_JAR)
-	cp clj-smoke/jars/$(CLOJURE_JAR)     dist/$(CLOJURE_JAR)
-	cp clj-smoke/jars/$(CLOJURE_SPEC_JAR) dist/$(CLOJURE_SPEC_JAR)
-	cp clj-smoke/jars/$(CLOJURE_CORE_SPEC_JAR) dist/$(CLOJURE_CORE_SPEC_JAR)
+	$(foreach jar,$(ALL_JAR_NAMES),cp web/$(jar) dist/$(jar);)
 	@echo ""
 	@echo "==> dist/ contents:"
 	@find dist -type f | sort
@@ -195,17 +209,11 @@ endif
 	  gcloud storage cp "$$src" "$$dst" "$$@"; \
 	}; \
 	upload_if_changed dist/javac.js                    "$(GCS)/javac.js"                    --cache-control="public,max-age=31536000"; \
+	upload_if_changed dist/launcher.js                 "$(GCS)/launcher.js"                 --cache-control="public,max-age=31536000"; \
 	upload_if_changed dist/pkg/jvm_core.js             "$(GCS)/pkg/jvm_core.js"             --cache-control="public,max-age=31536000"; \
 	upload_if_changed dist/pkg/jvm_core_bg.wasm        "$(GCS)/pkg/jvm_core_bg.wasm"        --cache-control="public,max-age=31536000" --content-type="application/wasm"; \
 	upload_if_changed dist/bundle/shim.bin             "$(GCS)/bundle/shim.bin"             --cache-control="public,max-age=31536000" --content-type="application/octet-stream"; \
-	upload_if_changed dist/$(RAOH_JAR)                 "$(GCS)/$(RAOH_JAR)"                 --cache-control="public,max-age=31536000" --content-type="application/java-archive"; \
-	upload_if_changed dist/$(RAOH_JSON_JAR)            "$(GCS)/$(RAOH_JSON_JAR)"            --cache-control="public,max-age=31536000" --content-type="application/java-archive"; \
-	upload_if_changed dist/$(JACKSON_ANN_JAR)          "$(GCS)/$(JACKSON_ANN_JAR)"          --cache-control="public,max-age=31536000" --content-type="application/java-archive"; \
-	upload_if_changed dist/$(JACKSON_CORE_JAR)         "$(GCS)/$(JACKSON_CORE_JAR)"         --cache-control="public,max-age=31536000" --content-type="application/java-archive"; \
-	upload_if_changed dist/$(JACKSON_DATABIND_JAR)     "$(GCS)/$(JACKSON_DATABIND_JAR)"     --cache-control="public,max-age=31536000" --content-type="application/java-archive"; \
-	upload_if_changed dist/$(CLOJURE_JAR)              "$(GCS)/$(CLOJURE_JAR)"              --cache-control="public,max-age=31536000" --content-type="application/java-archive"; \
-	upload_if_changed dist/$(CLOJURE_SPEC_JAR)         "$(GCS)/$(CLOJURE_SPEC_JAR)"         --cache-control="public,max-age=31536000" --content-type="application/java-archive"; \
-	upload_if_changed dist/$(CLOJURE_CORE_SPEC_JAR)    "$(GCS)/$(CLOJURE_CORE_SPEC_JAR)"    --cache-control="public,max-age=31536000" --content-type="application/java-archive"; \
+	$(foreach jar,$(ALL_JAR_NAMES),upload_if_changed dist/$(jar) "$(GCS)/$(jar)" --cache-control="public,max-age=31536000" --content-type="application/java-archive"; ) \
 	echo "  upload: index.html (always)"; \
 	gcloud storage cp dist/index.html "$(GCS)/index.html" --cache-control="no-cache" --content-type="text/html; charset=utf-8"
 	@echo ""

--- a/web/index.html
+++ b/web/index.html
@@ -1621,17 +1621,12 @@ public class JvmInterfaceDefault implements Describable {
 
     const ASSET_VERSION = "__BUILD_TIMESTAMP__";
     const IS_VERSIONED_BUILD = typeof ASSET_VERSION === "string" && !ASSET_VERSION.startsWith("__");
-    const CLOJURE_JAR_CANDIDATES = IS_VERSIONED_BUILD
-      ? [
-          ["./clojure-1.12.0.jar", "../clj-smoke/jars/clojure-1.12.0.jar"],
-          ["./spec.alpha-0.5.238.jar", "../clj-smoke/jars/spec.alpha-0.5.238.jar"],
-          ["./core.specs.alpha-0.4.74.jar", "../clj-smoke/jars/core.specs.alpha-0.4.74.jar"],
-        ]
-      : [
-          ["../clj-smoke/jars/clojure-1.12.0.jar", "./clojure-1.12.0.jar"],
-          ["../clj-smoke/jars/spec.alpha-0.5.238.jar", "./spec.alpha-0.5.238.jar"],
-          ["../clj-smoke/jars/core.specs.alpha-0.4.74.jar", "./core.specs.alpha-0.4.74.jar"],
-        ];
+    // Clojure JARs: in dist/ they sit next to index.html; in dev they are in web/.
+    const CLOJURE_JAR_CANDIDATES = [
+        ["./clojure-1.12.0.jar"],
+        ["./spec.alpha-0.5.238.jar"],
+        ["./core.specs.alpha-0.4.74.jar"],
+      ];
     const CLOJURE_EVAL_EXPR = "(let [result (load-string (slurp *in*))] (when (some? result) (prn result)))";
 
     function getSnippetEntry(key) {

--- a/web/index.html
+++ b/web/index.html
@@ -1620,7 +1620,6 @@ public class JvmInterfaceDefault implements Describable {
     };
 
     const ASSET_VERSION = "__BUILD_TIMESTAMP__";
-    const IS_VERSIONED_BUILD = typeof ASSET_VERSION === "string" && !ASSET_VERSION.startsWith("__");
     // Clojure JARs: in dist/ they sit next to index.html; in dev they are in web/.
     const CLOJURE_JAR_CANDIDATES = [
         ["./clojure-1.12.0.jar"],


### PR DESCRIPTION
## Summary

- Download Clojure JARs via Maven (`dev-jars`) to `web/` alongside raoh/jackson JARs
- Remove `dist` dependency on `clj-smoke/jars/` — no longer requires `build-clj-smoke.sh` for deploy
- Unify `ALL_JAR_NAMES` list and use `foreach` loop for JAR copy/upload instead of individual lines
- Simplify `CLOJURE_JAR_CANDIDATES` in `index.html` (single path per JAR)
- Add missing `launcher.js` to deploy uploads
- Break `.PHONY` into logical groups for readability

## Motivation

`make dist` was broken because it depended on `clj-smoke/jars/` which requires Clojure toolchain (Docker). Since Clojure JARs are standard Maven artifacts, they should be downloaded the same way as other JARs.

## Test plan

- [x] `make dev-jars` — downloads all 8 JARs to `web/`
- [x] `make dist` — builds successfully, all JARs in `dist/`
- [x] `make test` — 322 compiler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)