### PR TITLE
perf: borrow method and class refs from constant pool

### DIFF
--- a/jvm-core/src/interpreter/bytecode.rs
+++ b/jvm-core/src/interpreter/bytecode.rs
@@ -54,8 +54,8 @@ impl Vm {
                 return Some((entry.handler_pc as usize, exc_obj));
             }
             // Resolve catch_type to class name and check if exception is instance.
-            let catch_class = resolve_class_name(cp, entry.catch_type);
-            if exc_class == catch_class || self.is_instance_of(exc_class, &catch_class) {
+            let catch_class = resolve_class_name_ref(cp, entry.catch_type);
+            if exc_class == catch_class || self.is_instance_of(exc_class, catch_class) {
                 let exc_obj = self.take_or_create_exception(exc_class, err_msg);
                 return Some((entry.handler_pc as usize, exc_obj));
             }
@@ -802,20 +802,20 @@ impl Vm {
                 // ---- Object creation ----
                 0xbb => { // new
                     let idx = read_u16(code, &mut frame.pc);
-                    let new_class = resolve_class_name(cp, idx);
+                    let new_class = resolve_class_name_ref(cp, idx);
                     // Run <clinit> for the class being instantiated.
-                    self.ensure_class_init(&new_class)?;
+                    self.ensure_class_init(new_class)?;
                     // A ParseError entry means the class was registered but malformed —
                     // surface consistently as ClassFormatError (same as Class.forName0 path).
-                    if matches!(self.classes.get(&new_class), Some(super::LazyClass::ParseError(_))) {
-                        self.throw_class_format_error(&new_class);
+                    if matches!(self.classes.get(new_class), Some(super::LazyClass::ParseError(_))) {
+                        self.throw_class_format_error(new_class);
                         return Err(format!("java/lang/ClassFormatError: malformed class file for {new_class}"));
                     }
-                    let obj = if self.get_class(&new_class).is_some() {
+                    let obj = if self.get_class(new_class).is_some() {
                         // Class is loaded (bytecode available) — use plain object.
                         JObject::new(new_class)
                     } else {
-                        match new_class.as_str() {
+                        match new_class {
                             // JDK collection types backed by Array payload (no shim loaded).
                             "java/util/ArrayList" | "java/util/LinkedList" =>
                                 JObject::new_array(new_class, vec![]),
@@ -846,7 +846,7 @@ impl Vm {
                 }
                 0xbd => { // anewarray
                     let idx = read_u16(code, &mut frame.pc);
-                    let elem_class = resolve_class_name(cp, idx);
+                    let elem_class = resolve_class_name_ref(cp, idx);
                     let count_int = frame.stack.pop().unwrap().as_int();
                     if count_int < 0 {
                         return Err(format!("java/lang/NegativeArraySizeException: {count_int}"));
@@ -862,7 +862,7 @@ impl Vm {
                     let idx = read_u16(code, &mut frame.pc);
                     let dimensions = code[frame.pc] as usize;
                     frame.pc += 1;
-                    let class_name_str = resolve_class_name(cp, idx);
+                    let class_name_str = resolve_class_name_ref(cp, idx);
                     let mut dim_sizes = Vec::with_capacity(dimensions);
                     for _ in 0..dimensions {
                         let n = frame.stack.pop().unwrap().as_int();
@@ -872,7 +872,7 @@ impl Vm {
                         dim_sizes.push(n as usize);
                     }
                     dim_sizes.reverse();
-                    let arr = self.create_multi_array(&class_name_str, &dim_sizes, 0);
+                    let arr = self.create_multi_array(class_name_str, &dim_sizes, 0);
                     frame.stack.push(JValue::Ref(Some(arr)));
                 }
                 0xbe => { // arraylength
@@ -893,7 +893,7 @@ impl Vm {
                 // ---- instanceof / checkcast ----
                 0xc0 => { // checkcast — per JVMS §6.5.checkcast
                     let idx = read_u16(code, &mut frame.pc);
-                    let target_class = resolve_class_name(cp, idx);
+                    let target_class = resolve_class_name_ref(cp, idx);
                     // Peek at top of stack (don't pop — value stays if check passes).
                     let obj = frame.stack.last()
                         .ok_or_else(|| "checkcast: empty stack".to_owned())?;
@@ -901,7 +901,7 @@ impl Vm {
                         None => {} // null passes checkcast
                         Some(r) => {
                             let cn = r.borrow().class_name.clone();
-                            if !self.is_instance_of(&cn, &target_class) {
+                            if !self.is_instance_of(&cn, target_class) {
                                 return Err(format!(
                                     "ClassCastException: {} cannot be cast to {}",
                                     cn.replace('/', "."),
@@ -913,13 +913,13 @@ impl Vm {
                 }
                 0xc1 => { // instanceof
                     let idx = read_u16(code, &mut frame.pc);
-                    let target_class = resolve_class_name(cp, idx);
+                    let target_class = resolve_class_name_ref(cp, idx);
                     let obj = frame.stack.pop().unwrap();
                     let is_instance = match obj.as_ref() {
                         None => false,
                         Some(r) => {
                             let cn = r.borrow().class_name.clone();
-                            self.is_instance_of(&cn, &target_class)
+                            self.is_instance_of(&cn, target_class)
                         }
                     };
                     frame.stack.push(JValue::Int(is_instance as i32));
@@ -1030,8 +1030,8 @@ impl Vm {
             }
             ConstantPoolEntry::Class { name_index } => {
                 let name = match &cp[*name_index as usize] {
-                    ConstantPoolEntry::Utf8(s) => s.clone(),
-                    _ => String::new(),
+                    ConstantPoolEntry::Utf8(s) => s.as_str(),
+                    _ => "",
                 };
                 let obj = self.class_object(name);
                 frame.stack.push(JValue::Ref(Some(obj)));

--- a/jvm-core/src/interpreter/descriptors.rs
+++ b/jvm-core/src/interpreter/descriptors.rs
@@ -82,8 +82,8 @@ pub(super) fn resolve_class_name_ref<'a>(cp: &'a [ConstantPoolEntry], idx: u16) 
 
 #[allow(dead_code)]
 pub(super) fn resolve_methodref(cp: &[ConstantPoolEntry], idx: u16) -> (String, String, String) {
-    let (a, b, c) = resolve_methodref_ref(cp, idx);
-    (a.to_owned(), b.to_owned(), c.to_owned())
+    let (class_name, name, desc) = resolve_methodref_ref(cp, idx);
+    (class_name.to_owned(), name.to_owned(), desc.to_owned())
 }
 
 pub(super) fn resolve_methodref_ref<'a>(cp: &'a [ConstantPoolEntry], idx: u16) -> (&'a str, &'a str, &'a str) {

--- a/jvm-core/src/interpreter/descriptors.rs
+++ b/jvm-core/src/interpreter/descriptors.rs
@@ -64,10 +64,6 @@ pub(super) fn read_i32(code: &[u8], pc: &mut usize) -> i32 {
 // Constant pool resolution
 // ---------------------------------------------------------------------------
 
-pub(super) fn resolve_class_name(cp: &[ConstantPoolEntry], idx: u16) -> String {
-    resolve_class_name_ref(cp, idx).to_owned()
-}
-
 pub(super) fn resolve_class_name_ref<'a>(cp: &'a [ConstantPoolEntry], idx: u16) -> &'a str {
     match &cp[idx as usize] {
         ConstantPoolEntry::Class { name_index } => {

--- a/jvm-core/src/interpreter/dispatch.rs
+++ b/jvm-core/src/interpreter/dispatch.rs
@@ -72,7 +72,6 @@ impl Vm {
         };
 
         let push_return = !desc.ends_with(")V");
-
         // Resolve method exec info once (used for both frame building and cache population).
         match self.resolve_method_exec_info(class_name, method_name, &desc) {
             Some(info) if info.has_code => {
@@ -245,7 +244,7 @@ impl Vm {
         match this_val {
             JValue::Ref(Some(r)) => {
                 let push_return = !descriptor.ends_with(")V");
-                self.dispatch_virtual_on_ref(r, &class_name, &method_name, &descriptor, args, push_return, frame)
+                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame)
             }
             JValue::Ref(None) => Err(format!("NullPointerException: invokevirtual {class_name}.{method_name}{descriptor}")),
             other => Err(format!(
@@ -378,18 +377,18 @@ impl Vm {
         let n_args = count_args(descriptor);
         let args = pop_args(frame, n_args);
 
-        let is_static = self.find_method_flags(&class_name, &method_name, &descriptor)
+        let is_static = self.find_method_flags(class_name, method_name, descriptor)
             .map(|flags| flags & 0x0008 != 0)
             .unwrap_or(false);
         if is_static {
             let push_return = !descriptor.ends_with(")V");
-            match self.build_static_frame(&class_name, &method_name, &descriptor, args.clone(), push_return)? {
+            match self.build_static_frame(class_name, method_name, descriptor, args.clone(), push_return)? {
                 Some(fi) => {
                     *self.pending_frame_mut() = Some(fi);
                     return Ok(None);
                 }
                 None => {
-                    let result = self.invoke_static(&class_name, &method_name, &descriptor, args)?;
+                    let result = self.invoke_static(class_name, method_name, descriptor, args)?;
                     if !matches!(result, JValue::Void) {
                         frame.stack.push(result);
                     }
@@ -402,7 +401,7 @@ impl Vm {
         match this_val {
             JValue::Ref(Some(r)) => {
                 let push_return = !descriptor.ends_with(")V");
-                self.dispatch_virtual_on_ref(r, &class_name, &method_name, &descriptor, args, push_return, frame)
+                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame)
             }
             JValue::Ref(None) => Err(format!("NullPointerException: invokeinterface {class_name}.{method_name}{descriptor}")),
             other => Err(format!(


### PR DESCRIPTION
## Summary

Follow up the no-allocation direction from #80 by borrowing constant-pool strings on method/class reference read paths instead of cloning them into temporary `String`s.

Main changes:

- add `resolve_methodref_ref` returning `(&str, &str, &str)`
- add `resolve_class_name_ref` returning `&str`
- use borrowed method refs in `dispatch_static`, `dispatch_virtual`, `dispatch_special`, and `dispatch_interface`
- use borrowed class refs in exception handler matching, `ldc Class`, `new`, `anewarray`, `multianewarray`, `checkcast`, and `instanceof`

This PR intentionally does **not** add any caches or dispatch/lifecycle restructuring.

## Why

The goal is to keep the optimization surface as small as possible and continue the approach from #80: remove avoidable `String` allocations first, then only consider caches if they are still needed.

## Validation

- `docker-compose run --rm java make shim`
- `docker-compose run --rm java ./build-test-bundle.sh`
- `docker-compose run --rm rust cargo test --package jvm-core`
- `docker-compose run --rm rust cargo bench --package jvm-core --bench interpreter method_call_1000x`
- `docker-compose run --rm rust cargo bench --package jvm-core --bench interpreter virtual_call_1000x`
- `make clj-smoke-bundle-docker`
- `docker-compose run --rm rust cargo test --package jvm-core --test clojure_integration_test clojure_smoke -- --ignored --exact`

Observed benchmark results on this branch:

- `method_call_1000x`: `[1.2663 ms 1.2906 ms 1.3232 ms]`
- `virtual_call_1000x`: `[1.5090 ms 1.5120 ms 1.5158 ms]`
- `clojure_smoke`: passed in `44.18s`

## Context

This is intended as a smaller perf follow-up in favor of the no-allocation path, rather than continuing the larger lifecycle/cache branches.