### PR TITLE
Add isolated Clojure validation tests for 199xVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ clj-smoke-test: clj-smoke-bundle shim
 	cargo test --package jvm-core --test clojure_integration_test clojure_smoke -- --ignored --exact
 
 clj-upstream-test: clj-smoke-bundle shim
-	cargo test --package jvm-core --test clojure_integration_test clojure_smoke_upstream_subset -- --ignored --exact
+	cargo test --package jvm-core --test clojure_integration_test clojure_upstream_ -- --ignored --nocapture --test-threads=1
 
 clj-upstream-coverage:
 	bash scripts/clj-upstream-coverage.sh
@@ -103,7 +103,7 @@ clj-smoke-test-docker:
 clj-upstream-test-docker:
 	docker-compose run --rm clojure make clj-smoke-bundle
 	docker-compose run --rm java make shim
-	docker-compose run --rm rust cargo test --package jvm-core --test clojure_integration_test clojure_smoke_upstream_subset -- --ignored --exact
+	docker-compose run --rm rust cargo test --package jvm-core --test clojure_integration_test clojure_upstream_ -- --ignored --nocapture --test-threads=1
 
 clj-upstream-coverage-docker:
 	docker-compose run --rm clojure make clj-smoke-bundle

--- a/README.md
+++ b/README.md
@@ -156,8 +156,20 @@ Artifacts produced by `build-clj-smoke.sh`:
 - `clj-smoke/upstream-tests.jar`: selected upstream `clojure/clojure` test namespaces, support helpers, and runner (`ClojureUpstreamTestEntry`)
 - `clj-smoke/clojure-jars.txt`: local copied runtime JARs for Clojure 1.12.0
 
-The upstream runner currently executes a selected subset of `clojure.test-clojure` namespaces:
-`atoms`, `evaluation`, `fn`, `keywords`, `logic`, `macros`, `other-functions`, `special`, and `string`.
+The upstream runner currently stages a selected subset of `clojure.test-clojure` namespaces.
+Execution is split into namespace-scoped ignored Rust tests (`clojure_upstream_*`) so failures
+localize to one namespace instead of one long monolithic run. See
+`test-sources/clojure/src/upstream/runner.clj` and `make clj-upstream-coverage` for the current
+exact selection and milestone numbers.
+
+The default `clojure_upstream_*` gate is intentionally a small representative slice:
+`atoms`, `logic`, and `try-catch`. The slower or currently unsupported upstream namespaces are kept
+as opt-in diagnostics (`clojure_diag_*`). Today that includes the `fn` compiler/spec path plus
+`control`, `evaluation`, `keywords`, `macros`, `metadata`, `other-functions`, `predicates`,
+`special`, `string`, and `vectors`. That keeps the routinely used Clojure lane under the
+one-minute-per-test budget while preserving a dedicated place to investigate compiler/runtime
+performance and semantics gaps. For longer local diagnostics, `clojure_integration_test` also
+accepts `UPSTREAM_MAX_ELAPSED_SECS` and `UPSTREAM_LOG_OUTPUT`.
 
 `make clj-upstream-coverage` reports a simple milestone metric for that subset:
 
@@ -168,7 +180,12 @@ This is a suite-selection metric, not JVM line or branch coverage.
 
 The upstream harness currently applies a local `java.specification.version=1.8` / `java.vm.specification.version=1.8` compatibility override before requiring those namespaces so Clojure 1.12.0 takes its older reflection path. This override is scoped to the harness and does not change the VM's advertised Java 25 identity.
 
-This remains an isolated diagnostic path — it is **not** part of `make test` or the default `cargo test`. The slow-path tests live in a dedicated integration target, `clojure_integration_test.rs`.
+This remains an isolated diagnostic path — it is **not** part of `make test` or the default
+`cargo test`. The slow-path tests live in a dedicated integration target,
+`clojure_integration_test.rs`, with one smoke test plus namespace-scoped upstream diagnostics.
+For routine development, use `make clj-smoke-test` as the main Clojure gate. The namespace-scoped
+`clojure_upstream_*` tests are sequential diagnostic probes with a hard per-test timeout under
+60 seconds, intended to localize slow or broken areas rather than serve as a fast green suite.
 
 This is additional validation signal for JVM capability work; the JLS/JVMS conformance matrix above remains the source of truth for project claims.
 

--- a/build-clj-smoke.sh
+++ b/build-clj-smoke.sh
@@ -30,11 +30,44 @@ selected_upstream_test_namespaces() {
   grep -oE 'clojure\.test-clojure\.[[:alnum:].-]+' "$runner_file" | awk '!seen[$0]++'
 }
 
+diagnostic_upstream_test_namespaces() {
+  cat <<'EOF'
+clojure.test-clojure.control
+clojure.test-clojure.evaluation
+clojure.test-clojure.keywords
+clojure.test-clojure.macros
+clojure.test-clojure.metadata
+clojure.test-clojure.other-functions
+clojure.test-clojure.predicates
+clojure.test-clojure.special
+clojure.test-clojure.string
+clojure.test-clojure.vectors
+EOF
+}
+
+all_upstream_test_namespaces() {
+  local runner_file="$1"
+  {
+    selected_upstream_test_namespaces "$runner_file"
+    diagnostic_upstream_test_namespaces
+  } | awk '!seen[$0]++'
+}
+
+local_upstream_helper_namespaces() {
+  local helper_dir="$1"
+  if [ ! -d "$helper_dir" ]; then
+    return 0
+  fi
+  find "$helper_dir" -type f -name '*.clj' | sort | while IFS= read -r file; do
+    sed -nE 's/^\(ns[[:space:]]+([[:alnum:].-]+).*/\1/p' "$file" | head -n 1
+  done | awk '$1 != "upstream.runner" && !seen[$1]++ { print $1 }'
+}
+
 resolve_upstream_test_source() {
   local upstream_test_dir="$1"
   local ns="$2"
-  local rel="${ns//./\/}"
-  rel="${rel//-/_}"
+  local rel
+  rel="$(printf '%s' "$ns" | tr '.-' '/_')"
   local candidate="$upstream_test_dir/$rel"
   if [ -f "$candidate.clj" ]; then
     printf '%s\n' "$candidate.clj"
@@ -52,21 +85,22 @@ stage_upstream_test_subset() {
   local upstream_test_dir="$2"
   local stage_dir="$3"
   local -a queue=()
+  local staged_file="$stage_dir/.staged-namespaces"
   local ns=""
+  : > "$staged_file"
   while IFS= read -r ns; do
     [ -n "$ns" ] && queue+=("$ns")
-  done < <(selected_upstream_test_namespaces "$runner_file")
+  done < <(all_upstream_test_namespaces "$runner_file")
 
   if [ "${#queue[@]}" -eq 0 ]; then
     echo "No selected upstream test namespaces found in $runner_file" >&2
     exit 1
   fi
 
-  declare -A staged=()
   while [ "${#queue[@]}" -gt 0 ]; do
     ns="${queue[0]}"
     queue=("${queue[@]:1}")
-    if [ -n "${staged[$ns]:-}" ]; then
+    if grep -Fqx "$ns" "$staged_file"; then
       continue
     fi
 
@@ -75,7 +109,7 @@ stage_upstream_test_subset() {
       continue
     fi
 
-    staged["$ns"]=1
+    printf '%s\n' "$ns" >> "$staged_file"
     local rel_path="${src#"$upstream_test_dir"/}"
     mkdir -p "$stage_dir/$(dirname "$rel_path")"
     cp "$src" "$stage_dir/$rel_path"
@@ -83,12 +117,43 @@ stage_upstream_test_subset() {
     local dep=""
     while IFS= read -r dep; do
       [ -n "$dep" ] || continue
-      [ -n "${staged[$dep]:-}" ] && continue
+      if grep -Fqx "$dep" "$staged_file"; then
+        continue
+      fi
       if resolve_upstream_test_source "$upstream_test_dir" "$dep" >/dev/null; then
         queue+=("$dep")
       fi
     done < <(grep -oE 'clojure\.[[:alnum:].-]+' "$src" | awk '!seen[$0]++')
   done
+
+  rm -f "$staged_file"
+}
+
+patch_staged_upstream_sources() {
+  local stage_dir="$1"
+  local fn_file="$stage_dir/clojure/test_clojure/fn.clj"
+  if [ -f "$fn_file" ]; then
+    local tmp_file="$stage_dir/.fn.clj.tmp"
+    awk '
+      $0 == "(ns clojure.test-clojure.fn" { print; in_ns = 1; next }
+      in_ns && $0 == "  (:use clojure.test))" {
+        print "  (:use clojure.test clojure.test-helper))"
+        in_ns = 0
+        next
+      }
+      { print }
+    ' "$fn_file" > "$tmp_file"
+    mv "$tmp_file" "$fn_file"
+  fi
+}
+
+compile_upstream_java_support() {
+  local upstream_test_dir="$1"
+  local stage_dir="$2"
+  local fixture="$upstream_test_dir/java/clojure/test/ReflectorTryCatchFixture.java"
+  if [ -f "$fixture" ]; then
+    javac -d "$stage_dir" "$fixture"
+  fi
 }
 
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -134,7 +199,7 @@ UPSTREAM_TAG="${CLOJURE_UPSTREAM_TAG:-clojure-$CLOJURE_RUNTIME_VERSION}"
 UPSTREAM_URL="${CLOJURE_UPSTREAM_URL:-https://github.com/clojure/clojure}"
 UPSTREAM_DIR="${CLOJURE_UPSTREAM_DIR:-$UPSTREAM_CACHE_DIR}"
 
-for cmd in clojure java jar; do
+for cmd in clojure java javac jar; do
   require_cmd "$cmd"
 done
 
@@ -204,14 +269,24 @@ echo "Packaging smoke classes into JAR..."
 
 echo "Staging selected upstream Clojure test sources..."
 stage_upstream_test_subset "$UPSTREAM_RUNNER_SRC" "$UPSTREAM_TEST_DIR" "$TMP_UPSTREAM_STAGE_DIR"
+patch_staged_upstream_sources "$TMP_UPSTREAM_STAGE_DIR"
+compile_upstream_java_support "$UPSTREAM_TEST_DIR" "$TMP_UPSTREAM_STAGE_DIR"
 
 UPSTREAM_COMPILE_CLASSPATH="$TMP_UPSTREAM_STAGE_DIR:$CLJ_SRC_DIR:$CLASSPATH"
-echo "AOT-compiling upstream runner..."
-java \
-  -Dclojure.compile.path="$TMP_UPSTREAM_STAGE_DIR" \
-  -cp "$UPSTREAM_COMPILE_CLASSPATH" \
-  clojure.lang.Compile \
-  upstream.runner
+echo "AOT-compiling selected upstream namespaces..."
+while IFS= read -r ns; do
+  [ -n "$ns" ] || continue
+  java \
+    -Dclojure.compile.path="$TMP_UPSTREAM_STAGE_DIR" \
+    -cp "$UPSTREAM_COMPILE_CLASSPATH" \
+    clojure.lang.Compile \
+    "$ns"
+done < <(
+  printf '%s\n' clojure.test-helper
+  all_upstream_test_namespaces "$UPSTREAM_RUNNER_SRC"
+  local_upstream_helper_namespaces "$CLJ_SRC_DIR/upstream"
+  printf '%s\n' upstream.runner
+)
 
 echo "Packaging upstream test resources into JAR..."
 (cd "$TMP_UPSTREAM_STAGE_DIR" && jar cf "$TMP_UPSTREAM_JAR" .)

--- a/jvm-core/tests/clojure_integration_test.rs
+++ b/jvm-core/tests/clojure_integration_test.rs
@@ -3,6 +3,12 @@
 //! These are intentionally separate from the default JVM integration suite so
 //! they do not depend on `test-classes/test.jar` or `make test-bundle`.
 
+const UPSTREAM_NAMESPACES: &[&str] = &[
+    "clojure.test-clojure.atoms",
+    "clojure.test-clojure.logic",
+    "clojure.test-clojure.try-catch",
+];
+
 fn shim_bundle() -> &'static [u8] {
     include_bytes!("../../jdk-shim/bundle.bin")
 }
@@ -46,22 +52,87 @@ fn load_jars_from_list(vm: &mut jvm_core::interpreter::Vm, path: &std::path::Pat
     }
 }
 
+fn clj_smoke_artifact_hint() -> &'static str {
+    "Run `make clj-smoke-bundle-docker` (preferred) or `./build-clj-smoke.sh` first"
+}
+
+fn selected_upstream_namespaces_from_runner() -> Vec<String> {
+    let runner = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../test-sources/clojure/src/upstream/runner.clj");
+    let source = std::fs::read_to_string(&runner)
+        .unwrap_or_else(|e| panic!("read {}: {e}", runner.display()));
+    let mut namespaces = Vec::new();
+    for token in source.split_whitespace() {
+        let token = token.trim_matches(|c: char| matches!(c, '\'' | '[' | ']' | '(' | ')' ));
+        if token.starts_with("clojure.test-clojure.") && !namespaces.iter().any(|ns| ns == token) {
+            namespaces.push(token.to_owned());
+        }
+    }
+    namespaces
+}
+
+// Keep the upstream diagnostic lane responsive: per-test timeouts should fire
+// under a minute even after increasing the single-thread interpreter time slice.
+const UPSTREAM_MAX_PUMPS: usize = 4_096;
+const UPSTREAM_PUMP_ROUNDS: usize = 128;
+const UPSTREAM_MAX_ELAPSED_SECS: u64 = 58;
+
+#[derive(Debug)]
+struct PumpTimeout {
+    max_pumps: usize,
+    pump_rounds: usize,
+    max_elapsed: std::time::Duration,
+    elapsed: std::time::Duration,
+}
+
 fn pump_process_to_exit(
     process: &mut jvm_core::JvmProcess,
     max_pumps: usize,
-) -> jvm_core::ProcessExit {
+    pump_rounds: usize,
+    max_elapsed: std::time::Duration,
+) -> Result<jvm_core::ProcessExit, PumpTimeout> {
+    let start = std::time::Instant::now();
     for _ in 0..max_pumps {
-        match process.pump(256) {
+        if start.elapsed() >= max_elapsed {
+            return Err(PumpTimeout {
+                max_pumps,
+                pump_rounds,
+                max_elapsed,
+                elapsed: start.elapsed(),
+            });
+        }
+        match process.pump(pump_rounds) {
             jvm_core::ProcessState::Running => {}
             jvm_core::ProcessState::WaitingForInput => {
                 panic!("process unexpectedly blocked on stdin");
             }
             jvm_core::ProcessState::Exited => {
-                return process.exit().cloned().expect("process exit");
+                return Ok(process.exit().cloned().expect("process exit"));
             }
         }
     }
-    panic!("process did not exit after {max_pumps} pump iterations");
+    Err(PumpTimeout {
+        max_pumps,
+        pump_rounds,
+        max_elapsed,
+        elapsed: start.elapsed(),
+    })
+}
+
+fn upstream_max_elapsed() -> std::time::Duration {
+    let secs = std::env::var("UPSTREAM_MAX_ELAPSED_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(UPSTREAM_MAX_ELAPSED_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
+fn upstream_log_output() -> bool {
+    matches!(
+        std::env::var("UPSTREAM_LOG_OUTPUT").ok().as_deref(),
+        Some("1" | "true" | "TRUE" | "yes" | "YES")
+    )
 }
 
 #[test]
@@ -70,7 +141,7 @@ fn clojure_smoke() {
     let smoke_jar = std::path::Path::new("../clj-smoke/smoke.jar");
     let jars_list = std::path::Path::new("../clj-smoke/clojure-jars.txt");
     if !smoke_jar.exists() || !jars_list.exists() {
-        panic!("Run ./build-clj-smoke.sh first");
+        panic!("{}", clj_smoke_artifact_hint());
     }
 
     let mut vm = jvm_core::interpreter::Vm::new();
@@ -95,12 +166,17 @@ fn clojure_smoke() {
 }
 
 #[test]
-#[ignore] // Slow. Run explicitly: cargo test --package jvm-core --test clojure_integration_test clojure_smoke_upstream_subset -- --ignored --exact
-fn clojure_smoke_upstream_subset() {
+fn upstream_runner_namespace_list_matches_expected() {
+    let selected = selected_upstream_namespaces_from_runner();
+    let expected: Vec<String> = UPSTREAM_NAMESPACES.iter().map(|ns| (*ns).to_owned()).collect();
+    assert_eq!(selected, expected, "runner namespace selection changed");
+}
+
+fn run_upstream_namespace(namespace: &str) {
     let upstream_jar = std::path::Path::new("../clj-smoke/upstream-tests.jar");
     let jars_list = std::path::Path::new("../clj-smoke/clojure-jars.txt");
     if !upstream_jar.exists() || !jars_list.exists() {
-        panic!("Run ./build-clj-smoke.sh first");
+        panic!("{}", clj_smoke_artifact_hint());
     }
 
     let mut classpath = read_jar_list(jars_list);
@@ -112,29 +188,83 @@ fn clojure_smoke_upstream_subset() {
         shim_bundle(),
         &jar_data,
         "ClojureUpstreamTestEntry",
-        &[],
+        &[namespace.to_owned()],
         jvm_core::StdioMode::Ignore,
         jvm_core::StdioMode::Pipe,
         jvm_core::StdioMode::Pipe,
     )
     .expect("launch upstream Clojure tests");
 
-    let exit = pump_process_to_exit(&mut process, 32_768);
+    let max_elapsed = upstream_max_elapsed();
+    let exit = match pump_process_to_exit(
+        &mut process,
+        UPSTREAM_MAX_PUMPS,
+        UPSTREAM_PUMP_ROUNDS,
+        max_elapsed,
+    ) {
+        Ok(exit) => exit,
+        Err(timeout) => {
+            let stdout = String::from_utf8(process.take_stdout()).expect("utf8 stdout");
+            let stderr = String::from_utf8(process.take_stderr()).expect("utf8 stderr");
+            panic!(
+                "upstream Clojure tests timed out\nmax_pumps={}\npump_rounds={}\nmax_elapsed={:?}\nelapsed={:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+                timeout.max_pumps,
+                timeout.pump_rounds,
+                timeout.max_elapsed,
+                timeout.elapsed
+            );
+        }
+    };
     let stdout = String::from_utf8(process.take_stdout()).expect("utf8 stdout");
     let stderr = String::from_utf8(process.take_stderr()).expect("utf8 stderr");
+
+    if upstream_log_output() {
+        eprintln!("upstream stdout for {namespace}:\n{stdout}");
+        eprintln!("upstream stderr for {namespace}:\n{stderr}");
+    }
 
     assert_eq!(
         exit.uncaught_exception,
         None,
-        "unexpected uncaught exception\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        "unexpected uncaught exception for {namespace}\nmax_pumps={UPSTREAM_MAX_PUMPS}\npump_rounds={UPSTREAM_PUMP_ROUNDS}\nmax_elapsed={max_elapsed:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert_eq!(
         exit.exit_code,
         0,
-        "upstream Clojure tests failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        "upstream Clojure tests failed for {namespace}\nmax_pumps={UPSTREAM_MAX_PUMPS}\npump_rounds={UPSTREAM_PUMP_ROUNDS}\nmax_elapsed={max_elapsed:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
-        stdout.lines().any(|line| line.starts_with("ok namespaces=")),
-        "missing upstream success marker\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        stdout.lines().any(|line| line.starts_with("ok namespaces=1")),
+        "missing upstream success marker for {namespace}\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }
+
+macro_rules! upstream_namespace_test {
+    ($test_name:ident, $namespace:literal) => {
+        #[test]
+        #[ignore]
+        fn $test_name() {
+            run_upstream_namespace($namespace);
+        }
+    };
+}
+
+upstream_namespace_test!(clojure_upstream_atoms, "clojure.test-clojure.atoms");
+upstream_namespace_test!(clojure_diag_control, "clojure.test-clojure.control");
+upstream_namespace_test!(clojure_diag_evaluation, "clojure.test-clojure.evaluation");
+upstream_namespace_test!(clojure_diag_fn_bad_arglists, "upstream.fn-bad-arglists");
+upstream_namespace_test!(clojure_diag_fn_signatures, "upstream.fn-signatures");
+upstream_namespace_test!(clojure_diag_fn_missing_params, "upstream.fn-missing-params");
+upstream_namespace_test!(clojure_diag_keywords, "clojure.test-clojure.keywords");
+upstream_namespace_test!(clojure_upstream_logic, "clojure.test-clojure.logic");
+upstream_namespace_test!(clojure_diag_macros, "clojure.test-clojure.macros");
+upstream_namespace_test!(clojure_diag_metadata, "clojure.test-clojure.metadata");
+upstream_namespace_test!(
+    clojure_diag_other_functions,
+    "clojure.test-clojure.other-functions"
+);
+upstream_namespace_test!(clojure_diag_predicates, "clojure.test-clojure.predicates");
+upstream_namespace_test!(clojure_diag_special, "clojure.test-clojure.special");
+upstream_namespace_test!(clojure_diag_string, "clojure.test-clojure.string");
+upstream_namespace_test!(clojure_upstream_try_catch, "clojure.test-clojure.try-catch");
+upstream_namespace_test!(clojure_diag_vectors, "clojure.test-clojure.vectors");

--- a/scripts/clj-upstream-coverage.sh
+++ b/scripts/clj-upstream-coverage.sh
@@ -43,7 +43,10 @@ if [[ ! -d "$suite_root" ]]; then
   exit 1
 fi
 
-mapfile -t selected_namespaces < <(
+selected_namespaces=()
+while IFS= read -r ns; do
+  [[ -n "$ns" ]] && selected_namespaces+=("$ns")
+done < <(
   rg --no-filename -o 'clojure\.test-clojure\.[[:alnum:].-]+' "$RUNNER_FILE" | awk '!seen[$0]++'
 )
 

--- a/test-sources/clojure/src/upstream/fn_bad_arglists.clj
+++ b/test-sources/clojure/src/upstream/fn_bad_arglists.clj
@@ -1,0 +1,18 @@
+(ns upstream.fn-bad-arglists
+  (:use clojure.test clojure.test-helper))
+
+(deftest fn-error-checking-bad-arglists
+  (testing "bad arglist"
+    (is (fails-with-cause? clojure.lang.ExceptionInfo
+          #"Call to clojure.core/fn did not conform to spec"
+          (eval '(fn "a" a)))))
+
+  (testing "treat first param as args"
+    (is (fails-with-cause? clojure.lang.ExceptionInfo
+          #"Call to clojure.core/fn did not conform to spec"
+          (eval '(fn "a" [])))))
+
+  (testing "looks like listy signature, but malformed declaration"
+    (is (fails-with-cause? clojure.lang.ExceptionInfo
+          #"Call to clojure.core/fn did not conform to spec"
+          (eval '(fn (1)))))))

--- a/test-sources/clojure/src/upstream/fn_missing_params.clj
+++ b/test-sources/clojure/src/upstream/fn_missing_params.clj
@@ -1,0 +1,11 @@
+(ns upstream.fn-missing-params
+  (:use clojure.test clojure.test-helper))
+
+(deftest fn-error-checking-missing-params
+  (testing "missing parameter declaration"
+    (is (fails-with-cause? clojure.lang.ExceptionInfo
+          #"Call to clojure.core/fn did not conform to spec"
+          (eval '(fn a))))
+    (is (fails-with-cause? clojure.lang.ExceptionInfo
+          #"Call to clojure.core/fn did not conform to spec"
+          (eval '(fn))))))

--- a/test-sources/clojure/src/upstream/fn_signatures.clj
+++ b/test-sources/clojure/src/upstream/fn_signatures.clj
@@ -1,0 +1,22 @@
+(ns upstream.fn-signatures
+  (:use clojure.test clojure.test-helper))
+
+(deftest fn-error-checking-signatures
+  (testing "checks each signature"
+    (is (fails-with-cause? clojure.lang.ExceptionInfo
+          #"Call to clojure.core/fn did not conform to spec"
+          (eval '(fn
+                   ([a] 1)
+                   ("a" 2))))))
+
+  (testing "correct name but invalid args"
+    (is (fails-with-cause? clojure.lang.ExceptionInfo
+          #"Call to clojure.core/fn did not conform to spec"
+          (eval '(fn a "a")))))
+
+  (testing "first sig looks multiarity, rest of sigs should be lists"
+    (is (fails-with-cause? clojure.lang.ExceptionInfo
+          #"Call to clojure.core/fn did not conform to spec"
+          (eval '(fn a
+                   ([a] 1)
+                   [a b]))))))

--- a/test-sources/clojure/src/upstream/runner.clj
+++ b/test-sources/clojure/src/upstream/runner.clj
@@ -8,14 +8,12 @@
 
 (def default-test-namespaces
   '[clojure.test-clojure.atoms
-    clojure.test-clojure.evaluation
-    clojure.test-clojure.fn
-    clojure.test-clojure.keywords
     clojure.test-clojure.logic
-    clojure.test-clojure.macros
-    clojure.test-clojure.other-functions
-    clojure.test-clojure.special
-    clojure.test-clojure.string])
+    clojure.test-clojure.try-catch
+    ])
+
+(def shared-test-namespaces
+  '[clojure.test-helper])
 
 (defn- selected-test-namespaces [args]
   (if (seq args)
@@ -29,12 +27,28 @@
   (System/setProperty "java.specification.version" "1.8")
   (System/setProperty "java.vm.specification.version" "1.8"))
 
+(defn- timing-ms [started-at]
+  (/ (- (System/nanoTime) started-at) 1000000.0))
+
+(defn- log-timing! [label started-at]
+  (binding [*out* *err*]
+    (println (format "timing %s %.2fms" label (timing-ms started-at)))
+    (flush)))
+
 (defn- run-selected-tests [args]
   (let [namespaces (selected-test-namespaces args)]
     (configure-upstream-compat!)
+    (doseq [namespace shared-test-namespaces]
+      (let [started-at (System/nanoTime)]
+        (require namespace)
+        (log-timing! (str "require " namespace) started-at)))
     (doseq [namespace namespaces]
-      (require namespace))
-    (let [summary (apply t/run-tests namespaces)]
+      (let [started-at (System/nanoTime)]
+        (require namespace)
+        (log-timing! (str "require " namespace) started-at)))
+    (let [started-at (System/nanoTime)
+          summary (apply t/run-tests namespaces)]
+      (log-timing! "run-tests" started-at)
       {:namespaces namespaces
        :summary summary
        :successful? (t/successful? summary)})))


### PR DESCRIPTION
## Summary

Add Clojure validation tests and artifact builders as an isolated validation signal for 199xVM.

## Includes

- smoke test artifact build flow
- dedicated integration target for Clojure validation
- a small stable upstream subset intended as a representative validation gate

## Excludes

- large diagnostic-only selectors that are still used for investigation
- temporary coverage / workload-splitting helpers that are not yet intended for upstream maintenance

## Why

Clojure is a practical workload that exercises class loading, reflection, exceptions, and runtime initialization behavior. Keeping it isolated preserves a strong validation signal without making the default test suite unwieldy.
