### PR TITLE
runtime: cache regexes and add UTF-16 perf guardrails

### DIFF
--- a/Benchmark.md
+++ b/Benchmark.md
@@ -1,6 +1,7 @@
 # Benchmark Guide
 
 Benchmarks measure the interpreter hot paths identified in [Issue #13](https://github.com/kawasima/199xVM/issues/13).
+Unicode-sensitive string and regex benchmarks also track the UTF-16 compatibility work from [Issue #77](https://github.com/kawasima/199xVM/issues/77).
 
 ## Prerequisites
 
@@ -11,10 +12,22 @@ Build the JDK shim and benchmark class bundles before running:
 ./build-test-bundle.sh   # builds test-classes/bench-bundle.bin
 ```
 
+Using the repo's container workflow:
+
+```sh
+docker-compose run --rm java make test-bundle
+```
+
 ## Running benchmarks
 
 ```sh
 cargo bench --package jvm-core
+```
+
+Using Docker:
+
+```sh
+docker-compose run --rm rust cargo bench --package jvm-core
 ```
 
 Results are written to `target/criterion/` as HTML reports.
@@ -27,8 +40,20 @@ Results are written to `target/criterion/` as HTML reports.
 | `static_field_1000x` | `BenchStaticField.run()` | `format!` string allocation on every `getstatic`/`putstatic` |
 | `string_ldc_1000x` | `BenchStringLdc.run()` | `String::clone` on every `ldc` string constant |
 | `virtual_call_1000x` | `BenchVirtualCall.run()` | Interface virtual dispatch + interface name list rebuild |
+| `string_utf16_ascii_10000x` | `BenchStringUtf16Ascii.run()` | ASCII baseline for UTF-16 string operations |
+| `string_utf16_cjk_10000x` | `BenchStringUtf16Cjk.run()` | CJK path guard for UTF-8 multibyte / UTF-16 single-unit indexing |
+| `string_utf16_emoji_10000x` | `BenchStringUtf16Emoji.run()` | Surrogate-pair path guard for UTF-16 string operations |
+| `regex_find_ascii_10000x` | `BenchRegexFindAscii.run()` | ASCII baseline for `Matcher.find()` |
+| `regex_find_cjk_10000x` | `BenchRegexFindCjk.run()` | CJK regression guard for byte/code-unit conversion in regex search |
+| `regex_find_emoji_10000x` | `BenchRegexFindEmoji.run()` | Surrogate-pair path guard for regex offset conversion |
+| `regex_find_empty_emoji_10000x` | `BenchRegexFindEmptyEmoji.run()` | Empty-pattern UTF-16 boundary enumeration on surrogate pairs |
 
-Each Java method runs a loop of 1000 iterations so the per-call overhead is amplified and measurable above criterion's noise floor.
+Each Java method runs an inner loop of either 1000 or 10000 iterations so the per-call overhead is amplified and measurable above criterion's noise floor.
+
+The Unicode-specific scenarios are intentionally split by text shape:
+
+- CJK benchmarks isolate the original `#77` failure mode where UTF-8 byte offsets and UTF-16-visible indexes diverged even without surrogate pairs.
+- Emoji benchmarks isolate surrogate-pair handling and the empty-pattern boundary path. They are correctness-sensitive first and performance-sensitive second.
 
 ## Comparing before and after a fix
 
@@ -45,6 +70,31 @@ cargo bench --package jvm-core -- --baseline before
 ```
 
 criterion will print a percentage change and confidence interval for each benchmark.
+
+For the new UTF-16 scenarios, a targeted compare is often easier to read:
+
+```sh
+docker-compose run --rm rust cargo bench --package jvm-core --bench interpreter -- \
+  string_utf16_cjk_10000x regex_find_cjk_10000x \
+  string_utf16_emoji_10000x regex_find_emoji_10000x
+```
+
+## PR guardrail
+
+For pull requests, use the lightweight relative-ratio gate before looking at full Criterion output:
+
+```sh
+docker-compose run --rm rust cargo test --release --package jvm-core --test perf_guardrail_test
+```
+
+Current guardrails:
+
+- `string_utf16_cjk / string_utf16_ascii <= 6x`
+- `regex_find_cjk / regex_find_ascii <= 6x`
+- `string_utf16_emoji / string_utf16_ascii <= 12x`
+- `regex_find_emoji / regex_find_ascii <= 12x`
+
+`regex_find_empty_emoji_10000x` is benchmarked in Criterion but intentionally not used as a hard PR gate because the path is correctness-sensitive and more timing-noise-prone.
 
 ## Baseline (2026-03-12, unoptimized interpreter)
 

--- a/jvm-core/benches/interpreter.rs
+++ b/jvm-core/benches/interpreter.rs
@@ -66,6 +66,55 @@ fn bench_virtual_call(c: &mut Criterion) {
     });
 }
 
+fn bench_string_utf16_ascii(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("string_utf16_ascii_10000x", |b| {
+        b.iter(|| jvm_core::run_static_native(&bundle, "BenchStringUtf16Ascii", "run", "()I"))
+    });
+}
+
+fn bench_string_utf16_cjk(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("string_utf16_cjk_10000x", |b| {
+        b.iter(|| jvm_core::run_static_native(&bundle, "BenchStringUtf16Cjk", "run", "()I"))
+    });
+}
+
+fn bench_string_utf16_emoji(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("string_utf16_emoji_10000x", |b| {
+        b.iter(|| jvm_core::run_static_native(&bundle, "BenchStringUtf16Emoji", "run", "()I"))
+    });
+}
+
+fn bench_regex_find_ascii(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("regex_find_ascii_10000x", |b| {
+        b.iter(|| jvm_core::run_static_native(&bundle, "BenchRegexFindAscii", "run", "()I"))
+    });
+}
+
+fn bench_regex_find_cjk(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("regex_find_cjk_10000x", |b| {
+        b.iter(|| jvm_core::run_static_native(&bundle, "BenchRegexFindCjk", "run", "()I"))
+    });
+}
+
+fn bench_regex_find_emoji(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("regex_find_emoji_10000x", |b| {
+        b.iter(|| jvm_core::run_static_native(&bundle, "BenchRegexFindEmoji", "run", "()I"))
+    });
+}
+
+fn bench_regex_find_empty_emoji(c: &mut Criterion) {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    c.bench_function("regex_find_empty_emoji_10000x", |b| {
+        b.iter(|| jvm_core::run_static_native(&bundle, "BenchRegexFindEmptyEmoji", "run", "()I"))
+    });
+}
+
 /// Measures lazy JAR registration plus first execution of a class loaded from the JAR.
 fn bench_lazy_jar_load_and_run(c: &mut Criterion) {
     c.bench_function("lazy_jar_load_and_run_entry", |b| {
@@ -104,6 +153,13 @@ criterion_group!(
     bench_static_field,
     bench_string_ldc,
     bench_virtual_call,
+    bench_string_utf16_ascii,
+    bench_string_utf16_cjk,
+    bench_string_utf16_emoji,
+    bench_regex_find_ascii,
+    bench_regex_find_cjk,
+    bench_regex_find_emoji,
+    bench_regex_find_empty_emoji,
     bench_lazy_jar_load_and_run,
     bench_lazy_jar_load_and_read_resource
 );

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -45,9 +45,62 @@ pub(super) struct MethodExecInfo {
     pub access_flags: u16,
 }
 
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct RegexCacheKey {
+    pattern: String,
+    flags: i32,
+}
+
+struct RegexCache {
+    capacity: usize,
+    order: VecDeque<RegexCacheKey>,
+    entries: HashMap<RegexCacheKey, regex::Regex>,
+}
+
+impl RegexCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            order: VecDeque::new(),
+            entries: HashMap::new(),
+        }
+    }
+
+    fn compile(&mut self, pattern: &str, flags: i32) -> Option<regex::Regex> {
+        let key = RegexCacheKey {
+            pattern: pattern.to_owned(),
+            flags,
+        };
+        if let Some(regex) = self.entries.get(&key).cloned() {
+            self.touch(&key);
+            return Some(regex);
+        }
+
+        let regex = regex::Regex::new(pattern).ok()?;
+        if self.capacity != 0 {
+            while self.entries.len() >= self.capacity {
+                let Some(lru_key) = self.order.pop_front() else {
+                    break;
+                };
+                self.entries.remove(&lru_key);
+            }
+            self.order.push_back(key.clone());
+            self.entries.insert(key, regex.clone());
+        }
+        Some(regex)
+    }
+
+    fn touch(&mut self, key: &RegexCacheKey) {
+        if let Some(pos) = self.order.iter().position(|existing| existing == key) {
+            self.order.remove(pos);
+        }
+        self.order.push_back(key.clone());
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{LazyClass, Vm};
+    use super::{LazyClass, RegexCache, RegexCacheKey, Vm};
     use std::io::{Cursor, Write};
 
     fn build_misnamed_jar() -> Vec<u8> {
@@ -147,6 +200,28 @@ mod tests {
             );
         }
         assert!(vm.resolve_class("missing/Type").is_none(), "missing class must remain unresolved");
+    }
+
+    #[test]
+    fn regex_cache_evicts_least_recently_used_entry() {
+        let mut cache = RegexCache::new(2);
+        cache.compile("a", 0).expect("compile a");
+        cache.compile("b", 0).expect("compile b");
+        cache.compile("a", 0).expect("touch a");
+        cache.compile("c", 0).expect("compile c");
+
+        assert!(cache.entries.contains_key(&RegexCacheKey {
+            pattern: "a".to_owned(),
+            flags: 0,
+        }));
+        assert!(cache.entries.contains_key(&RegexCacheKey {
+            pattern: "c".to_owned(),
+            flags: 0,
+        }));
+        assert!(!cache.entries.contains_key(&RegexCacheKey {
+            pattern: "b".to_owned(),
+            flags: 0,
+        }));
     }
 
 }
@@ -479,6 +554,8 @@ pub struct Vm {
     /// Method resolution cache: (class, method_name, descriptor) → owner class name.
     /// Avoids repeated super-chain walks for the same method lookup.
     method_owner_cache: HashMap<(String, String, String), Option<String>>,
+    /// Bounded LRU cache for compiled host-side regular expressions.
+    regex_cache: RegexCache,
     /// Materialized non-class resources from loaded JARs, keyed by path.
     pub resources: HashMap<String, Vec<u8>>,
     /// Non-class resources that still point at compressed JAR entries.
@@ -511,10 +588,15 @@ impl Vm {
             scheduler: Scheduler::new(),
             monitors: HashMap::new(),
             method_owner_cache: HashMap::new(),
+            regex_cache: RegexCache::new(64),
             resources: HashMap::new(),
             pending_resources: HashMap::new(),
             jar_archives: Vec::new(),
         }
+    }
+
+    pub(super) fn compile_regex_cached(&mut self, pattern: &str, flags: i32) -> Option<regex::Regex> {
+        self.regex_cache.compile(pattern, flags)
     }
 
     fn read_jar_entry(&mut self, entry: &JarEntryRef) -> Result<Vec<u8>, String> {

--- a/jvm-core/src/interpreter/native_static.rs
+++ b/jvm-core/src/interpreter/native_static.rs
@@ -17,30 +17,21 @@ fn ends_with_unescaped_dollar(regex: &str) -> bool {
     trailing_backslashes % 2 == 0
 }
 
-/// Perform a full-string regex match as Java's `Matcher.matches()` requires.
+/// Build the host regex source for Java's full-string `Matcher.matches()` semantics.
 ///
 /// Always wraps the pattern with `^(?:...)$` to enforce full-string semantics.
 /// To avoid `^(?:^...$)$` (which breaks Rust's regex engine), a leading `^`
-/// and a trailing unescaped `$` are stripped before wrapping.  This correctly
+/// and a trailing unescaped `$` are stripped before wrapping. This correctly
 /// handles alternations like `^foo$|bar$` — the stripped form `foo$|bar` is
 /// re-anchored as `^(?:foo$|bar)$`, so `"xxbar"` no longer matches.
-pub(super) fn regex_full_match(regex: &str, input: &str) -> bool {
-    if regex == ".*" {
-        return true;
-    }
+pub(super) fn regex_full_match_source(regex: &str) -> String {
     let stripped_start = regex.strip_prefix('^').unwrap_or(regex);
     let stripped = if ends_with_unescaped_dollar(stripped_start) {
         &stripped_start[..stripped_start.len() - 1]
     } else {
         stripped_start
     };
-    let anchored = format!("^(?:{stripped})$");
-    regex::Regex::new(&anchored)
-        .map(|re| re.is_match(input))
-        .unwrap_or_else(|e| {
-            eprintln!("Unsupported regex pattern '{regex}': {e}");
-            false
-        })
+    format!("^(?:{stripped})$")
 }
 
 /// Encode a Java UTF-16 string into a Rust `String` suitable for the regex crate.
@@ -135,7 +126,17 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string_value().cloned())
                     .map(|s| regex_encode_java_string(&s).into_owned())
                     .unwrap_or_default();
-                let ok = regex_full_match(&regex, &input);
+                let ok = if regex == ".*" {
+                    true
+                } else {
+                    let anchored = regex_full_match_source(&regex);
+                    self.compile_regex_cached(&anchored, 0)
+                        .map(|re| re.is_match(&input))
+                        .unwrap_or_else(|| {
+                            eprintln!("Unsupported regex pattern '{regex}'");
+                            false
+                        })
+                };
                 Some(JValue::Int(if ok { 1 } else { 0 }))
             }
             ("java/util/regex/Matcher", "nativeMatches", "(Ljava/lang/String;Ljava/lang/String;)Z") => {
@@ -151,7 +152,17 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string_value().cloned())
                     .map(|s| regex_encode_java_string(&s).into_owned())
                     .unwrap_or_default();
-                let ok = regex_full_match(&regex, &input);
+                let ok = if regex == ".*" {
+                    true
+                } else {
+                    let anchored = regex_full_match_source(&regex);
+                    self.compile_regex_cached(&anchored, 0)
+                        .map(|re| re.is_match(&input))
+                        .unwrap_or_else(|| {
+                            eprintln!("Unsupported regex pattern '{regex}'");
+                            false
+                        })
+                };
                 Some(JValue::Int(if ok { 1 } else { 0 }))
             }
             ("java/util/Arrays", "hashCode", "([Ljava/lang/Object;)I") => {

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -7,7 +7,7 @@ use crate::heap::{JavaStringValue, JObject, JRef, JValue, NativePayload};
 
 use super::LazyClass;
 use super::descriptors::*;
-use super::native_static::regex_encode_java_string;
+use super::native_static::{regex_encode_java_string, regex_full_match_source};
 
 #[cfg(target_arch = "wasm32")]
 use super::{console_error, console_log};
@@ -671,34 +671,37 @@ impl super::Vm {
                 Some(JValue::Ref(Some(m)))
             }
             ("java/util/regex/Matcher", "matches") => {
-                let (regex, input_value) = {
+                let (regex, flags, input_value) = {
                     let mb = this.borrow();
                     // Try bytecode field names first, then native field names
                     let pattern_ref = mb.fields.get("pattern")
                         .or_else(|| mb.fields.get("__pattern"));
-                    let regex = pattern_ref
+                    let (regex, flags) = pattern_ref
                         .and_then(|v| v.as_ref())
-                        .and_then(|p| {
+                        .map(|p| {
                             let pb = p.borrow();
                             // Try bytecode field name "regex" first, then native "__regex"
-                            pb.fields.get("regex")
+                            let regex = pb.fields.get("regex")
                                 .or_else(|| pb.fields.get("__regex"))
                                 .and_then(|v| v.as_ref().cloned())
                                 .and_then(|s| s.borrow().as_java_string_value().cloned())
                                 .map(|s| regex_encode_java_string(&s).into_owned())
+                                .unwrap_or_default();
+                            let flags = pb.fields.get("__flags").map(|v| v.as_int()).unwrap_or(0);
+                            (regex, flags)
                         })
-                        .unwrap_or_default();
+                        .unwrap_or_else(|| (String::new(), 0));
                     let input = mb.fields.get("input")
                         .or_else(|| mb.fields.get("__input"))
                         .and_then(|v| v.as_ref())
                         .and_then(|s| s.borrow().as_java_string_value().cloned())
                         .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
-                    (regex, input)
+                    (regex, flags, input)
                 };
                 let input_text = regex_encode_java_string(&input_value);
                 // Use captures to extract groups
-                let anchored = format!("^(?:{regex})$");
-                let re = regex::Regex::new(&anchored).ok();
+                let anchored = regex_full_match_source(&regex);
+                let re = self.compile_regex_cached(&anchored, flags);
                 let caps = re.as_ref().and_then(|r| r.captures(input_text.as_ref()));
                 let ok = caps.is_some();
                 // Store captured groups in __groups array field + matchStart/matchEnd
@@ -736,24 +739,27 @@ impl super::Vm {
                 Some(JValue::Int(if ok { 1 } else { 0 }))
             }
             ("java/util/regex/Matcher", "find") => {
-                let (regex, input_value, search_index) = {
+                let (regex, flags, input_value, search_index) = {
                     let mb = this.borrow();
                     let pattern_ref = mb
                         .fields
                         .get("pattern")
                         .or_else(|| mb.fields.get("__pattern"));
-                    let regex = pattern_ref
+                    let (regex, flags) = pattern_ref
                         .and_then(|v| v.as_ref())
-                        .and_then(|p| {
+                        .map(|p| {
                             let pb = p.borrow();
-                            pb.fields
+                            let regex = pb.fields
                                 .get("regex")
                                 .or_else(|| pb.fields.get("__regex"))
                                 .and_then(|v| v.as_ref().cloned())
                                 .and_then(|s| s.borrow().as_java_string_value().cloned())
                                 .map(|s| regex_encode_java_string(&s).into_owned())
+                                .unwrap_or_default();
+                            let flags = pb.fields.get("__flags").map(|v| v.as_int()).unwrap_or(0);
+                            (regex, flags)
                         })
-                        .unwrap_or_default();
+                        .unwrap_or_else(|| (String::new(), 0));
                     let input = mb
                         .fields
                         .get("input")
@@ -766,7 +772,7 @@ impl super::Vm {
                         .get("searchIndex")
                         .map(|v| v.as_int().max(0) as usize)
                         .unwrap_or(0);
-                    (regex, input, search_index)
+                    (regex, flags, input, search_index)
                 };
                 let input_len = input_value.len_utf16();
 
@@ -817,7 +823,7 @@ impl super::Vm {
                 }
 
                 let input_text = regex_encode_java_string(&input_value);
-                let re = regex::Regex::new(&regex).ok();
+                let re = self.compile_regex_cached(&regex, flags);
                 let start_byte = utf16_index_to_byte_offset(input_text.as_ref(), search_index);
                 let hay = &input_text.as_ref()[start_byte..];
                 let caps = re.as_ref().and_then(|r| r.captures(hay));

--- a/jvm-core/tests/perf_guardrail_test.rs
+++ b/jvm-core/tests/perf_guardrail_test.rs
@@ -1,0 +1,85 @@
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+fn shim_bundle() -> &'static [u8] {
+    include_bytes!("../../jdk-shim/bundle.bin")
+}
+
+fn bench_bundle() -> &'static [u8] {
+    include_bytes!("../../test-classes/bench-bundle.bin")
+}
+
+fn combined_bundle(shim: &[u8], app: &[u8]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(shim.len() + app.len());
+    v.extend_from_slice(shim);
+    v.extend_from_slice(app);
+    v
+}
+
+fn run_bench_class(bundle: &[u8], class: &str) -> i32 {
+    let result = jvm_core::run_static_native(bundle, class, "run", "()I");
+    result
+        .parse::<i32>()
+        .unwrap_or_else(|e| panic!("unexpected bench result from {class}: {result:?} ({e})"))
+}
+
+fn measure(bundle: &[u8], class: &str, iterations: usize) -> Duration {
+    let mut checksum = 0i64;
+    let start = Instant::now();
+    for _ in 0..iterations {
+        checksum += i64::from(run_bench_class(bundle, class));
+    }
+    black_box(checksum);
+    start.elapsed()
+}
+
+fn assert_ratio(label: &str, numerator: Duration, denominator: Duration, max_ratio: f64) {
+    let ratio = numerator.as_secs_f64() / denominator.as_secs_f64();
+    assert!(
+        ratio <= max_ratio,
+        "{label} regressed to {ratio:.2}x (limit {max_ratio:.2}x, numerator={numerator:?}, denominator={denominator:?})"
+    );
+}
+
+#[test]
+fn utf16_perf_guardrails() {
+    let bundle = combined_bundle(shim_bundle(), bench_bundle());
+    const ITERS: usize = 6;
+
+    black_box(run_bench_class(&bundle, "BenchStringUtf16Ascii"));
+    black_box(run_bench_class(&bundle, "BenchStringUtf16Cjk"));
+    black_box(run_bench_class(&bundle, "BenchStringUtf16Emoji"));
+    black_box(run_bench_class(&bundle, "BenchRegexFindAscii"));
+    black_box(run_bench_class(&bundle, "BenchRegexFindCjk"));
+    black_box(run_bench_class(&bundle, "BenchRegexFindEmoji"));
+    black_box(run_bench_class(&bundle, "BenchRegexFindEmptyEmoji"));
+
+    let string_ascii = measure(&bundle, "BenchStringUtf16Ascii", ITERS);
+    let string_cjk = measure(&bundle, "BenchStringUtf16Cjk", ITERS);
+    let string_emoji = measure(&bundle, "BenchStringUtf16Emoji", ITERS);
+    let regex_ascii = measure(&bundle, "BenchRegexFindAscii", ITERS);
+    let regex_cjk = measure(&bundle, "BenchRegexFindCjk", ITERS);
+    let regex_emoji = measure(&bundle, "BenchRegexFindEmoji", ITERS);
+
+    black_box(measure(&bundle, "BenchRegexFindEmptyEmoji", ITERS));
+
+    assert_ratio("string_utf16_cjk / string_utf16_ascii", string_cjk, string_ascii, 6.0);
+    assert_ratio(
+        "regex_find_cjk / regex_find_ascii",
+        regex_cjk,
+        regex_ascii,
+        6.0,
+    );
+    assert_ratio(
+        "string_utf16_emoji / string_utf16_ascii",
+        string_emoji,
+        string_ascii,
+        12.0,
+    );
+    assert_ratio(
+        "regex_find_emoji / regex_find_ascii",
+        regex_emoji,
+        regex_ascii,
+        12.0,
+    );
+}

--- a/test-sources/bench/BenchRegexFindAscii.java
+++ b/test-sources/bench/BenchRegexFindAscii.java
@@ -1,0 +1,17 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class BenchRegexFindAscii {
+    static int run() {
+        Pattern p = Pattern.compile("needle");
+        int sum = 0;
+        for (int i = 0; i < 10000; i++) {
+            Matcher m = p.matcher("prefix-needle-suffix");
+            if (m.find()) {
+                sum += m.start();
+                sum += m.end();
+            }
+        }
+        return sum;
+    }
+}

--- a/test-sources/bench/BenchRegexFindCjk.java
+++ b/test-sources/bench/BenchRegexFindCjk.java
@@ -1,0 +1,17 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class BenchRegexFindCjk {
+    static int run() {
+        Pattern p = Pattern.compile("\uD55C\u4E2D");
+        int sum = 0;
+        for (int i = 0; i < 10000; i++) {
+            Matcher m = p.matcher("\u6F22\u3042\uD55C\u4E2D\u6587");
+            if (m.find()) {
+                sum += m.start();
+                sum += m.end();
+            }
+        }
+        return sum;
+    }
+}

--- a/test-sources/bench/BenchRegexFindEmoji.java
+++ b/test-sources/bench/BenchRegexFindEmoji.java
@@ -1,0 +1,17 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class BenchRegexFindEmoji {
+    static int run() {
+        Pattern p = Pattern.compile("\uD83D\uDE00");
+        int sum = 0;
+        for (int i = 0; i < 10000; i++) {
+            Matcher m = p.matcher("a\uD83D\uDE00b\uD83D\uDE00c");
+            if (m.find()) {
+                sum += m.start();
+                sum += m.end();
+            }
+        }
+        return sum;
+    }
+}

--- a/test-sources/bench/BenchRegexFindEmptyEmoji.java
+++ b/test-sources/bench/BenchRegexFindEmptyEmoji.java
@@ -1,0 +1,17 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class BenchRegexFindEmptyEmoji {
+    static int run() {
+        Pattern p = Pattern.compile("");
+        int sum = 0;
+        for (int i = 0; i < 10000; i++) {
+            Matcher m = p.matcher("\uD83D\uDE00");
+            while (m.find()) {
+                sum += m.start();
+                sum += m.end();
+            }
+        }
+        return sum;
+    }
+}

--- a/test-sources/bench/BenchStringUtf16Ascii.java
+++ b/test-sources/bench/BenchStringUtf16Ascii.java
@@ -1,0 +1,14 @@
+class BenchStringUtf16Ascii {
+    static int run() {
+        String s = "alphabet-soup";
+        int sum = 0;
+        for (int i = 0; i < 10000; i++) {
+            sum += s.length();
+            sum += s.charAt(3);
+            sum += s.substring(2, 5).length();
+            sum += s.indexOf("bet");
+            sum += s.lastIndexOf('o');
+        }
+        return sum;
+    }
+}

--- a/test-sources/bench/BenchStringUtf16Cjk.java
+++ b/test-sources/bench/BenchStringUtf16Cjk.java
@@ -1,0 +1,14 @@
+class BenchStringUtf16Cjk {
+    static int run() {
+        String s = "\u6F22\u3042\uD55C\u4E2D\u6587";
+        int sum = 0;
+        for (int i = 0; i < 10000; i++) {
+            sum += s.length();
+            sum += s.charAt(2);
+            sum += s.substring(1, 4).length();
+            sum += s.indexOf("\uD55C");
+            sum += s.lastIndexOf('\u6587');
+        }
+        return sum;
+    }
+}

--- a/test-sources/bench/BenchStringUtf16Emoji.java
+++ b/test-sources/bench/BenchStringUtf16Emoji.java
@@ -1,0 +1,15 @@
+class BenchStringUtf16Emoji {
+    static int run() {
+        String s = "a\uD83D\uDE00b\uD83D\uDE00c";
+        int sum = 0;
+        for (int i = 0; i < 10000; i++) {
+            sum += s.length();
+            sum += s.charAt(1);
+            sum += s.charAt(2);
+            sum += s.substring(1, 3).length();
+            sum += s.indexOf("\uD83D\uDE00");
+            sum += s.lastIndexOf('c');
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
Depends on #78
Stack: #78 -> #79

## Background

After the UTF-16 correctness work, regex-heavy paths were still paying repeated host-side `Regex::new(...)` cost on every `Matcher.find()` / `Matcher.matches()` call.

This follow-up keeps correctness unchanged and focuses only on recovering that performance cost.

## What changed

- add a bounded per-VM LRU cache for compiled regexes
- key the cache by compiled regex source plus flags
- route `Pattern.matches`, `Matcher.nativeMatches`, `Matcher.matches`, and `Matcher.find` through the cache
- add benchmark fixtures and Criterion coverage for UTF-16 string and regex paths
- add a release-mode perf guardrail test
- document the benchmark/guardrail workflow

## Why the cache is bounded

The VM can be long-lived, so this is deliberately not an unbounded global cache.

The implementation uses a fixed-size per-VM LRU with a 64-entry cap so memory usage does not grow without bound.

## Evidence

Median benchmark results after this change versus the previous correctness-only branch:

- `regex_find_ascii_10000x`: `144.46 ms -> 109.41 ms`
- `regex_find_cjk_10000x`: `140.07 ms -> 106.69 ms`
- `regex_find_emoji_10000x`: `132.97 ms -> 104.80 ms`
- `regex_find_empty_emoji_10000x`: `192.10 ms -> 184.66 ms`

## Validation

- `docker-compose run --rm rust cargo test --package jvm-core regex_cache_evicts_least_recently_used_entry`
- `docker-compose run --rm rust cargo test --package jvm-core --test integration_test`
- `docker-compose run --rm rust cargo test --release --package jvm-core --test perf_guardrail_test`
- `docker-compose run --rm rust cargo bench --package jvm-core --bench interpreter -- 'string_utf16_(ascii|cjk|emoji)_10000x|regex_find_(ascii|cjk|emoji|empty_emoji)_10000x'`

## Base branch note

This PR logically depends on #78.

Because the parent branch is not writable in `kawasima/199xVM`, this upstream-visible replacement PR temporarily targets `develop` instead of the parent branch.
