### PR TITLE
runtime: make strings and regex UTF-16-aware

### DIFF
--- a/jvm-core/src/bin/run_bundle.rs
+++ b/jvm-core/src/bin/run_bundle.rs
@@ -43,12 +43,14 @@ fn main() {
                 jvm_core::heap::JValue::Ref(Some(r)) => {
                     let is_str = matches!(r.borrow().native, jvm_core::heap::NativePayload::JavaString(_));
                     if is_str {
-                        r.borrow().as_java_string().unwrap_or_default().to_owned()
+                        r.borrow().java_string_to_string_lossy().unwrap_or_default()
                     } else {
                         let cn = r.borrow().class_name.clone();
                         match vm.invoke_virtual(r.clone(), &cn, "toString", "()Ljava/lang/String;", vec![]) {
                             Ok(jvm_core::heap::JValue::Ref(Some(s))) => {
-                                s.borrow().as_java_string().unwrap_or_default().to_owned()
+                                s.borrow()
+                                    .java_string_to_string_lossy()
+                                    .unwrap_or_default()
                             }
                             _ => format!("{}@obj", cn),
                         }

--- a/jvm-core/src/class_file.rs
+++ b/jvm-core/src/class_file.rs
@@ -8,6 +8,69 @@ use std::rc::Rc;
 /// Magic number that starts every `.class` file.
 const MAGIC: u32 = 0xCAFE_BABE;
 
+fn utf16_units_to_string(utf16: &[u16]) -> Result<String, String> {
+    let mut out = String::new();
+    for decoded in std::char::decode_utf16(utf16.iter().copied()) {
+        match decoded {
+            Ok(ch) => out.push(ch),
+            Err(err) => {
+                return Err(format!(
+                    "Modified UTF-8 contains unpaired surrogate: 0x{:04X}",
+                    err.unpaired_surrogate()
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn decode_modified_utf8(bytes: &[u8]) -> Result<String, String> {
+    let mut utf16 = Vec::with_capacity(bytes.len());
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b0 = bytes[i];
+        if b0 & 0x80 == 0 {
+            if b0 == 0 {
+                return Err("Modified UTF-8 contains raw NUL byte".to_owned());
+            }
+            utf16.push(u16::from(b0));
+            i += 1;
+            continue;
+        }
+        if b0 & 0xE0 == 0xC0 {
+            if i + 1 >= bytes.len() {
+                return Err("Truncated Modified UTF-8 two-byte sequence".to_owned());
+            }
+            let b1 = bytes[i + 1];
+            if b1 & 0xC0 != 0x80 {
+                return Err("Invalid Modified UTF-8 continuation byte".to_owned());
+            }
+            let value = (u16::from(b0 & 0x1F) << 6) | u16::from(b1 & 0x3F);
+            utf16.push(value);
+            i += 2;
+            continue;
+        }
+        if b0 & 0xF0 == 0xE0 {
+            if i + 2 >= bytes.len() {
+                return Err("Truncated Modified UTF-8 three-byte sequence".to_owned());
+            }
+            let b1 = bytes[i + 1];
+            let b2 = bytes[i + 2];
+            if (b1 & 0xC0 != 0x80) || (b2 & 0xC0 != 0x80) {
+                return Err("Invalid Modified UTF-8 continuation byte".to_owned());
+            }
+            let value = (u16::from(b0 & 0x0F) << 12)
+                | (u16::from(b1 & 0x3F) << 6)
+                | u16::from(b2 & 0x3F);
+            utf16.push(value);
+            i += 3;
+            continue;
+        }
+        return Err(format!("Unsupported Modified UTF-8 leading byte: 0x{b0:02X}"));
+    }
+    utf16_units_to_string(&utf16)
+}
+
 /// A parsed Java class file.
 #[derive(Debug)]
 pub struct ClassFile {
@@ -373,7 +436,7 @@ pub fn parse_class_name(data: &[u8]) -> Option<String> {
 
     // Decode only the single target Utf8 entry.
     let (start, len) = utf8_spans[name_index]?;
-    Some(String::from_utf8_lossy(&data[start..start + len]).into_owned())
+    decode_modified_utf8(&data[start..start + len]).ok()
 }
 
 /// Parse a `.class` file from raw bytes.
@@ -461,7 +524,7 @@ fn parse_constant_pool(r: &mut Reader, count: u16) -> Result<ConstantPool, Strin
                 let length = r.u16() as usize;
                 let bytes = r.bytes(length);
                 // Modified UTF-8 — for ASCII-heavy Java class names this is fine.
-                let s = String::from_utf8_lossy(&bytes).into_owned();
+                let s = decode_modified_utf8(&bytes)?;
                 ConstantPoolEntry::Utf8(s)
             }
             3 => ConstantPoolEntry::Integer(r.i32()),
@@ -767,5 +830,18 @@ mod tests {
         let mut b: Vec<u8> = vec![0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x3D];
         b.push(0xEA); b.push(0x60); // cp_count = 60000
         assert_eq!(parse_class_name(&b), None);
+    }
+
+    #[test]
+    fn test_decode_modified_utf8_supplementary_scalar() {
+        let bytes = [0xED, 0xA0, 0xBD, 0xED, 0xB8, 0x80];
+        assert_eq!(decode_modified_utf8(&bytes).as_deref(), Ok("😀"));
+    }
+
+    #[test]
+    fn test_decode_modified_utf8_rejects_unpaired_surrogate() {
+        let bytes = [0xED, 0xA0, 0xBD];
+        let err = decode_modified_utf8(&bytes).expect_err("must reject lone surrogate");
+        assert!(err.contains("unpaired surrogate"), "unexpected error: {err}");
     }
 }

--- a/jvm-core/src/heap.rs
+++ b/jvm-core/src/heap.rs
@@ -6,7 +6,110 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::rc::Rc;
+
+/// Native backing storage for `java.lang.String`.
+///
+/// The canonical payload is UTF-16 code units so VM-visible string indices can
+/// follow Java semantics even when the content includes surrogate pairs or lone
+/// surrogates created by slicing.
+#[derive(Clone)]
+pub struct JavaStringValue {
+    utf16: Vec<u16>,
+    utf8: Option<String>,
+}
+
+impl JavaStringValue {
+    pub fn new(s: impl Into<String>) -> Self {
+        let utf8 = s.into();
+        Self {
+            utf16: utf8.encode_utf16().collect(),
+            utf8: Some(utf8),
+        }
+    }
+
+    pub fn from_utf16(utf16: Vec<u16>) -> Self {
+        let utf8 = String::from_utf16(&utf16).ok();
+        Self { utf16, utf8 }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        self.utf8.as_deref()
+    }
+
+    pub fn to_string_lossy(&self) -> String {
+        self.utf8
+            .clone()
+            .unwrap_or_else(|| String::from_utf16_lossy(&self.utf16))
+    }
+
+    pub fn utf16(&self) -> &[u16] {
+        &self.utf16
+    }
+
+    pub fn len_utf16(&self) -> usize {
+        self.utf16.len()
+    }
+
+    pub fn code_unit_at(&self, index: usize) -> Option<u16> {
+        self.utf16.get(index).copied()
+    }
+
+    pub fn slice_utf16(&self, start: usize, end: usize) -> Vec<u16> {
+        let len = self.utf16.len();
+        let start = start.min(len);
+        let end = end.min(len).max(start);
+        self.utf16[start..end].to_vec()
+    }
+
+    pub fn concat(&self, other: &Self) -> Self {
+        let mut utf16 = Vec::with_capacity(self.utf16.len() + other.utf16.len());
+        utf16.extend_from_slice(&self.utf16);
+        utf16.extend_from_slice(&other.utf16);
+        let utf8 = match (&self.utf8, &other.utf8) {
+            (Some(left), Some(right)) => {
+                let mut s = String::with_capacity(left.len() + right.len());
+                s.push_str(left);
+                s.push_str(right);
+                Some(s)
+            }
+            _ => None,
+        };
+        Self { utf16, utf8 }
+    }
+
+    pub fn hash_code(&self) -> i32 {
+        self.utf16.iter().fold(0i32, |hash, code_unit| {
+            hash.wrapping_mul(31).wrapping_add(i32::from(*code_unit))
+        })
+    }
+}
+
+impl PartialEq for JavaStringValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.utf16 == other.utf16
+    }
+}
+
+impl Eq for JavaStringValue {}
+
+impl Hash for JavaStringValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.utf16.hash(state);
+    }
+}
+
+impl std::fmt::Debug for JavaStringValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "JavaStringValue({:?}, utf16_len={})",
+            self.to_string_lossy(),
+            self.utf16.len()
+        )
+    }
+}
 
 /// A Java value that can appear on the operand stack or in a local variable slot.
 #[derive(Debug, Clone)]
@@ -91,7 +194,7 @@ pub struct JObject {
 pub enum NativePayload {
     None,
     /// `java.lang.String` content.
-    JavaString(String),
+    JavaString(JavaStringValue),
     /// Object array (`[Ljava/lang/Object;` etc.).
     Array(Vec<JValue>),
     /// Byte/char/int primitive arrays.
@@ -181,7 +284,21 @@ impl JObject {
         Rc::new(RefCell::new(JObject {
             class_name: "java/lang/String".to_owned(),
             fields: HashMap::new(),
-            native: NativePayload::JavaString(s.into()),
+            native: NativePayload::JavaString(JavaStringValue::new(s)),
+        }))
+    }
+
+    /// Create a `java.lang.String` backed by raw UTF-16 code units.
+    pub fn new_string_utf16(utf16: Vec<u16>) -> JRef {
+        Self::new_string_value(JavaStringValue::from_utf16(utf16))
+    }
+
+    /// Create a `java.lang.String` backed by an existing UTF-16 value.
+    pub fn new_string_value(value: JavaStringValue) -> JRef {
+        Rc::new(RefCell::new(JObject {
+            class_name: "java/lang/String".to_owned(),
+            fields: HashMap::new(),
+            native: NativePayload::JavaString(value),
         }))
     }
 
@@ -224,8 +341,23 @@ impl JObject {
     /// Get the string content if this is a `java.lang.String`.
     pub fn as_java_string(&self) -> Option<&str> {
         match &self.native {
+            NativePayload::JavaString(s) => s.as_str(),
+            _ => None,
+        }
+    }
+
+    pub fn as_java_string_value(&self) -> Option<&JavaStringValue> {
+        match &self.native {
             NativePayload::JavaString(s) => Some(s),
             _ => None,
         }
+    }
+
+    pub fn as_java_string_utf16(&self) -> Option<&[u16]> {
+        self.as_java_string_value().map(JavaStringValue::utf16)
+    }
+
+    pub fn java_string_to_string_lossy(&self) -> Option<String> {
+        self.as_java_string_value().map(JavaStringValue::to_string_lossy)
     }
 }

--- a/jvm-core/src/interpreter/dispatch.rs
+++ b/jvm-core/src/interpreter/dispatch.rs
@@ -2,13 +2,20 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::class_file::{BootstrapMethod, ConstantPoolEntry};
-use crate::heap::{JObject, JRef, JValue, NativePayload};
+use crate::heap::{JavaStringValue, JObject, JRef, JValue, NativePayload};
 
 use super::Vm;
 use super::descriptors::*;
 use super::frame::*;
 use super::trampoline::FrameInfo;
 
+fn push_utf16_str(out: &mut Vec<u16>, s: &str) {
+    out.extend(s.encode_utf16());
+}
+
+fn push_java_string_value(out: &mut Vec<u16>, value: &JavaStringValue) {
+    out.extend_from_slice(value.utf16());
+}
 
 impl Vm {
     // -----------------------------------------------------------------------
@@ -462,7 +469,7 @@ impl Vm {
                 };
 
                 let arg_types = arg_type_chars(&descriptor);
-                let mut result = String::new();
+                let mut result = Vec::new();
                 let mut arg_idx = 0;
                 let mut const_idx = 0usize;
                 for ch in recipe.chars() {
@@ -471,31 +478,32 @@ impl Vm {
                         if let Some(a) = args.get(arg_idx) {
                             let is_bool = arg_types.get(arg_idx) == Some(&'Z');
                             match a {
-                                JValue::Int(v) if is_bool => result.push_str(if *v != 0 { "true" } else { "false" }),
+                                JValue::Int(v) if is_bool => push_utf16_str(&mut result, if *v != 0 { "true" } else { "false" }),
                                 JValue::Int(v) if arg_types.get(arg_idx) == Some(&'C') => {
-                                    // char argument — convert int to character
-                                    result.push(char::from_u32(*v as u32).unwrap_or('\u{FFFD}'));
+                                    result.push(*v as u16);
                                 }
-                                JValue::Int(v) => result.push_str(&v.to_string()),
-                                JValue::Long(v) => result.push_str(&v.to_string()),
-                                JValue::Float(v) => result.push_str(&v.to_string()),
-                                JValue::Double(v) => result.push_str(&v.to_string()),
+                                JValue::Int(v) => push_utf16_str(&mut result, &v.to_string()),
+                                JValue::Long(v) => push_utf16_str(&mut result, &v.to_string()),
+                                JValue::Float(v) => push_utf16_str(&mut result, &v.to_string()),
+                                JValue::Double(v) => push_utf16_str(&mut result, &v.to_string()),
                                 JValue::Ref(Some(r)) => {
-                                    if let Some(s) = r.borrow().as_java_string() {
-                                        result.push_str(s);
+                                    if let Some(s) = r.borrow().as_java_string_value().cloned() {
+                                        push_java_string_value(&mut result, &s);
                                     } else {
                                         // Call toString() on the object.
                                         match self.invoke_virtual(r.clone(), &r.borrow().class_name.clone(), "toString", "()Ljava/lang/String;", vec![]) {
                                             Ok(JValue::Ref(Some(sr))) => {
-                                                if let Some(s) = sr.borrow().as_java_string() {
-                                                    result.push_str(s);
+                                                if let Some(s) = sr.borrow().as_java_string_value().cloned() {
+                                                    push_java_string_value(&mut result, &s);
+                                                } else if let Some(s) = sr.borrow().java_string_to_string_lossy() {
+                                                    push_utf16_str(&mut result, &s);
                                                 }
                                             }
-                                            _ => result.push_str(&r.borrow().class_name),
+                                            _ => push_utf16_str(&mut result, &r.borrow().class_name),
                                         }
                                     }
                                 }
-                                JValue::Ref(None) => result.push_str("null"),
+                                JValue::Ref(None) => push_utf16_str(&mut result, "null"),
                                 _ => {}
                             }
                         }
@@ -508,42 +516,42 @@ impl Vm {
                             Some(&cp_idx) => match cp.get(cp_idx as usize) {
                                 Some(ConstantPoolEntry::String { string_index }) => {
                                     if let Some(ConstantPoolEntry::Utf8(s)) = cp.get(*string_index as usize) {
-                                        result.push_str(s);
+                                        push_utf16_str(&mut result, s);
                                     }
                                 }
-                                Some(ConstantPoolEntry::Integer(v)) => result.push_str(&v.to_string()),
-                                Some(ConstantPoolEntry::Long(v)) => result.push_str(&v.to_string()),
+                                Some(ConstantPoolEntry::Integer(v)) => push_utf16_str(&mut result, &v.to_string()),
+                                Some(ConstantPoolEntry::Long(v)) => push_utf16_str(&mut result, &v.to_string()),
                                 Some(ConstantPoolEntry::Float(v)) => {
                                     // Use Java-compatible formatting: finite values via Rust,
                                     // but infinities/NaN must match Java's Float.toString output.
                                     if v.is_infinite() {
-                                        result.push_str(if *v > 0.0 { "Infinity" } else { "-Infinity" });
+                                        push_utf16_str(&mut result, if *v > 0.0 { "Infinity" } else { "-Infinity" });
                                     } else if v.is_nan() {
-                                        result.push_str("NaN");
+                                        push_utf16_str(&mut result, "NaN");
                                     } else {
-                                        result.push_str(&v.to_string());
+                                        push_utf16_str(&mut result, &v.to_string());
                                     }
                                 }
                                 Some(ConstantPoolEntry::Double(v)) => {
                                     if v.is_infinite() {
-                                        result.push_str(if *v > 0.0 { "Infinity" } else { "-Infinity" });
+                                        push_utf16_str(&mut result, if *v > 0.0 { "Infinity" } else { "-Infinity" });
                                     } else if v.is_nan() {
-                                        result.push_str("NaN");
+                                        push_utf16_str(&mut result, "NaN");
                                     } else {
-                                        result.push_str(&v.to_string());
+                                        push_utf16_str(&mut result, &v.to_string());
                                     }
                                 }
-                                Some(ConstantPoolEntry::Utf8(s)) => result.push_str(s),
+                                Some(ConstantPoolEntry::Utf8(s)) => push_utf16_str(&mut result, s),
                                 Some(ConstantPoolEntry::Class { name_index }) => {
                                     if let Some(ConstantPoolEntry::Utf8(s)) = cp.get(*name_index as usize) {
-                                        result.push_str(s);
+                                        push_utf16_str(&mut result, s);
                                     }
                                 }
                                 Some(ConstantPoolEntry::MethodHandle { .. })
                                 | Some(ConstantPoolEntry::MethodType { .. }) => {
                                     // Stable debug representation for unsupported handle/type constants.
                                     if let Some(entry) = cp.get(cp_idx as usize) {
-                                        result.push_str(&format!("{entry:?}"));
+                                        push_utf16_str(&mut result, &format!("{entry:?}"));
                                     }
                                 }
                                 Some(other) => {
@@ -561,10 +569,12 @@ impl Vm {
                         }
                         const_idx += 1;
                     } else {
-                        result.push(ch);
+                        let mut buf = [0u16; 2];
+                        let encoded = ch.encode_utf16(&mut buf);
+                        result.extend_from_slice(encoded);
                     }
                 }
-                Ok(JValue::Ref(Some(JObject::new_string(result))))
+                Ok(JValue::Ref(Some(JObject::new_string_utf16(result))))
             }
 
             "java/lang/runtime/SwitchBootstraps" | "java/lang/invoke/SwitchBootstraps" => {

--- a/jvm-core/src/interpreter/invoke.rs
+++ b/jvm-core/src/interpreter/invoke.rs
@@ -1,5 +1,5 @@
 
-use crate::heap::{JObject, JRef, JValue, NativePayload};
+use crate::heap::{JavaStringValue, JObject, JRef, JValue, NativePayload};
 
 use super::Vm;
 use super::descriptors::*;
@@ -136,14 +136,21 @@ impl Vm {
                         // args[0] = the record instance
                         let recv = args.into_iter().next().unwrap_or(JValue::Ref(None));
                         if let JValue::Ref(Some(recv_ref)) = recv {
-                            let mut parts = Vec::new();
+                            let mut result = Vec::new();
+                            result.extend(class_simple_name.encode_utf16());
+                            result.push('[' as u16);
                             for ((getter_class, getter_method, getter_desc), comp_name) in getters.iter().zip(component_names.iter()) {
                                 let val = self.invoke_virtual(recv_ref.clone(), getter_class, getter_method, getter_desc, vec![])?;
-                                let s = self.jvalue_to_string(val)?;
-                                parts.push(format!("{comp_name}={s}"));
+                                let value = self.jvalue_to_java_string_value(val)?;
+                                if result.last().copied() != Some('[' as u16) {
+                                    result.extend(", ".encode_utf16());
+                                }
+                                result.extend(comp_name.encode_utf16());
+                                result.push('=' as u16);
+                                result.extend_from_slice(value.utf16());
                             }
-                            let result = format!("{}[{}]", class_simple_name, parts.join(", "));
-                            return Ok(JValue::Ref(Some(JObject::new_string(result))));
+                            result.push(']' as u16);
+                            return Ok(JValue::Ref(Some(JObject::new_string_utf16(result))));
                         }
                         return Ok(JValue::Ref(Some(JObject::new_string(format!("{}[]", class_simple_name)))));
                     }
@@ -293,26 +300,37 @@ impl Vm {
     // Record method helpers
     // ------------------------------------------------------------------
 
-    /// Convert a JValue to its Java string representation, calling toString() for objects.
-    pub(in crate::interpreter) fn jvalue_to_string(&mut self, val: JValue) -> Result<String, String> {
+    /// Convert a JValue to its Java string representation while preserving UTF-16 content.
+    pub(in crate::interpreter) fn jvalue_to_java_string_value(
+        &mut self,
+        val: JValue,
+    ) -> Result<JavaStringValue, String> {
         match val {
-            JValue::Void => Ok("null".to_owned()),
-            JValue::Int(v) => Ok(v.to_string()),
-            JValue::Long(v) => Ok(v.to_string()),
-            JValue::Float(v) => Ok(v.to_string()),
-            JValue::Double(v) => Ok(v.to_string()),
-            JValue::Ref(None) => Ok("null".to_owned()),
+            JValue::Void => Ok(JavaStringValue::new("null")),
+            JValue::Int(v) => Ok(JavaStringValue::new(v.to_string())),
+            JValue::Long(v) => Ok(JavaStringValue::new(v.to_string())),
+            JValue::Float(v) => Ok(JavaStringValue::new(v.to_string())),
+            JValue::Double(v) => Ok(JavaStringValue::new(v.to_string())),
+            JValue::Ref(None) => Ok(JavaStringValue::new("null")),
             JValue::Ref(Some(r)) => {
-                if let Some(s) = r.borrow().as_java_string() {
-                    return Ok(s.to_owned());
+                if let Some(s) = r.borrow().as_java_string_value().cloned() {
+                    return Ok(s);
                 }
                 let class_name = r.borrow().class_name.clone();
                 match self.invoke_virtual(r, &class_name, "toString", "()Ljava/lang/String;", vec![])? {
-                    JValue::Ref(Some(sr)) => Ok(sr.borrow().as_java_string().unwrap_or("").to_owned()),
-                    _ => Ok("null".to_owned()),
+                    JValue::Ref(Some(sr)) => {
+                        let value = {
+                            let sb = sr.borrow();
+                            sb.as_java_string_value()
+                                .cloned()
+                                .or_else(|| sb.java_string_to_string_lossy().map(JavaStringValue::new))
+                        };
+                        Ok(value.unwrap_or_else(|| JavaStringValue::new("null")))
+                    }
+                    _ => Ok(JavaStringValue::new("null")),
                 }
             }
-            JValue::ReturnAddress(_) => Ok("?".to_owned()),
+            JValue::ReturnAddress(_) => Ok(JavaStringValue::new("?")),
         }
     }
 
@@ -326,8 +344,8 @@ impl Vm {
             (JValue::Ref(None), JValue::Ref(None)) => Ok(true),
             (JValue::Ref(Some(ra)), JValue::Ref(Some(rb))) => {
                 // Try string equality first.
-                let sa = ra.borrow().as_java_string().map(|s| s.to_owned());
-                let sb = rb.borrow().as_java_string().map(|s| s.to_owned());
+                let sa = ra.borrow().as_java_string_value().cloned();
+                let sb = rb.borrow().as_java_string_value().cloned();
                 if let (Some(sa), Some(sb)) = (sa, sb) {
                     return Ok(sa == sb);
                 }
@@ -348,12 +366,8 @@ impl Vm {
             JValue::Double(v) => Ok((v.to_bits() ^ (v.to_bits() >> 32)) as i32),
             JValue::Ref(None) => Ok(0),
             JValue::Ref(Some(r)) => {
-                if let Some(s) = r.borrow().as_java_string() {
-                    let mut h: i32 = 0;
-                    for b in s.bytes() {
-                        h = h.wrapping_mul(31).wrapping_add(b as i32);
-                    }
-                    return Ok(h);
+                if let Some(s) = r.borrow().as_java_string_value() {
+                    return Ok(s.hash_code());
                 }
                 let class_name = r.borrow().class_name.clone();
                 match self.invoke_virtual(r.clone(), &class_name, "hashCode", "()I", vec![])? {
@@ -416,5 +430,47 @@ impl Vm {
                 ))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jvalue_hash_uses_utf16_code_units_for_strings() {
+        let mut vm = Vm::new();
+        let emoji = JValue::Ref(Some(JObject::new_string("😀")));
+        let high_surrogate = JValue::Ref(Some(JObject::new_string_utf16(vec![0xD83D])));
+
+        assert_eq!(vm.jvalue_hash(&emoji).expect("emoji hash"), 1_772_899);
+        assert_eq!(
+            vm.jvalue_hash(&high_surrogate).expect("surrogate hash"),
+            55_357,
+        );
+    }
+
+    #[test]
+    fn jvalue_equals_compares_utf16_backed_strings() {
+        let mut vm = Vm::new();
+        let left = JValue::Ref(Some(JObject::new_string_utf16(vec![0xD83D])));
+        let same = JValue::Ref(Some(JObject::new_string_utf16(vec![0xD83D])));
+        let different = JValue::Ref(Some(JObject::new_string_utf16(vec![0xDE00])));
+
+        assert!(vm.jvalue_equals(&left, &same).expect("same surrogate"));
+        assert!(!vm
+            .jvalue_equals(&left, &different)
+            .expect("different surrogate"));
+    }
+
+    #[test]
+    fn jvalue_to_java_string_value_preserves_surrogate_halves() {
+        let mut vm = Vm::new();
+        let high_surrogate = JValue::Ref(Some(JObject::new_string_utf16(vec![0xD83D])));
+
+        let rendered = vm
+            .jvalue_to_java_string_value(high_surrogate)
+            .expect("string value");
+        assert_eq!(rendered.utf16(), &[0xD83D]);
     }
 }

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -17,7 +17,7 @@ use wasm_bindgen::prelude::*;
 use crate::class_file::{
     self, Attribute, BootstrapMethod, ClassFile, ConstantPoolEntry, ExceptionTableEntry,
 };
-use crate::heap::{JObject, JRef, JValue};
+use crate::heap::{JavaStringValue, JObject, JRef, JValue};
 
 type OwnedJarArchive = zip::ZipArchive<std::io::Cursor<Vec<u8>>>;
 
@@ -148,6 +148,7 @@ mod tests {
         }
         assert!(vm.resolve_class("missing/Type").is_none(), "missing class must remain unresolved");
     }
+
 }
 
 /// A class entry in the VM's class registry.
@@ -438,8 +439,8 @@ pub struct Vm {
     /// Entries start as `LazyClass::PendingBytes`/`PendingJarEntry` and are promoted to
     /// `LazyClass::Ready` (parsed `ClassFile`) on first access.
     pub(in crate::interpreter) classes: HashMap<String, LazyClass>,
-    /// Interned strings cache (not strictly required but saves allocations).
-    pub(in crate::interpreter) string_pool: HashMap<String, JRef>,
+    /// Interned strings cache keyed by UTF-16 content.
+    pub(in crate::interpreter) string_pool: HashMap<JavaStringValue, JRef>,
     /// Static field storage keyed by class name → field name.
     /// Avoids allocating a `"ClassName.fieldName"` string on every getstatic/putstatic.
     pub(in crate::interpreter) static_fields: HashMap<String, HashMap<String, JValue>>,
@@ -1119,15 +1120,35 @@ impl Vm {
             .any(|t| matches!(t.state, ThreadState::WaitingOnCondition(id) if id == stdin_id))
     }
 
-    /// Intern a Java string (returns same `JRef` for equal content).
+    /// Intern a Java string (returns same `JRef` for equal UTF-16 content).
     pub fn intern_string(&mut self, s: impl Into<String>) -> JRef {
+        self.intern_string_value(JavaStringValue::new(s))
+    }
+
+    pub fn intern_string_utf16(&mut self, utf16: Vec<u16>) -> JRef {
+        self.intern_string_value(JavaStringValue::from_utf16(utf16))
+    }
+
+    pub fn intern_string_value(&mut self, value: JavaStringValue) -> JRef {
         use std::collections::hash_map::Entry;
-        let s = s.into();
-        match self.string_pool.entry(s) {
+        match self.string_pool.entry(value.clone()) {
             Entry::Occupied(e) => Rc::clone(e.get()),
             Entry::Vacant(e) => {
-                let jobj = JObject::new_string(e.key().clone());
+                let jobj = JObject::new_string_value(value);
                 Rc::clone(e.insert(jobj))
+            }
+        }
+    }
+
+    pub fn intern_existing_string_ref(&mut self, string_ref: &JRef) -> Option<JRef> {
+        use std::collections::hash_map::Entry;
+
+        let value = string_ref.borrow().as_java_string_value().cloned()?;
+        match self.string_pool.entry(value) {
+            Entry::Occupied(e) => Some(Rc::clone(e.get())),
+            Entry::Vacant(e) => {
+                e.insert(Rc::clone(string_ref));
+                Some(Rc::clone(string_ref))
             }
         }
     }
@@ -1144,10 +1165,10 @@ impl Vm {
                 let b = r.borrow();
                 let mut s = format!("Exception: {}", b.class_name);
                 if let Some(JValue::Ref(Some(msg_ref))) = b.fields.get("detailMessage") {
-                    if let Some(msg) = msg_ref.borrow().as_java_string() {
+                    if let Some(msg) = msg_ref.borrow().java_string_to_string_lossy() {
                         if !msg.is_empty() {
                             s.push_str(": ");
-                            s.push_str(msg);
+                            s.push_str(&msg);
                         }
                     }
                 }

--- a/jvm-core/src/interpreter/native_static.rs
+++ b/jvm-core/src/interpreter/native_static.rs
@@ -1,5 +1,6 @@
+use std::borrow::Cow;
 use std::rc::Rc;
-use crate::heap::{JObject, JValue, NativePayload};
+use crate::heap::{JavaStringValue, JObject, JValue, NativePayload};
 
 /// Returns true if `regex` ends with an unescaped `$` anchor.
 /// A `$` is escaped when preceded by an odd number of backslashes.
@@ -42,6 +43,49 @@ pub(super) fn regex_full_match(regex: &str, input: &str) -> bool {
         })
 }
 
+/// Encode a Java UTF-16 string into a Rust `String` suitable for the regex crate.
+///
+/// Valid surrogate pairs are materialized as their scalar value so regex
+/// operators like `.` still see a single Unicode character. Lone surrogates are
+/// mapped into the BMP private-use area so they survive round-trips without
+/// collapsing to an empty string or U+FFFD.
+pub(super) fn regex_encode_java_string(value: &JavaStringValue) -> Cow<'_, str> {
+    if let Some(utf8) = value.as_str() {
+        return Cow::Borrowed(utf8);
+    }
+    let mut out = String::new();
+    for decoded in std::char::decode_utf16(value.utf16().iter().copied()) {
+        match decoded {
+            Ok(ch) => out.push(ch),
+            Err(err) => {
+                let encoded = 0xE000 + (u32::from(err.unpaired_surrogate()) - 0xD800);
+                out.push(char::from_u32(encoded).expect("valid encoded code point"));
+            }
+        }
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::regex_encode_java_string;
+    use crate::heap::JavaStringValue;
+
+    #[test]
+    fn regex_encode_java_string_keeps_supplementary_scalars() {
+        let value = JavaStringValue::from_utf16(vec![0xD83D, 0xDE00]);
+        let encoded = regex_encode_java_string(&value);
+        assert_eq!(encoded.as_ref(), "😀");
+    }
+
+    #[test]
+    fn regex_encode_java_string_maps_unpaired_surrogates_to_private_use() {
+        let value = JavaStringValue::from_utf16(vec![0xD83D]);
+        let encoded = regex_encode_java_string(&value);
+        assert_eq!(encoded.chars().collect::<Vec<_>>(), vec!['\u{E03D}']);
+    }
+}
+
 impl super::Vm {
     pub(super) fn native_static(
         &mut self,
@@ -52,25 +96,29 @@ impl super::Vm {
     ) -> Option<JValue> {
         match (_class_name, _method_name, _descriptor) {
             ("java/util/regex/Pattern", "compile", "(Ljava/lang/String;)Ljava/util/regex/Pattern;") => {
-                let regex = _args
+                let regex_ref = _args
                     .first()
                     .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                    .unwrap_or_default();
+                    .cloned()
+                    .unwrap_or_else(|| self.intern_string(""));
                 let p = JObject::new("java/util/regex/Pattern");
-                p.borrow_mut().fields.insert("__regex".to_owned(), JValue::Ref(Some(self.intern_string(regex))));
+                p.borrow_mut()
+                    .fields
+                    .insert("__regex".to_owned(), JValue::Ref(Some(regex_ref)));
                 p.borrow_mut().fields.insert("__flags".to_owned(), JValue::Int(0));
                 Some(JValue::Ref(Some(p)))
             }
             ("java/util/regex/Pattern", "compile", "(Ljava/lang/String;I)Ljava/util/regex/Pattern;") => {
-                let regex = _args
+                let regex_ref = _args
                     .first()
                     .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                    .unwrap_or_default();
+                    .cloned()
+                    .unwrap_or_else(|| self.intern_string(""));
                 let flags = _args.get(1).map(|v| v.as_int()).unwrap_or(0);
                 let p = JObject::new("java/util/regex/Pattern");
-                p.borrow_mut().fields.insert("__regex".to_owned(), JValue::Ref(Some(self.intern_string(regex))));
+                p.borrow_mut()
+                    .fields
+                    .insert("__regex".to_owned(), JValue::Ref(Some(regex_ref)));
                 p.borrow_mut().fields.insert("__flags".to_owned(), JValue::Int(flags));
                 Some(JValue::Ref(Some(p)))
             }
@@ -78,12 +126,14 @@ impl super::Vm {
                 let regex = _args
                     .first()
                     .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .and_then(|r| r.borrow().as_java_string_value().cloned())
+                    .map(|s| regex_encode_java_string(&s).into_owned())
                     .unwrap_or_default();
                 let input = _args
                     .get(1)
                     .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .and_then(|r| r.borrow().as_java_string_value().cloned())
+                    .map(|s| regex_encode_java_string(&s).into_owned())
                     .unwrap_or_default();
                 let ok = regex_full_match(&regex, &input);
                 Some(JValue::Int(if ok { 1 } else { 0 }))
@@ -92,12 +142,14 @@ impl super::Vm {
                 let regex = _args
                     .first()
                     .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .and_then(|r| r.borrow().as_java_string_value().cloned())
+                    .map(|s| regex_encode_java_string(&s).into_owned())
                     .unwrap_or_default();
                 let input = _args
                     .get(1)
                     .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                    .and_then(|r| r.borrow().as_java_string_value().cloned())
+                    .map(|s| regex_encode_java_string(&s).into_owned())
                     .unwrap_or_default();
                 let ok = regex_full_match(&regex, &input);
                 Some(JValue::Int(if ok { 1 } else { 0 }))

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -3,39 +3,167 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::class_file::Attribute;
-use crate::heap::{JObject, JRef, JValue, NativePayload};
+use crate::heap::{JavaStringValue, JObject, JRef, JValue, NativePayload};
 
 use super::LazyClass;
 use super::descriptors::*;
+use super::native_static::regex_encode_java_string;
 
 #[cfg(target_arch = "wasm32")]
 use super::{console_error, console_log};
 
-/// Convert a Java char-index to a UTF-8 byte offset within `s`.
-/// Returns `s.len()` when `char_idx` is beyond the end of the string.
-fn char_to_byte_offset(s: &str, char_idx: usize) -> usize {
-    if char_idx == 0 {
+/// Convert a UTF-16 code unit index to a UTF-8 byte offset within `s`.
+///
+/// When the index lands inside a surrogate pair, round up to the next scalar
+/// boundary so repeated regex searches can keep making progress.
+fn utf16_index_to_byte_offset(s: &str, utf16_idx: usize) -> usize {
+    if utf16_idx == 0 {
         return 0;
     }
-    s.char_indices().nth(char_idx).map(|(b, _)| b).unwrap_or(s.len())
+    let mut byte_offset = 0usize;
+    let mut code_units = 0usize;
+    for ch in s.chars() {
+        byte_offset += ch.len_utf8();
+        code_units += ch.len_utf16();
+        if code_units >= utf16_idx {
+            return byte_offset;
+        }
+    }
+    s.len()
+}
+
+/// Convert a UTF-16 code unit index to a UTF-8 byte offset only when it lands
+/// on an exact scalar boundary. Returns `None` for indices inside surrogate
+/// pairs, where Rust `str` cannot slice losslessly.
+fn utf16_index_to_byte_offset_exact(s: &str, utf16_idx: usize) -> Option<usize> {
+    let mut byte_offset = 0usize;
+    let mut code_units = 0usize;
+    if utf16_idx == 0 {
+        return Some(0);
+    }
+    for ch in s.chars() {
+        if code_units == utf16_idx {
+            return Some(byte_offset);
+        }
+        let next_code_units = code_units + ch.len_utf16();
+        if utf16_idx < next_code_units {
+            return None;
+        }
+        code_units = next_code_units;
+        byte_offset += ch.len_utf8();
+    }
+    (code_units == utf16_idx).then_some(byte_offset)
+}
+
+/// Convert a UTF-8 byte offset to a UTF-16 code unit index.
+fn byte_offset_to_utf16_index(s: &str, byte_offset: usize) -> usize {
+    let mut utf16_idx = 0usize;
+    let mut bytes_seen = 0usize;
+    for ch in s.chars() {
+        if bytes_seen >= byte_offset {
+            break;
+        }
+        bytes_seen += ch.len_utf8();
+        utf16_idx += ch.len_utf16();
+    }
+    utf16_idx
+}
+
+fn arg_string_value(arg: &JValue) -> Option<JavaStringValue> {
+    match arg {
+        JValue::Ref(Some(r)) => r.borrow().as_java_string_value().cloned(),
+        _ => None,
+    }
+}
+
+fn u16_find(haystack: &[u16], needle: &[u16], from: usize) -> Option<usize> {
+    let from = from.min(haystack.len());
+    if needle.is_empty() {
+        return Some(from);
+    }
+    if needle.len() > haystack.len() || from > haystack.len().saturating_sub(needle.len()) {
+        return None;
+    }
+    let max = haystack.len() - needle.len();
+    (from..=max).find(|&i| &haystack[i..i + needle.len()] == needle)
+}
+
+fn u16_last_index_of_unit(haystack: &[u16], needle: u16, from: usize) -> Option<usize> {
+    if haystack.is_empty() {
+        return None;
+    }
+    let start = from.min(haystack.len().saturating_sub(1));
+    (0..=start).rev().find(|&i| haystack[i] == needle)
+}
+
+fn u16_rfind(haystack: &[u16], needle: &[u16], from: usize) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(from.min(haystack.len()));
+    }
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    let start = from.min(haystack.len() - needle.len());
+    (0..=start)
+        .rev()
+        .find(|&i| &haystack[i..i + needle.len()] == needle)
+}
+
+fn u16_replace(haystack: &[u16], needle: &[u16], replacement: &[u16]) -> Vec<u16> {
+    if needle.is_empty() {
+        return haystack.to_vec();
+    }
+    let mut out = Vec::with_capacity(haystack.len());
+    let mut cursor = 0usize;
+    while cursor <= haystack.len().saturating_sub(needle.len()) {
+        if &haystack[cursor..cursor + needle.len()] == needle {
+            out.extend_from_slice(replacement);
+            cursor += needle.len();
+        } else {
+            out.push(haystack[cursor]);
+            cursor += 1;
+        }
+    }
+    out.extend_from_slice(&haystack[cursor..]);
+    out
+}
+
+fn string_slice_value(value: &JavaStringValue, start: usize, end: usize) -> JavaStringValue {
+    if let Some(text) = value.as_str() {
+        if let (Some(start_byte), Some(end_byte)) = (
+            utf16_index_to_byte_offset_exact(text, start),
+            utf16_index_to_byte_offset_exact(text, end),
+        ) {
+            return JavaStringValue::new(text[start_byte..end_byte].to_owned());
+        }
+    }
+    JavaStringValue::from_utf16(value.slice_utf16(start, end))
+}
+
+fn string_index_of_value(haystack: &JavaStringValue, needle: &JavaStringValue, from_index: usize) -> Option<usize> {
+    if let (Some(hs), Some(ns)) = (haystack.as_str(), needle.as_str()) {
+        let start_byte = utf16_index_to_byte_offset(hs, from_index);
+        return hs[start_byte..]
+            .find(ns)
+            .map(|byte_idx| byte_offset_to_utf16_index(hs, start_byte + byte_idx));
+    }
+    u16_find(haystack.utf16(), needle.utf16(), from_index)
 }
 
 impl super::Vm {
-    /// Extract a Rust `String` from `java/lang/String` constructor arguments based on the method descriptor.
-    /// Returns an empty string if the descriptor is not recognized or arguments are invalid.
-    pub(super) fn string_from_init_args(&self, descriptor: &str, args: &[JValue], _this: &JRef) -> String {
+    /// Extract UTF-16-backed string content from `java/lang/String` constructor arguments.
+    pub(super) fn string_from_init_args(&self, descriptor: &str, args: &[JValue], _this: &JRef) -> JavaStringValue {
         match descriptor {
-            "()V" => String::new(),
+            "()V" => JavaStringValue::from_utf16(Vec::new()),
             "([C)V" => {
                 // String(char[])
                 if let Some(r) = args.first().and_then(|a| a.as_ref()) {
                     if let NativePayload::Array(chars) = &r.borrow().native {
-                        chars.iter().map(|v| {
-                            let code = v.as_int() as u32;
-                            char::from_u32(code).unwrap_or('?')
-                        }).collect()
-                    } else { String::new() }
-                } else { String::new() }
+                        JavaStringValue::from_utf16(
+                            chars.iter().map(|v| v.as_int() as u16).collect(),
+                        )
+                    } else { JavaStringValue::from_utf16(Vec::new()) }
+                } else { JavaStringValue::from_utf16(Vec::new()) }
             }
             "([CII)V" => {
                 // String(char[], offset, count)
@@ -44,22 +172,24 @@ impl super::Vm {
                     let count = args.get(2).map(|a| a.as_int().max(0) as usize).unwrap_or(0);
                     if let NativePayload::Array(chars) = &r.borrow().native {
                         let end = offset.saturating_add(count).min(chars.len());
-                        chars[offset.min(chars.len())..end].iter()
-                            .map(|v| {
-                                let code = v.as_int() as u32;
-                                char::from_u32(code).unwrap_or('?')
-                            })
-                            .collect()
-                    } else { String::new() }
-                } else { String::new() }
+                        JavaStringValue::from_utf16(
+                            chars[offset.min(chars.len())..end]
+                                .iter()
+                                .map(|v| v.as_int() as u16)
+                                .collect(),
+                        )
+                    } else { JavaStringValue::from_utf16(Vec::new()) }
+                } else { JavaStringValue::from_utf16(Vec::new()) }
             }
             "([B)V" => {
                 // String(byte[])
                 if let Some(r) = args.first().and_then(|a| a.as_ref()) {
                     if let NativePayload::Array(bytes) = &r.borrow().native {
-                        bytes.iter().map(|v| v.as_int() as u8 as char).collect()
-                    } else { String::new() }
-                } else { String::new() }
+                        JavaStringValue::from_utf16(
+                            bytes.iter().map(|v| v.as_int() as u8 as u16).collect(),
+                        )
+                    } else { JavaStringValue::from_utf16(Vec::new()) }
+                } else { JavaStringValue::from_utf16(Vec::new()) }
             }
             "([BII)V" | "([BIILjava/lang/String;)V" | "([BIILjava/nio/charset/Charset;)V" => {
                 if let Some(r) = args.first().and_then(|a| a.as_ref()) {
@@ -67,19 +197,23 @@ impl super::Vm {
                     let count = args.get(2).map(|a| a.as_int().max(0) as usize).unwrap_or(0);
                     if let NativePayload::Array(bytes) = &r.borrow().native {
                         let end = offset.saturating_add(count).min(bytes.len());
-                        bytes[offset.min(bytes.len())..end]
-                            .iter()
-                            .map(|v| v.as_int() as u8 as char)
-                            .collect()
-                    } else { String::new() }
-                } else { String::new() }
+                        JavaStringValue::from_utf16(
+                            bytes[offset.min(bytes.len())..end]
+                                .iter()
+                                .map(|v| v.as_int() as u8 as u16)
+                                .collect(),
+                        )
+                    } else { JavaStringValue::from_utf16(Vec::new()) }
+                } else { JavaStringValue::from_utf16(Vec::new()) }
             }
             "([BLjava/lang/String;)V" | "([BLjava/nio/charset/Charset;)V" => {
                 if let Some(r) = args.first().and_then(|a| a.as_ref()) {
                     if let NativePayload::Array(bytes) = &r.borrow().native {
-                        bytes.iter().map(|v| v.as_int() as u8 as char).collect()
-                    } else { String::new() }
-                } else { String::new() }
+                        JavaStringValue::from_utf16(
+                            bytes.iter().map(|v| v.as_int() as u8 as u16).collect(),
+                        )
+                    } else { JavaStringValue::from_utf16(Vec::new()) }
+                } else { JavaStringValue::from_utf16(Vec::new()) }
             }
             "([BIII)V" => {
                 if let Some(r) = args.first().and_then(|a| a.as_ref()) {
@@ -88,20 +222,25 @@ impl super::Vm {
                     let count = args.get(3).map(|a| a.as_int().max(0) as usize).unwrap_or(0);
                     if let NativePayload::Array(bytes) = &r.borrow().native {
                         let end = offset.saturating_add(count).min(bytes.len());
-                        bytes[offset.min(bytes.len())..end]
-                            .iter()
-                            .map(|v| v.as_int() as u8 as char)
-                            .collect()
-                    } else { String::new() }
-                } else { String::new() }
+                        JavaStringValue::from_utf16(
+                            bytes[offset.min(bytes.len())..end]
+                                .iter()
+                                .map(|v| v.as_int() as u8 as u16)
+                                .collect(),
+                        )
+                    } else { JavaStringValue::from_utf16(Vec::new()) }
+                } else { JavaStringValue::from_utf16(Vec::new()) }
             }
             "(Ljava/lang/String;)V" => {
                 // String(String) — copy constructor
                 if let Some(r) = args.first().and_then(|a| a.as_ref()) {
-                    r.borrow().as_java_string().unwrap_or("").to_owned()
-                } else { String::new() }
+                    r.borrow()
+                        .as_java_string_value()
+                        .cloned()
+                        .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()))
+                } else { JavaStringValue::from_utf16(Vec::new()) }
             }
-            _ => String::new(),
+            _ => JavaStringValue::from_utf16(Vec::new()),
         }
     }
 
@@ -369,17 +508,15 @@ impl super::Vm {
         // java/lang/Object instance methods are inherited by all reference types.
         match method_name {
             "hashCode" if _descriptor == "()I" => {
-                // Strings have value-based equality: use Java's string hash algorithm.
-                if let Some(s) = this.borrow().as_java_string().map(|s| s.to_owned()) {
-                    let hash = s.chars().fold(0i32, |h, c| h.wrapping_mul(31).wrapping_add(c as i32));
-                    return Some(JValue::Int(hash));
+                if let Some(s) = this.borrow().as_java_string_value() {
+                    return Some(JValue::Int(s.hash_code()));
                 }
                 // For all other objects use identity (pointer address).
                 let ptr = Rc::as_ptr(this) as usize;
                 return Some(JValue::Int((ptr as u64 as u32) as i32));
             }
-            "intern" if _descriptor == "()Ljava/lang/String;" && this.borrow().as_java_string().is_some() => {
-                return Some(JValue::Ref(Some(this.clone())));
+            "intern" if _descriptor == "()Ljava/lang/String;" && this.borrow().as_java_string_value().is_some() => {
+                return Some(JValue::Ref(self.intern_existing_string_ref(this)));
             }
             "getClass" if _descriptor == "()Ljava/lang/Class;" => {
                 let runtime_class = this.borrow().class_name.clone();
@@ -526,15 +663,15 @@ impl super::Vm {
                 let input = _args
                     .first()
                     .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                    .unwrap_or_default();
+                    .cloned()
+                    .unwrap_or_else(|| self.intern_string(""));
                 let m = JObject::new("java/util/regex/Matcher");
                 m.borrow_mut().fields.insert("__pattern".to_owned(), JValue::Ref(Some(this.clone())));
-                m.borrow_mut().fields.insert("__input".to_owned(), JValue::Ref(Some(self.intern_string(input))));
+                m.borrow_mut().fields.insert("__input".to_owned(), JValue::Ref(Some(input)));
                 Some(JValue::Ref(Some(m)))
             }
             ("java/util/regex/Matcher", "matches") => {
-                let (regex, input) = {
+                let (regex, input_value) = {
                     let mb = this.borrow();
                     // Try bytecode field names first, then native field names
                     let pattern_ref = mb.fields.get("pattern")
@@ -547,33 +684,47 @@ impl super::Vm {
                             pb.fields.get("regex")
                                 .or_else(|| pb.fields.get("__regex"))
                                 .and_then(|v| v.as_ref().cloned())
-                                .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
+                                .and_then(|s| s.borrow().as_java_string_value().cloned())
+                                .map(|s| regex_encode_java_string(&s).into_owned())
                         })
                         .unwrap_or_default();
                     let input = mb.fields.get("input")
                         .or_else(|| mb.fields.get("__input"))
                         .and_then(|v| v.as_ref())
-                        .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
-                        .unwrap_or_default();
+                        .and_then(|s| s.borrow().as_java_string_value().cloned())
+                        .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
                     (regex, input)
                 };
+                let input_text = regex_encode_java_string(&input_value);
                 // Use captures to extract groups
                 let anchored = format!("^(?:{regex})$");
                 let re = regex::Regex::new(&anchored).ok();
-                let caps = re.as_ref().and_then(|r| r.captures(&input));
+                let caps = re.as_ref().and_then(|r| r.captures(input_text.as_ref()));
                 let ok = caps.is_some();
                 // Store captured groups in __groups array field + matchStart/matchEnd
                 if let Some(caps) = &caps {
                     let mut groups = Vec::new();
                     for i in 0..caps.len() {
                         if let Some(m) = caps.get(i) {
-                            groups.push(JValue::Ref(Some(self.intern_string(m.as_str()))));
+                            let start = byte_offset_to_utf16_index(&input_text, m.start());
+                            let end = byte_offset_to_utf16_index(input_text.as_ref(), m.end());
+                            groups.push(JValue::Ref(Some(self.intern_string_value(
+                                string_slice_value(&input_value, start, end),
+                            ))));
                         } else {
                             groups.push(JValue::Ref(None));
                         }
                     }
                     let groups_arr = JObject::new_array("[Ljava/lang/String;", groups);
-                    let (ms, me) = caps.get(0).map(|m| (m.start() as i32, m.end() as i32)).unwrap_or((-1, -1));
+                    let (ms, me) = caps
+                        .get(0)
+                        .map(|m| {
+                            (
+                                byte_offset_to_utf16_index(input_text.as_ref(), m.start()) as i32,
+                                byte_offset_to_utf16_index(input_text.as_ref(), m.end()) as i32,
+                            )
+                        })
+                        .unwrap_or((-1, -1));
                     this.borrow_mut().fields.insert("__groups".to_owned(), JValue::Ref(Some(groups_arr)));
                     this.borrow_mut().fields.insert("matchStart".to_owned(), JValue::Int(ms));
                     this.borrow_mut().fields.insert("matchEnd".to_owned(), JValue::Int(me));
@@ -585,7 +736,7 @@ impl super::Vm {
                 Some(JValue::Int(if ok { 1 } else { 0 }))
             }
             ("java/util/regex/Matcher", "find") => {
-                let (regex, input, search_index) = {
+                let (regex, input_value, search_index) = {
                     let mb = this.borrow();
                     let pattern_ref = mb
                         .fields
@@ -599,7 +750,8 @@ impl super::Vm {
                                 .get("regex")
                                 .or_else(|| pb.fields.get("__regex"))
                                 .and_then(|v| v.as_ref().cloned())
-                                .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
+                                .and_then(|s| s.borrow().as_java_string_value().cloned())
+                                .map(|s| regex_encode_java_string(&s).into_owned())
                         })
                         .unwrap_or_default();
                     let input = mb
@@ -607,8 +759,8 @@ impl super::Vm {
                         .get("input")
                         .or_else(|| mb.fields.get("__input"))
                         .and_then(|v| v.as_ref())
-                        .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
-                        .unwrap_or_default();
+                        .and_then(|s| s.borrow().as_java_string_value().cloned())
+                        .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
                     let search_index = mb
                         .fields
                         .get("searchIndex")
@@ -616,8 +768,40 @@ impl super::Vm {
                         .unwrap_or(0);
                     (regex, input, search_index)
                 };
+                let input_len = input_value.len_utf16();
 
-                if search_index > input.len() {
+                if regex.is_empty() {
+                    if search_index > input_len {
+                        let mut mb = this.borrow_mut();
+                        mb.fields.remove("__groups");
+                        mb.fields.insert("matchStart".to_owned(), JValue::Int(-1));
+                        mb.fields.insert("matchEnd".to_owned(), JValue::Int(-1));
+                        mb.fields.insert(
+                            "searchIndex".to_owned(),
+                            JValue::Int(input_len.saturating_add(1) as i32),
+                        );
+                        return Some(JValue::Int(0));
+                    }
+                    let groups_arr = JObject::new_array(
+                        "[Ljava/lang/String;",
+                        vec![JValue::Ref(Some(self.intern_string("")))],
+                    );
+                    let next_search = search_index.saturating_add(1);
+                    let mut mb = this.borrow_mut();
+                    mb.fields
+                        .insert("__groups".to_owned(), JValue::Ref(Some(groups_arr)));
+                    mb.fields
+                        .insert("matchStart".to_owned(), JValue::Int(search_index as i32));
+                    mb.fields
+                        .insert("matchEnd".to_owned(), JValue::Int(search_index as i32));
+                    mb.fields.insert(
+                        "searchIndex".to_owned(),
+                        JValue::Int(next_search.min(input_len.saturating_add(1)) as i32),
+                    );
+                    return Some(JValue::Int(1));
+                }
+
+                if search_index > input_len {
                     this.borrow_mut().fields.remove("__groups");
                     this.borrow_mut()
                         .fields
@@ -625,18 +809,28 @@ impl super::Vm {
                     this.borrow_mut()
                         .fields
                         .insert("matchEnd".to_owned(), JValue::Int(-1));
+                    this.borrow_mut().fields.insert(
+                        "searchIndex".to_owned(),
+                        JValue::Int(input_len.saturating_add(1) as i32),
+                    );
                     return Some(JValue::Int(0));
                 }
 
+                let input_text = regex_encode_java_string(&input_value);
                 let re = regex::Regex::new(&regex).ok();
-                let hay = &input[search_index..];
+                let start_byte = utf16_index_to_byte_offset(input_text.as_ref(), search_index);
+                let hay = &input_text.as_ref()[start_byte..];
                 let caps = re.as_ref().and_then(|r| r.captures(hay));
 
                 if let Some(caps) = caps {
                     let mut groups = Vec::new();
                     for i in 0..caps.len() {
                         if let Some(m) = caps.get(i) {
-                            groups.push(JValue::Ref(Some(self.intern_string(m.as_str()))));
+                            let start = byte_offset_to_utf16_index(input_text.as_ref(), start_byte + m.start());
+                            let end = byte_offset_to_utf16_index(input_text.as_ref(), start_byte + m.end());
+                            groups.push(JValue::Ref(Some(self.intern_string_value(
+                                string_slice_value(&input_value, start, end),
+                            ))));
                         } else {
                             groups.push(JValue::Ref(None));
                         }
@@ -646,8 +840,8 @@ impl super::Vm {
                         .get(0)
                         .map(|m| {
                             (
-                                (search_index + m.start()) as i32,
-                                (search_index + m.end()) as i32,
+                                byte_offset_to_utf16_index(input_text.as_ref(), start_byte + m.start()) as i32,
+                                byte_offset_to_utf16_index(input_text.as_ref(), start_byte + m.end()) as i32,
                             )
                         })
                         .unwrap_or((-1, -1));
@@ -663,7 +857,7 @@ impl super::Vm {
                     mb.fields.insert("matchEnd".to_owned(), JValue::Int(me));
                     mb.fields.insert(
                         "searchIndex".to_owned(),
-                        JValue::Int(next_search.min(input.len().saturating_add(1)) as i32),
+                        JValue::Int(next_search.min(input_len.saturating_add(1)) as i32),
                     );
                     return Some(JValue::Int(1));
                 }
@@ -674,7 +868,7 @@ impl super::Vm {
                 mb.fields.insert("matchEnd".to_owned(), JValue::Int(-1));
                 mb.fields.insert(
                     "searchIndex".to_owned(),
-                    JValue::Int(input.len().saturating_add(1) as i32),
+                    JValue::Int(input_len.saturating_add(1) as i32),
                 );
                 Some(JValue::Int(0))
             }
@@ -696,11 +890,13 @@ impl super::Vm {
                     let input = mb.fields.get("input")
                         .or_else(|| mb.fields.get("__input"))
                         .and_then(|v| v.as_ref())
-                        .and_then(|s| s.borrow().as_java_string().map(|x| x.to_owned()))
-                        .unwrap_or_default();
+                        .and_then(|s| s.borrow().as_java_string_value().cloned())
+                        .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
                     drop(mb);
-                    if start >= 0 && end >= 0 && (end as usize) <= input.len() {
-                        return Some(JValue::Ref(Some(self.intern_string(&input[start as usize..end as usize]))));
+                    if start >= 0 && end >= 0 && (end as usize) <= input.len_utf16() {
+                        return Some(JValue::Ref(Some(JObject::new_string_value(
+                            string_slice_value(&input, start as usize, end as usize),
+                        ))));
                     }
                 } else {
                     drop(mb);
@@ -1435,161 +1631,271 @@ impl super::Vm {
             }
             // String native methods — backed by NativePayload::JavaString in Rust.
             ("java/lang/String", "toString") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
-                Some(JValue::Ref(Some(JObject::new_string(s))))
+                Some(JValue::Ref(Some(Rc::clone(this))))
             }
             ("java/lang/String", "length") => {
-                let len = this.borrow().as_java_string().map(|s| s.chars().count() as i32).unwrap_or(0);
+                let len = this
+                    .borrow()
+                    .as_java_string_value()
+                    .map(|s| s.len_utf16() as i32)
+                    .unwrap_or(0);
                 Some(JValue::Int(len))
             }
             ("java/lang/String", "charAt") => {
                 let idx = _args.first().map(|v| v.as_int() as usize).unwrap_or(0);
-                let ch = this.borrow().as_java_string()
-                    .and_then(|s| s.chars().nth(idx))
-                    .unwrap_or('\0') as i32;
+                let ch = this
+                    .borrow()
+                    .as_java_string_value()
+                    .and_then(|s| s.code_unit_at(idx))
+                    .unwrap_or(0) as i32;
                 Some(JValue::Int(ch))
             }
             ("java/lang/String", "isEmpty") => {
-                let empty = this.borrow().as_java_string().map(|s| s.is_empty()).unwrap_or(true);
+                let empty = this
+                    .borrow()
+                    .as_java_string_value()
+                    .map(|s| s.len_utf16() == 0)
+                    .unwrap_or(true);
                 Some(JValue::Int(if empty { 1 } else { 0 }))
             }
             ("java/lang/String", "equals") => {
-                let other_str = _args.first()
-                    .and_then(|a| a.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()));
-                let this_str = this.borrow().as_java_string().map(|s| s.to_owned());
-                let eq = match (this_str, other_str) {
-                    (Some(a), Some(b)) => a == b,
-                    _ => false,
-                };
+                let this_borrow = this.borrow();
+                let eq = this_borrow
+                    .as_java_string_value()
+                    .map(|this_value| {
+                        _args
+                            .first()
+                            .and_then(|arg| match arg {
+                                JValue::Ref(Some(other_ref)) => Some(other_ref),
+                                _ => None,
+                            })
+                            .map(|other_ref| {
+                                let other_borrow = other_ref.borrow();
+                                other_borrow
+                                    .as_java_string_value()
+                                    .map(|other_value| this_value == other_value)
+                                    .unwrap_or(false)
+                            })
+                            .unwrap_or(false)
+                    })
+                    .unwrap_or(false);
                 Some(JValue::Int(if eq { 1 } else { 0 }))
             }
             ("java/lang/String", "hashCode") => {
-                let hash = this.borrow().as_java_string().map(|s| {
-                    s.chars().fold(0i32, |h, c| h.wrapping_mul(31).wrapping_add(c as i32))
-                }).unwrap_or(0);
+                let hash = this
+                    .borrow()
+                    .as_java_string_value()
+                    .map(JavaStringValue::hash_code)
+                    .unwrap_or(0);
                 Some(JValue::Int(hash))
             }
             ("java/lang/String", "substring") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
-                let char_len = s.chars().count();
-                let begin = (_args.first().map(|v| v.as_int() as usize).unwrap_or(0)).min(char_len);
-                let end = (_args.get(1).map(|v| v.as_int() as usize).unwrap_or(char_len)).min(char_len).max(begin);
-                let sub: String = s.chars().skip(begin).take(end - begin).collect();
-                Some(JValue::Ref(Some(JObject::new_string(sub))))
+                let this_borrow = this.borrow();
+                let value = this_borrow.as_java_string_value();
+                let len = value.map(JavaStringValue::len_utf16).unwrap_or(0);
+                let begin = (_args.first().map(|v| v.as_int() as usize).unwrap_or(0)).min(len);
+                let end = (_args.get(1).map(|v| v.as_int() as usize).unwrap_or(len))
+                    .min(len)
+                    .max(begin);
+                let result = value
+                    .map(|value| string_slice_value(value, begin, end))
+                    .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
+                Some(JValue::Ref(Some(JObject::new_string_value(result))))
             }
             ("java/lang/String", "concat") => {
-                let a = this.borrow().as_java_string().unwrap_or("").to_owned();
-                let b = _args.first()
-                    .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                    .unwrap_or_default();
-                Some(JValue::Ref(Some(JObject::new_string(a + &b))))
+                let this_borrow = this.borrow();
+                let result = if let Some(left) = this_borrow.as_java_string_value() {
+                    if let Some(arg_ref) = _args.first().and_then(|arg| arg.as_ref()) {
+                        let arg_borrow = arg_ref.borrow();
+                        if let Some(right) = arg_borrow.as_java_string_value() {
+                            left.concat(right)
+                        } else {
+                            left.clone()
+                        }
+                    } else {
+                        left.clone()
+                    }
+                } else {
+                    JavaStringValue::from_utf16(Vec::new())
+                };
+                Some(JValue::Ref(Some(JObject::new_string_value(result))))
             }
             ("java/lang/String", "contains") => {
-                let haystack = this.borrow().as_java_string().unwrap_or("").to_owned();
-                let needle = _args.first()
-                    .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                    .unwrap_or_default();
-                Some(JValue::Int(if haystack.contains(&needle) { 1 } else { 0 }))
+                let this_borrow = this.borrow();
+                let found = this_borrow
+                    .as_java_string_value()
+                    .map(|haystack| {
+                        _args
+                            .first()
+                            .and_then(|arg| match arg {
+                                JValue::Ref(Some(needle_ref)) => Some(needle_ref),
+                                _ => None,
+                            })
+                            .map(|needle_ref| {
+                                let needle_borrow = needle_ref.borrow();
+                                needle_borrow
+                                    .as_java_string_value()
+                                    .map(|needle| string_index_of_value(haystack, needle, 0).is_some())
+                                    .unwrap_or(false)
+                            })
+                            .unwrap_or(false)
+                    })
+                    .unwrap_or(false);
+                Some(JValue::Int(if found { 1 } else { 0 }))
             }
             ("java/lang/String", "startsWith") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
-                let prefix = _args.first()
-                    .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                    .unwrap_or_default();
-                Some(JValue::Int(if s.starts_with(&prefix) { 1 } else { 0 }))
+                let this_borrow = this.borrow();
+                let s = this_borrow.as_java_string_utf16().unwrap_or(&[]);
+                let prefix = _args
+                    .first()
+                    .and_then(arg_string_value);
+                let ok = if let Some(prefix) = prefix {
+                    s.len() >= prefix.len_utf16() && s[..prefix.len_utf16()] == prefix.utf16()[..]
+                } else {
+                    false
+                };
+                Some(JValue::Int(if ok { 1 } else { 0 }))
             }
             ("java/lang/String", "endsWith") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
-                let suffix = _args.first()
-                    .and_then(|v| v.as_ref())
-                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                    .unwrap_or_default();
-                Some(JValue::Int(if s.ends_with(&suffix) { 1 } else { 0 }))
+                let this_borrow = this.borrow();
+                let s = this_borrow.as_java_string_utf16().unwrap_or(&[]);
+                let suffix = _args
+                    .first()
+                    .and_then(arg_string_value);
+                let ok = if let Some(suffix) = suffix {
+                    s.len() >= suffix.len_utf16()
+                        && s[s.len() - suffix.len_utf16()..] == suffix.utf16()[..]
+                } else {
+                    false
+                };
+                Some(JValue::Int(if ok { 1 } else { 0 }))
             }
             ("java/lang/String", "indexOf") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
-                // fromIndex (char-index): default 0
-                let from_char = _args.get(1).map(|v| v.as_int().max(0) as usize).unwrap_or(0);
-                let from_byte = char_to_byte_offset(&s, from_char);
-                let search_str = &s[from_byte..];
+                let this_borrow = this.borrow();
+                let value = this_borrow.as_java_string_value();
+                let from_index = _args
+                    .get(1)
+                    .map(|v| v.as_int().max(0) as usize)
+                    .unwrap_or(0);
                 let idx = match _args.first() {
-                    Some(JValue::Ref(Some(r))) => {
-                        let needle = r.borrow().as_java_string().unwrap_or("").to_owned();
-                        search_str.find(needle.as_str()).map(|byte_pos| {
-                            s[..from_byte + byte_pos].chars().count() as i32
-                        }).unwrap_or(-1)
+                    Some(arg) => {
+                        match arg {
+                            JValue::Ref(Some(needle_ref)) => {
+                                let needle_borrow = needle_ref.borrow();
+                                if let (Some(haystack), Some(needle)) =
+                                    (value, needle_borrow.as_java_string_value())
+                                {
+                                    string_index_of_value(haystack, needle, from_index)
+                                        .map(|i| i as i32)
+                                        .unwrap_or(-1)
+                                } else {
+                                    -1
+                                }
+                            }
+                            JValue::Int(ch) => {
+                                let needle = *ch as u16;
+                                let units = value.map(JavaStringValue::utf16).unwrap_or(&[]);
+                                (from_index.min(units.len())..units.len())
+                                    .find(|&i| units[i] == needle)
+                                    .map(|i| i as i32)
+                                    .unwrap_or(-1)
+                            }
+                            _ => -1,
+                        }
                     }
-                    Some(JValue::Int(ch)) => {
-                        let c = char::from_u32(*ch as u32).unwrap_or('\0');
-                        search_str.find(c).map(|byte_pos| {
-                            s[..from_byte + byte_pos].chars().count() as i32
-                        }).unwrap_or(-1)
-                    }
-                    _ => -1,
+                    None => -1,
                 };
                 Some(JValue::Int(idx))
             }
             ("java/lang/String", "lastIndexOf") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
-                // fromIndex (char-index): default = end of string.
-                // JDK semantics: search backwards starting AT fromIndex (inclusive),
-                // so slice up to the byte offset of fromIndex+1.
-                let char_len = s.chars().count();
-                let from_char = _args.get(1).map(|v| (v.as_int() as usize).min(char_len)).unwrap_or(char_len);
-                let from_byte = char_to_byte_offset(&s, from_char.saturating_add(1).min(char_len));
-                let search_str = &s[..from_byte];
+                let this_borrow = this.borrow();
+                let value = this_borrow.as_java_string_value();
+                let units = value.map(JavaStringValue::utf16).unwrap_or(&[]);
+                let from_index = _args
+                    .get(1)
+                    .map(|v| v.as_int().max(0) as usize)
+                    .unwrap_or_else(|| units.len().saturating_sub(1));
                 let idx = match _args.first() {
-                    Some(JValue::Ref(Some(r))) => {
-                        let needle = r.borrow().as_java_string().unwrap_or("").to_owned();
-                        search_str.rfind(needle.as_str()).map(|byte_pos| {
-                            s[..byte_pos].chars().count() as i32
-                        }).unwrap_or(-1)
+                    Some(arg) => {
+                        match arg {
+                            JValue::Ref(Some(needle_ref)) => {
+                                let needle_borrow = needle_ref.borrow();
+                                if let Some(needle) = needle_borrow.as_java_string_value() {
+                                    u16_rfind(units, needle.utf16(), from_index)
+                                        .map(|i| i as i32)
+                                        .unwrap_or(-1)
+                                } else {
+                                    -1
+                                }
+                            }
+                            JValue::Int(ch) => {
+                                u16_last_index_of_unit(units, *ch as u16, from_index)
+                                    .map(|i| i as i32)
+                                    .unwrap_or(-1)
+                            }
+                            _ => -1,
+                        }
                     }
-                    Some(JValue::Int(ch)) => {
-                        let c = char::from_u32(*ch as u32).unwrap_or('\0');
-                        search_str.rfind(c).map(|byte_pos| {
-                            s[..byte_pos].chars().count() as i32
-                        }).unwrap_or(-1)
-                    }
-                    _ => -1,
+                    None => -1,
                 };
                 Some(JValue::Int(idx))
             }
             ("java/lang/String", "trim") => {
-                let s = this.borrow().as_java_string().unwrap_or("").trim().to_owned();
+                let s = this
+                    .borrow()
+                    .java_string_to_string_lossy()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_owned();
                 Some(JValue::Ref(Some(JObject::new_string(s))))
             }
             ("java/lang/String", "toLowerCase") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_lowercase();
+                let s = this
+                    .borrow()
+                    .java_string_to_string_lossy()
+                    .unwrap_or_default()
+                    .to_lowercase();
                 Some(JValue::Ref(Some(JObject::new_string(s))))
             }
             ("java/lang/String", "toUpperCase") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_uppercase();
+                let s = this
+                    .borrow()
+                    .java_string_to_string_lossy()
+                    .unwrap_or_default()
+                    .to_uppercase();
                 Some(JValue::Ref(Some(JObject::new_string(s))))
             }
             ("java/lang/String", "toCharArray") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
-                let chars: Vec<JValue> = s.chars().map(|c| JValue::Int(c as i32)).collect();
+                let chars: Vec<JValue> = this
+                    .borrow()
+                    .as_java_string_utf16()
+                    .map(|s| s.iter().map(|c| JValue::Int(i32::from(*c))).collect())
+                    .unwrap_or_default();
                 Some(JValue::Ref(Some(JObject::new_array("[C", chars))))
             }
             ("java/lang/String", "getBytes") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
+                let s = this
+                    .borrow()
+                    .java_string_to_string_lossy()
+                    .unwrap_or_default();
                 let bytes: Vec<JValue> = s.bytes().map(|b| JValue::Int(b as i32)).collect();
                 Some(JValue::Ref(Some(JObject::new_array("[B", bytes))))
             }
             ("java/lang/String", "replace") => {
-                let s = this.borrow().as_java_string().unwrap_or("").to_owned();
+                let s = this
+                    .borrow()
+                    .as_java_string_value()
+                    .cloned()
+                    .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
                 if _args.len() >= 2 {
                     // replace(char, char)
                     if let (JValue::Int(old_c), JValue::Int(new_c)) = (&_args[0], &_args[1]) {
-                        let old_ch = char::from_u32(*old_c as u32).unwrap_or('\u{FFFD}');
-                        let new_ch = char::from_u32(*new_c as u32).unwrap_or('\u{FFFD}');
-                        let result = s.replace(old_ch, &new_ch.to_string());
-                        Some(JValue::Ref(Some(self.intern_string(result))))
+                        let result: Vec<u16> = s
+                            .utf16()
+                            .iter()
+                            .map(|c| if *c == (*old_c as u16) { *new_c as u16 } else { *c })
+                            .collect();
+                        Some(JValue::Ref(Some(JObject::new_string_utf16(result))))
                     } else {
                         // replace(CharSequence, CharSequence) — null args throw NPE per JDK spec
                         let old_ref = _args[0].as_ref();
@@ -1598,10 +1904,14 @@ impl super::Vm {
                             self.throw_null_pointer("String.replace: null argument");
                             return Some(JValue::Void);
                         }
-                        let old_str = old_ref.unwrap().borrow().as_java_string().unwrap_or("").to_owned();
-                        let new_str = new_ref.unwrap().borrow().as_java_string().unwrap_or("").to_owned();
-                        let result = s.replace(&old_str, &new_str);
-                        Some(JValue::Ref(Some(self.intern_string(result))))
+                        let old_str = old_ref
+                            .and_then(|_| arg_string_value(&_args[0]))
+                            .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
+                        let new_str = new_ref
+                            .and_then(|_| arg_string_value(&_args[1]))
+                            .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
+                        let result = u16_replace(s.utf16(), old_str.utf16(), new_str.utf16());
+                        Some(JValue::Ref(Some(JObject::new_string_utf16(result))))
                     }
                 } else {
                     Some(JValue::Ref(Some(Rc::clone(this))))

--- a/jvm-core/src/interpreter/trampoline.rs
+++ b/jvm-core/src/interpreter/trampoline.rs
@@ -452,8 +452,8 @@ impl Vm {
                                 JValue::Float(v) => cs.result.push_str(&v.to_string()),
                                 JValue::Double(v) => cs.result.push_str(&v.to_string()),
                                 JValue::Ref(Some(r)) => {
-                                    if let Some(s) = r.borrow().as_java_string() {
-                                        cs.result.push_str(s);
+                                    if let Some(s) = r.borrow().java_string_to_string_lossy() {
+                                        cs.result.push_str(&s);
                                     } else {
                                         need_tostring = Some((r.clone(), r.borrow().class_name.clone()));
                                     }
@@ -496,7 +496,7 @@ impl Vm {
                         &r, &cn, "toString", "()Ljava/lang/String;", &[],
                     ) {
                         if let JValue::Ref(Some(sr)) = v {
-                            sr.borrow().as_java_string().unwrap_or("").to_owned()
+                            sr.borrow().java_string_to_string_lossy().unwrap_or_default()
                         } else {
                             cn.clone()
                         }
@@ -756,8 +756,8 @@ impl Vm {
 fn feed_concat_return(fi: &mut FrameInfo, ret: &JValue) {
     if let Some(ref mut cs) = fi.concat_state {
         if let JValue::Ref(Some(sr)) = ret {
-            if let Some(s) = sr.borrow().as_java_string() {
-                cs.result.push_str(s);
+            if let Some(s) = sr.borrow().java_string_to_string_lossy() {
+                cs.result.push_str(&s);
             }
         }
     }

--- a/jvm-core/src/lib.rs
+++ b/jvm-core/src/lib.rs
@@ -391,7 +391,7 @@ fn jvalue_to_string(v: &JValue) -> String {
         JValue::Ref(Some(r)) => {
             let obj = r.borrow();
             match &obj.native {
-                heap::NativePayload::JavaString(s) => s.clone(),
+                heap::NativePayload::JavaString(s) => s.to_string_lossy(),
                 heap::NativePayload::Array(v) => format!(
                     "[{}]",
                     v.iter()

--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -82,7 +82,7 @@ fn jvalue_to_string(v: &jvm_core::heap::JValue) -> String {
         jvm_core::heap::JValue::Ref(Some(r)) => {
             let obj = r.borrow();
             match &obj.native {
-                jvm_core::heap::NativePayload::JavaString(s) => s.clone(),
+                jvm_core::heap::NativePayload::JavaString(s) => s.to_string_lossy(),
                 _ => format!("{}@obj", obj.class_name),
             }
         }
@@ -116,6 +116,56 @@ fn string_concat() {
         "()Ljava/lang/String;",
     );
     assert_eq!(result, "OK: 42");
+}
+
+#[test]
+fn string_emoji_length_and_char_at() {
+    let result = run_jar_test(
+        "StringEmojiLengthAndCharAtTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "2|55357|56832");
+}
+
+#[test]
+fn string_emoji_substring_half_preserves_surrogates() {
+    let result = run_jar_test(
+        "StringEmojiSubstringHalfTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "1|55357|1|56832");
+}
+
+#[test]
+fn string_surrogate_hash_and_intern() {
+    let result = run_jar_test(
+        "StringSurrogateHashAndInternTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "1772899|55357|true");
+}
+
+#[test]
+fn string_concat_surrogate_half_preserves_utf16() {
+    let result = run_jar_test(
+        "StringConcatSurrogateHalfTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "2|55357|56832|true");
+}
+
+#[test]
+fn string_cjk_substring_and_index_of_last_index_of() {
+    let result = run_jar_test(
+        "StringCjkSubstringAndIndexOfTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "\u{3042}\u{D55C}\u{4E2D}|2|4");
 }
 
 // ---------------------------------------------------------------------------
@@ -763,6 +813,86 @@ fn regex_capture_groups() {
 fn regex_find_escaped_parens() {
     let result = run_jar_test("RegexFindEscapedParensTest", "run", "()Ljava/lang/String;");
     assert_eq!(result, "true|Wrong number of args (0) passed to: :kw|false");
+}
+
+#[test]
+fn regex_find_bmp_non_ascii_offsets() {
+    let result = run_jar_test(
+        "RegexFindBmpNonAsciiOffsetsTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "true|1|2|x");
+}
+
+#[test]
+fn regex_find_cjk_offsets() {
+    let result = run_jar_test(
+        "RegexFindCjkOffsetsTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "true|2|4|\u{D55C}\u{4E2D}");
+}
+
+#[test]
+fn regex_find_repeated_cjk_matches() {
+    let result = run_jar_test(
+        "RegexFindRepeatedCjkMatchesTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "1:2,3:4");
+}
+
+#[test]
+fn regex_find_zero_length_cjk_boundaries() {
+    let result = run_jar_test(
+        "RegexFindZeroLengthCjkBoundariesTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "0:0,1:1,2:2");
+}
+
+#[test]
+fn regex_find_emoji_offsets() {
+    let result = run_jar_test(
+        "RegexFindEmojiOffsetsTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, format!("true|1|3|{}", '\u{1F600}'));
+}
+
+#[test]
+fn regex_find_empty_emoji_boundaries() {
+    let result = run_jar_test(
+        "RegexFindEmptyEmojiBoundariesTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "0:0,1:1,2:2");
+}
+
+#[test]
+fn regex_surrogate_half_paths() {
+    let result = run_jar_test(
+        "RegexSurrogateHalfPathsTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "true|true|true|0|1|1|55357|false");
+}
+
+#[test]
+fn regex_find_emoji_wildcard() {
+    let result = run_jar_test(
+        "RegexFindEmojiWildcardTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "true|0|2|2|55357|56832");
 }
 
 #[test]

--- a/test-sources/RegexFindBmpNonAsciiOffsetsTest.java
+++ b/test-sources/RegexFindBmpNonAsciiOffsetsTest.java
@@ -1,0 +1,10 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexFindBmpNonAsciiOffsetsTest {
+    public static String run() {
+        Matcher m = Pattern.compile("x").matcher("\u3042x");
+        boolean found = m.find();
+        return found + "|" + m.start() + "|" + m.end() + "|" + (found ? m.group() : "miss");
+    }
+}

--- a/test-sources/RegexFindCjkOffsetsTest.java
+++ b/test-sources/RegexFindCjkOffsetsTest.java
@@ -1,0 +1,10 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexFindCjkOffsetsTest {
+    public static String run() {
+        Matcher m = Pattern.compile("\uD55C\u4E2D").matcher("\u6F22\u3042\uD55C\u4E2D\u6587");
+        boolean found = m.find();
+        return found + "|" + m.start() + "|" + m.end() + "|" + (found ? m.group() : "miss");
+    }
+}

--- a/test-sources/RegexFindEmojiOffsetsTest.java
+++ b/test-sources/RegexFindEmojiOffsetsTest.java
@@ -1,0 +1,10 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexFindEmojiOffsetsTest {
+    public static String run() {
+        Matcher m = Pattern.compile("\uD83D\uDE00").matcher("a\uD83D\uDE00b\uD83D\uDE00c");
+        boolean found = m.find();
+        return found + "|" + m.start() + "|" + m.end() + "|" + (found ? m.group() : "miss");
+    }
+}

--- a/test-sources/RegexFindEmojiWildcardTest.java
+++ b/test-sources/RegexFindEmojiWildcardTest.java
@@ -1,0 +1,16 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexFindEmojiWildcardTest {
+    public static String run() {
+        Matcher matcher = Pattern.compile(".").matcher("\uD83D\uDE00");
+        boolean found = matcher.find();
+        String group = found ? matcher.group() : "";
+        return found
+            + "|" + (found ? matcher.start() : -1)
+            + "|" + (found ? matcher.end() : -1)
+            + "|" + group.length()
+            + "|" + (group.length() > 0 ? (int) group.charAt(0) : -1)
+            + "|" + (group.length() > 1 ? (int) group.charAt(1) : -1);
+    }
+}

--- a/test-sources/RegexFindEmptyEmojiBoundariesTest.java
+++ b/test-sources/RegexFindEmptyEmojiBoundariesTest.java
@@ -1,0 +1,16 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexFindEmptyEmojiBoundariesTest {
+    public static String run() {
+        Matcher m = Pattern.compile("").matcher("\uD83D\uDE00");
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(m.start()).append(":").append(m.end());
+        }
+        return sb.toString();
+    }
+}

--- a/test-sources/RegexFindRepeatedCjkMatchesTest.java
+++ b/test-sources/RegexFindRepeatedCjkMatchesTest.java
@@ -1,0 +1,16 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexFindRepeatedCjkMatchesTest {
+    public static String run() {
+        Matcher m = Pattern.compile("\uD55C").matcher("\u6F22\uD55C\u6F22\uD55C");
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(m.start()).append(":").append(m.end());
+        }
+        return sb.toString();
+    }
+}

--- a/test-sources/RegexFindZeroLengthCjkBoundariesTest.java
+++ b/test-sources/RegexFindZeroLengthCjkBoundariesTest.java
@@ -1,0 +1,16 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexFindZeroLengthCjkBoundariesTest {
+    public static String run() {
+        Matcher m = Pattern.compile("").matcher("\u6F22\u5B57");
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(m.start()).append(":").append(m.end());
+        }
+        return sb.toString();
+    }
+}

--- a/test-sources/RegexSurrogateHalfPathsTest.java
+++ b/test-sources/RegexSurrogateHalfPathsTest.java
@@ -1,0 +1,28 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexSurrogateHalfPathsTest {
+    public static String run() {
+        String emoji = "\uD83D\uDE00";
+        String high = emoji.substring(0, 1);
+        String low = emoji.substring(1, 2);
+
+        boolean staticFull = Pattern.matches(high, high);
+        Matcher exact = Pattern.compile(high).matcher(high);
+        boolean instanceFull = exact.matches();
+
+        Matcher find = Pattern.compile(high).matcher(high);
+        boolean found = find.find();
+        String group = found ? find.group() : "";
+        boolean mismatch = Pattern.matches(high, low);
+
+        return staticFull
+            + "|" + instanceFull
+            + "|" + found
+            + "|" + (found ? find.start() : -1)
+            + "|" + (found ? find.end() : -1)
+            + "|" + group.length()
+            + "|" + (group.length() > 0 ? (int) group.charAt(0) : -1)
+            + "|" + mismatch;
+    }
+}

--- a/test-sources/StringCjkSubstringAndIndexOfTest.java
+++ b/test-sources/StringCjkSubstringAndIndexOfTest.java
@@ -1,0 +1,6 @@
+public class StringCjkSubstringAndIndexOfTest {
+    public static String run() {
+        String s = "\u6F22\u3042\uD55C\u4E2D\u6587";
+        return s.substring(1, 4) + "|" + s.indexOf("\uD55C") + "|" + s.lastIndexOf('\u6587');
+    }
+}

--- a/test-sources/StringConcatSurrogateHalfTest.java
+++ b/test-sources/StringConcatSurrogateHalfTest.java
@@ -1,0 +1,12 @@
+public class StringConcatSurrogateHalfTest {
+    public static String run() {
+        String emoji = "\uD83D\uDE00";
+        String high = emoji.substring(0, 1);
+        String low = emoji.substring(1, 2);
+        String rebuilt = "" + high + low;
+        return rebuilt.length()
+            + "|" + (int) rebuilt.charAt(0)
+            + "|" + (int) rebuilt.charAt(1)
+            + "|" + rebuilt.equals(emoji);
+    }
+}

--- a/test-sources/StringEmojiLengthAndCharAtTest.java
+++ b/test-sources/StringEmojiLengthAndCharAtTest.java
@@ -1,0 +1,6 @@
+public class StringEmojiLengthAndCharAtTest {
+    public static String run() {
+        String s = "\uD83D\uDE00";
+        return s.length() + "|" + (int) s.charAt(0) + "|" + (int) s.charAt(1);
+    }
+}

--- a/test-sources/StringEmojiSubstringHalfTest.java
+++ b/test-sources/StringEmojiSubstringHalfTest.java
@@ -1,0 +1,8 @@
+public class StringEmojiSubstringHalfTest {
+    public static String run() {
+        String s = "\uD83D\uDE00";
+        String high = s.substring(0, 1);
+        String low = s.substring(1, 2);
+        return high.length() + "|" + (int) high.charAt(0) + "|" + low.length() + "|" + (int) low.charAt(0);
+    }
+}

--- a/test-sources/StringSurrogateHashAndInternTest.java
+++ b/test-sources/StringSurrogateHashAndInternTest.java
@@ -1,0 +1,8 @@
+public class StringSurrogateHashAndInternTest {
+    public static String run() {
+        String emoji = "\uD83D\uDE00";
+        String high = emoji.substring(0, 1);
+        String same = new String(new char[] { high.charAt(0) });
+        return emoji.hashCode() + "|" + high.hashCode() + "|" + (high.intern() == same.intern());
+    }
+}


### PR DESCRIPTION
Stack: #78 -> #79

## Background

Issue #77 came from treating Java-visible string indices as if they were Rust UTF-8 byte offsets.

That broke `Matcher.find()` on non-ASCII input, and it also exposed a wider mismatch between Java's UTF-16 string semantics and the VM's previous native string handling.

## What changed

- store `java/lang/String` payloads as UTF-16 code units
- decode classfile Modified UTF-8 with explicit UTF-16 handling
- make `String.length/charAt/substring/indexOf/lastIndexOf/toCharArray/hashCode` follow UTF-16 semantics
- make regex bridges and `Matcher.find()/matches()/group()` respect UTF-16-visible indices
- preserve surrogate-half strings created by VM-side slicing and concatenation
- add focused regression tests for CJK, emoji, zero-length matches, and surrogate-half paths

## Why this PR is correctness-focused

This PR intentionally excludes regex compile caching and perf guardrails.

The retained changes are all about runtime-visible correctness:

- correct string indexing semantics
- correct reflection/string/hash behavior on UTF-16 data
- correct regex match positions on CJK and non-BMP input
- correct propagation of surrogate-half strings inside the VM

## Validation

- `docker-compose run --rm rust cargo test --package jvm-core --test integration_test`

## Out of scope

- regex compile caching
- benchmark fixtures and perf guardrails
- broader optimization work
