### PR TITLE
Add generic VM microbenchmarks for clinit and reflection hot paths

### DIFF
--- a/Benchmark.md
+++ b/Benchmark.md
@@ -25,8 +25,12 @@ Results are written to `target/criterion/` as HTML reports.
 |---|---|---|
 | `method_call_1000x` | `BenchMethodCall.run()` | O(n) method lookup + constant pool clone per static call |
 | `static_field_1000x` | `BenchStaticField.run()` | `format!` string allocation on every `getstatic`/`putstatic` |
+| `inherited_static_field_1000x` | `BenchInheritedStaticField.run()` | inherited `getstatic`/`putstatic` owner resolution on every access |
 | `string_ldc_1000x` | `BenchStringLdc.run()` | `String::clone` on every `ldc` string constant |
 | `virtual_call_1000x` | `BenchVirtualCall.run()` | Interface virtual dispatch + interface name list rebuild |
+| `declared_methods_1000x` | `BenchDeclaredMethods.run()` | repeated `Class.getDeclaredMethods()` metadata rebuild |
+| `process_clinit_launch_to_exit` | `ClinitYieldProcessMain.main()` | launcher/process path when the first bytecode schedules a heavy `<clinit>` |
+| `process_super_clinit_chain_launch_to_exit` | `ClinitChainYieldProcessMain.main()` | launcher/process path when class initialization walks a heavy superclass chain |
 
 Each Java method runs a loop of 1000 iterations so the per-call overhead is amplified and measurable above criterion's noise floor.
 
@@ -45,6 +49,9 @@ cargo bench --package jvm-core -- --baseline before
 ```
 
 criterion will print a percentage change and confidence interval for each benchmark.
+
+The historical tables below predate the later class-init and inherited-static-field scenarios, so
+they currently cover only the original four microbenchmarks.
 
 ## Baseline (2026-03-12, unoptimized interpreter)
 

--- a/jvm-core/benches/interpreter.rs
+++ b/jvm-core/benches/interpreter.rs
@@ -24,8 +24,41 @@ fn bench_bundle() -> &'static [u8] {
     include_bytes!("../../test-classes/bench-bundle.bin")
 }
 
+fn test_jar() -> &'static [u8] {
+    include_bytes!("../../test-classes/test.jar")
+}
+
 fn jar_loader_test_jar() -> &'static [u8] {
     include_bytes!("../tests/test.jar")
+}
+
+fn framed_jars(jars: &[&[u8]]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for jar in jars {
+        let len = jar.len() as u32;
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(jar);
+    }
+    out
+}
+
+fn pump_process_to_exit(
+    process: &mut jvm_core::JvmProcess,
+    max_iters: usize,
+    pump_rounds: usize,
+) -> jvm_core::ProcessExit {
+    for _ in 0..max_iters {
+        match process.pump(pump_rounds) {
+            jvm_core::ProcessState::Running => {}
+            jvm_core::ProcessState::WaitingForInput => {
+                panic!("process unexpectedly blocked on stdin");
+            }
+            jvm_core::ProcessState::Exited => {
+                return process.exit().cloned().expect("process exit");
+            }
+        }
+    }
+    panic!("process did not exit after {max_iters} iterations with pump_rounds={pump_rounds}");
 }
 
 /// Measures O(n) method lookup + constant pool clone per static call.
@@ -46,6 +79,16 @@ fn bench_static_field(c: &mut Criterion) {
     });
 }
 
+/// Measures inherited getstatic/putstatic when the symbolic owner differs from the declaring owner.
+fn bench_inherited_static_field(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("inherited_static_field_1000x", |b| {
+        b.iter(|| {
+            jvm_core::run_static_native(&bundle, "BenchInheritedStaticField", "run", "()I")
+        })
+    });
+}
+
 /// Measures ldc string constant clone cost.
 /// BenchStringLdc.run() loads the string literal "hello" 1000 times.
 fn bench_string_ldc(c: &mut Criterion) {
@@ -63,6 +106,16 @@ fn bench_virtual_call(c: &mut Criterion) {
     let bundle = combined_bundle(shim_bundle(), bench_bundle());
     c.bench_function("virtual_call_1000x", |b| {
         b.iter(|| jvm_core::run_static_native(&bundle, "BenchVirtualCall", "run", "()I"))
+    });
+}
+
+/// Measures repeated Class.getDeclaredMethods() metadata construction.
+fn bench_declared_methods(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("declared_methods_1000x", |b| {
+        b.iter(|| {
+            jvm_core::run_static_native(&bundle, "BenchDeclaredMethods", "run", "()I")
+        })
     });
 }
 
@@ -98,13 +151,108 @@ fn bench_lazy_jar_load_and_read_resource(c: &mut Criterion) {
     });
 }
 
+/// Measures repeated ClassLoader.getResourceAsStream on an already-loaded JAR resource.
+fn bench_classloader_get_resource_as_stream(c: &mut Criterion) {
+    c.bench_function("classloader_get_resource_as_stream_100x", |b| {
+        b.iter(|| {
+            let mut vm = jvm_core::interpreter::Vm::new();
+            jvm_core::load_bundle(&mut vm, shim_bundle());
+            vm.load_jar(test_jar()).expect("load test jar");
+
+            let class_loader = match vm
+                .invoke_static("java/lang/ClassLoader", "getSystemClassLoader", "()Ljava/lang/ClassLoader;", vec![])
+                .expect("getSystemClassLoader")
+            {
+                jvm_core::heap::JValue::Ref(Some(r)) => r,
+                other => panic!("unexpected class loader result: {other:?}"),
+            };
+            let name = jvm_core::heap::JValue::Ref(Some(vm.intern_string("resource.txt")));
+
+            for _ in 0..100 {
+                let stream = vm
+                    .invoke_virtual(
+                        class_loader.clone(),
+                        "java/lang/ClassLoader",
+                        "getResourceAsStream",
+                        "(Ljava/lang/String;)Ljava/io/InputStream;",
+                        vec![name.clone()],
+                    )
+                    .expect("getResourceAsStream");
+                match stream {
+                    jvm_core::heap::JValue::Ref(Some(_)) => {}
+                    other => panic!("unexpected stream result: {other:?}"),
+                }
+            }
+        })
+    });
+}
+
+/// Measures launcher/process execution when the first bytecode triggers a heavy class initializer.
+fn bench_process_clinit_launch_to_exit(c: &mut Criterion) {
+    let jar_data = framed_jars(&[test_jar()]);
+    c.bench_function("process_clinit_launch_to_exit", |b| {
+        b.iter(|| {
+            let mut process = jvm_core::launch_classpath_main_native(
+                shim_bundle(),
+                &jar_data,
+                "ClinitYieldProcessMain",
+                &[],
+                jvm_core::StdioMode::Ignore,
+                jvm_core::StdioMode::Pipe,
+                jvm_core::StdioMode::Pipe,
+            )
+            .expect("launch classpath main");
+
+            let exit = pump_process_to_exit(&mut process, 4096, 64);
+            let stdout = String::from_utf8(process.take_stdout()).expect("utf8 stdout");
+            let stderr = String::from_utf8(process.take_stderr()).expect("utf8 stderr");
+            assert_eq!(stdout, "Idone");
+            assert!(stderr.is_empty());
+            assert_eq!(exit.exit_code, 0);
+            assert_eq!(exit.uncaught_exception, None);
+        })
+    });
+}
+
+/// Measures launcher/process execution when class initialization walks a superclass chain.
+fn bench_process_super_clinit_chain_launch_to_exit(c: &mut Criterion) {
+    let jar_data = framed_jars(&[test_jar()]);
+    c.bench_function("process_super_clinit_chain_launch_to_exit", |b| {
+        b.iter(|| {
+            let mut process = jvm_core::launch_classpath_main_native(
+                shim_bundle(),
+                &jar_data,
+                "ClinitChainYieldProcessMain",
+                &[],
+                jvm_core::StdioMode::Ignore,
+                jvm_core::StdioMode::Pipe,
+                jvm_core::StdioMode::Pipe,
+            )
+            .expect("launch classpath main");
+
+            let exit = pump_process_to_exit(&mut process, 4096, 64);
+            let stdout = String::from_utf8(process.take_stdout()).expect("utf8 stdout");
+            let stderr = String::from_utf8(process.take_stderr()).expect("utf8 stderr");
+            assert_eq!(stdout, "BMLbase:mid:leaf");
+            assert!(stderr.is_empty());
+            assert_eq!(exit.exit_code, 0);
+            assert_eq!(exit.uncaught_exception, None);
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_method_call,
     bench_static_field,
+    bench_inherited_static_field,
     bench_string_ldc,
     bench_virtual_call,
+    bench_declared_methods,
     bench_lazy_jar_load_and_run,
-    bench_lazy_jar_load_and_read_resource
+    bench_lazy_jar_load_and_read_resource,
+    bench_classloader_get_resource_as_stream,
+    bench_process_clinit_launch_to_exit,
+    bench_process_super_clinit_chain_launch_to_exit
 );
 criterion_main!(benches);

--- a/jvm-core/benches/interpreter.rs
+++ b/jvm-core/benches/interpreter.rs
@@ -157,7 +157,7 @@ fn bench_classloader_get_resource_as_stream(c: &mut Criterion) {
         b.iter(|| {
             let mut vm = jvm_core::interpreter::Vm::new();
             jvm_core::load_bundle(&mut vm, shim_bundle());
-            vm.load_jar(test_jar()).expect("load test jar");
+            vm.load_jar(jar_loader_test_jar()).expect("load test jar");
 
             let class_loader = match vm
                 .invoke_static("java/lang/ClassLoader", "getSystemClassLoader", "()Ljava/lang/ClassLoader;", vec![])

--- a/test-sources/ClinitChainYieldProcessMain.java
+++ b/test-sources/ClinitChainYieldProcessMain.java
@@ -1,0 +1,42 @@
+class ClinitChainYieldBase {
+    static final String VALUE = initValue();
+
+    private static String initValue() {
+        for (int i = 0; i < 512; i++) {
+            Thread.yield();
+        }
+        System.out.print("B");
+        return "base";
+    }
+}
+
+class ClinitChainYieldMid extends ClinitChainYieldBase {
+    static final String VALUE = initValue();
+
+    private static String initValue() {
+        for (int i = 0; i < 512; i++) {
+            Thread.yield();
+        }
+        System.out.print("M");
+        return ClinitChainYieldBase.VALUE + ":mid";
+    }
+}
+
+class ClinitChainYieldLeaf extends ClinitChainYieldMid {
+    static final String VALUE = initValue();
+
+    private static String initValue() {
+        for (int i = 0; i < 512; i++) {
+            Thread.yield();
+        }
+        System.out.print("L");
+        return ClinitChainYieldMid.VALUE + ":leaf";
+    }
+}
+
+public class ClinitChainYieldProcessMain {
+    public static void main(String[] args) {
+        String value = ClinitChainYieldLeaf.VALUE;
+        System.out.print(value);
+    }
+}

--- a/test-sources/ClinitYieldProcessMain.java
+++ b/test-sources/ClinitYieldProcessMain.java
@@ -1,0 +1,18 @@
+class ClinitYieldTarget {
+    static final String VALUE = initValue();
+
+    private static String initValue() {
+        for (int i = 0; i < 1024; i++) {
+            Thread.yield();
+        }
+        return "I";
+    }
+}
+
+public class ClinitYieldProcessMain {
+    public static void main(String[] args) {
+        String value = ClinitYieldTarget.VALUE;
+        System.out.print(value);
+        System.out.print("done");
+    }
+}

--- a/test-sources/bench/BenchDeclaredMethods.java
+++ b/test-sources/bench/BenchDeclaredMethods.java
@@ -1,0 +1,23 @@
+public class BenchDeclaredMethods {
+    static final class Sample {
+        public int add(int x, int y) {
+            return x + y;
+        }
+
+        public String label() {
+            return "sample";
+        }
+
+        private static long widen(int x) {
+            return x;
+        }
+    }
+
+    public static int run() {
+        int sum = 0;
+        for (int i = 0; i < 1000; i++) {
+            sum += Sample.class.getDeclaredMethods().length;
+        }
+        return sum;
+    }
+}

--- a/test-sources/bench/BenchInheritedStaticField.java
+++ b/test-sources/bench/BenchInheritedStaticField.java
@@ -1,0 +1,12 @@
+class BenchInheritedStaticFieldBase {
+    static int counter = 0;
+}
+
+class BenchInheritedStaticField extends BenchInheritedStaticFieldBase {
+    static int run() {
+        for (int i = 0; i < 1000; i++) {
+            BenchInheritedStaticField.counter += i;
+        }
+        return BenchInheritedStaticFieldBase.counter;
+    }
+}


### PR DESCRIPTION
## Summary

Add generic interpreter microbenchmarks and benchmark notes for reflection and class-initialization hot paths.

## Why

These benchmarks provide a repeatable way to measure runtime changes without tying the measurement story to a single workload.

## Scope

- Criterion benchmarks under `jvm-core/benches`
- Java fixtures used by the benchmarks
- `Benchmark.md`
