### PR TITLE
JVMS-5 [1/3] Introduce loader-scoped lookup keys for class identity

### DIFF
--- a/jvm-core/src/interpreter/bytecode.rs
+++ b/jvm-core/src/interpreter/bytecode.rs
@@ -1,5 +1,5 @@
 
-use crate::class_file::{BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry};
+use crate::class_file::{Attribute, BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry};
 use crate::heap::{JObject, JValue, NativePayload};
 
 use super::Vm;
@@ -8,6 +8,65 @@ use super::descriptors::*;
 use super::frame::*;
 
 impl Vm {
+    fn normalize_exception_class_head<'a>(raw: &'a str) -> &'a str {
+        let head = raw
+            .split(" | ")
+            .next()
+            .unwrap_or(raw)
+            .trim();
+        head
+            .split(": ")
+            .next()
+            .unwrap_or(head)
+            .split(" at ")
+            .next()
+            .unwrap_or(head)
+            .trim()
+    }
+
+    fn exception_class_from_err_msg<'a>(err_msg: &'a str) -> &'a str {
+        if err_msg.starts_with("java/") || err_msg.starts_with("javax/") {
+            return Self::normalize_exception_class_head(err_msg);
+        }
+        if let Some(rest) = err_msg.strip_prefix("Exception: ") {
+            return Self::normalize_exception_class_head(rest);
+        }
+        if err_msg.starts_with("NullPointerException") {
+            return "java/lang/NullPointerException";
+        }
+        if err_msg.starts_with("ClassCastException") {
+            return "java/lang/ClassCastException";
+        }
+        if err_msg.contains("ArithmeticException") {
+            return "java/lang/ArithmeticException";
+        }
+        if err_msg.contains("StackOverflowError") {
+            return "java/lang/StackOverflowError";
+        }
+        if err_msg.starts_with("UnsupportedOperationException") {
+            return "java/lang/UnsupportedOperationException";
+        }
+        if err_msg.contains("IndexOutOfBoundsException") {
+            return "java/lang/IndexOutOfBoundsException";
+        }
+        // Last resort: keep execution flowing through catch(Exception).
+        "java/lang/RuntimeException"
+    }
+
+    pub(super) fn ensure_pending_exception_from_err(&mut self, err_msg: &str) {
+        if self.scheduler.current_thread().pending_exception.is_some() {
+            return;
+        }
+        let exc_class = Self::exception_class_from_err_msg(err_msg);
+        // Strip "Exception: <class>: " prefix when present.
+        let msg_str = err_msg
+            .strip_prefix("Exception: ")
+            .and_then(|s| s.find(": ").map(|i| &s[i + 2..]))
+            .unwrap_or(err_msg);
+        let exc = self.new_vm_exception(exc_class, Some(JObject::new_string(msg_str)));
+        *self.pending_exception_mut() = Some(exc);
+    }
+
     /// Search exception_table for a matching handler.
     /// Returns (handler_pc, exception_object) if found.
     pub(crate) fn find_exception_handler(
@@ -20,27 +79,7 @@ impl Vm {
     ) -> Option<(usize, JValue)> {
         // Extract exception class name from error message.
         // Preferred format: "java/lang/SomeException: message" — extract the class name directly.
-        let exc_class = if err_msg.starts_with("java/") || err_msg.starts_with("javax/") {
-            err_msg.split(':').next().unwrap_or(err_msg).trim()
-        } else if let Some(rest) = err_msg.strip_prefix("Exception: ") {
-            rest.split(':').next().unwrap_or(rest).trim()
-        } else if err_msg.starts_with("NullPointerException") {
-            "java/lang/NullPointerException"
-        } else if err_msg.starts_with("ClassCastException") {
-            "java/lang/ClassCastException"
-        } else if err_msg.contains("ArithmeticException") {
-            "java/lang/ArithmeticException"
-        } else if err_msg.contains("StackOverflowError") {
-            "java/lang/StackOverflowError"
-        } else if err_msg.starts_with("UnsupportedOperationException") {
-            "java/lang/UnsupportedOperationException"
-        } else if err_msg.contains("IndexOutOfBoundsException") {
-            "java/lang/IndexOutOfBoundsException"
-        } else {
-            // Last resort: treat any error as java/lang/RuntimeException so
-            // catch(Exception e) / catch-all can still handle it.
-            "java/lang/RuntimeException"
-        };
+        let exc_class = Self::exception_class_from_err_msg(err_msg);
 
         for entry in exception_table {
             let start = entry.start_pc as usize;
@@ -50,13 +89,13 @@ impl Vm {
             }
             // catch_type == 0 means catch-all (finally).
             if entry.catch_type == 0 {
-                let exc_obj = self.take_or_create_exception(exc_class, err_msg);
+                let exc_obj = self.take_or_create_exception(err_msg);
                 return Some((entry.handler_pc as usize, exc_obj));
             }
             // Resolve catch_type to class name and check if exception is instance.
             let catch_class = resolve_class_name_ref(cp, entry.catch_type);
             if exc_class == catch_class || self.is_instance_of(exc_class, catch_class) {
-                let exc_obj = self.take_or_create_exception(exc_class, err_msg);
+                let exc_obj = self.take_or_create_exception(err_msg);
                 return Some((entry.handler_pc as usize, exc_obj));
             }
         }
@@ -66,21 +105,12 @@ impl Vm {
     }
 
     /// Take the pending exception object if set, or create a new one.
-    fn take_or_create_exception(&mut self, exc_class: &str, err_msg: &str) -> JValue {
+    fn take_or_create_exception(&mut self, err_msg: &str) -> JValue {
         if let Some(r) = self.pending_exception_mut().take() {
             JValue::Ref(Some(r))
         } else {
-            // Store the error message in a "detailMessage" field (matches JDK Throwable).
-            // Strip the "Exception: classname" prefix to get just the meaningful message.
-            let msg_str = err_msg.strip_prefix("Exception: ")
-                .and_then(|s| {
-                    // After stripping "Exception: ", the remainder is class name.
-                    // If there's a ": " after the class name, extract the actual message.
-                    s.find(": ").map(|i| &s[i + 2..])
-                })
-                .unwrap_or(err_msg);
-            let exc = self.new_vm_exception(exc_class, Some(JObject::new_string(msg_str)));
-            JValue::Ref(Some(exc))
+            self.ensure_pending_exception_from_err(err_msg);
+            JValue::Ref(self.pending_exception_mut().take())
         }
     }
 
@@ -158,10 +188,17 @@ impl Vm {
                     let arr_ref = frame.stack.pop().unwrap();
                     let idx = array_index(idx_i)?;
                     if let Some(r) = arr_ref.as_ref() {
-                        let elem = match &r.borrow().native {
-                            NativePayload::Array(v) => v.get(idx).cloned()
+                        let arr = r.borrow();
+                        if !arr.class_name.starts_with('[') {
+                            return Err("java/lang/ArrayStoreException: aaload on non-array".to_owned());
+                        }
+                        let elem = match &arr.native {
+                            NativePayload::Array(v) => v.get(idx)
+                                .cloned()
                                 .ok_or_else(|| array_oob(idx_i))?,
-                            _ => JValue::Ref(None),
+                            _ => {
+                                return Err("java/lang/ArrayStoreException: aaload on non-reference array".to_owned());
+                            }
                         };
                         frame.stack.push(elem);
                     } else {
@@ -177,9 +214,11 @@ impl Vm {
                             NativePayload::ByteArray(v) => JValue::Int(
                                 *v.get(idx).ok_or_else(|| array_oob(idx_i))? as i32
                             ),
-                            NativePayload::Array(v) => JValue::Int(
-                                v.get(idx).ok_or_else(|| array_oob(idx_i))?.as_int() as i8 as i32
-                            ),
+                            NativePayload::Array(v) => {
+                                let raw = v.get(idx).ok_or_else(|| array_oob(idx_i))?.clone();
+                                let narrowed = self.adapt_value_for_descriptor("B", raw).as_int() as i8 as i32;
+                                JValue::Int(narrowed)
+                            }
                             _ => JValue::Int(0),
                         };
                         frame.stack.push(elem);
@@ -249,6 +288,61 @@ impl Vm {
                     match arr_ref.as_ref() {
                         None => return Err("NullPointerException: aastore".to_owned()),
                         Some(r) => {
+                            let (arr_class, arr_len, is_ref_array) = {
+                                let arr = r.borrow();
+                                let class_name = arr.class_name.clone();
+                                match &arr.native {
+                                    NativePayload::Array(v) => (class_name, v.len(), true),
+                                    NativePayload::ByteArray(v) => (class_name, v.len(), false),
+                                    NativePayload::IntArray(v) => (class_name, v.len(), false),
+                                    NativePayload::LongArray(v) => (class_name, v.len(), false),
+                                    _ => (class_name, 0usize, false),
+                                }
+                            };
+                            if !arr_class.starts_with('[') {
+                                return Err("java/lang/ArrayStoreException: aastore on non-array".to_owned());
+                            }
+                            if !is_ref_array {
+                                return Err("java/lang/ArrayStoreException: aastore on primitive array".to_owned());
+                            }
+                            if idx >= arr_len {
+                                return Err(array_oob(idx_i));
+                            }
+
+                            // Reference arrays require runtime assignability checks.
+                            let component_class = if arr_class.starts_with("[L") {
+                                Some(
+                                    arr_class
+                                        .strip_prefix("[L")
+                                        .and_then(|s| s.strip_suffix(';'))
+                                        .unwrap_or("java/lang/Object")
+                                        .to_owned(),
+                                )
+                            } else if arr_class.starts_with("[[") {
+                                // Component is itself an array descriptor (e.g. [Ljava/lang/String;).
+                                descriptor_to_class_name(&arr_class[1..])
+                            } else {
+                                None
+                            };
+                            if let Some(component) = component_class {
+                                match &val {
+                                    JValue::Ref(None) => {}
+                                    JValue::Ref(Some(obj)) => {
+                                        let runtime = obj.borrow().class_name.clone();
+                                        if !self.is_instance_of(&runtime, &component) {
+                                            return Err(format!(
+                                                "java/lang/ArrayStoreException: {} into {}",
+                                                runtime.replace('/', "."),
+                                                component.replace('/', ".")
+                                            ));
+                                        }
+                                    }
+                                    _ => {
+                                        return Err("java/lang/ArrayStoreException: primitive into reference array".to_owned());
+                                    }
+                                }
+                            }
+
                             if let NativePayload::Array(ref mut v) = r.borrow_mut().native {
                                 *v.get_mut(idx).ok_or_else(|| array_oob(idx_i))? = val;
                             }
@@ -677,29 +771,39 @@ impl Vm {
                 // ---- Field access ----
                 0xb2 => { // getstatic
                     let idx = read_u16(code, &mut frame.pc);
-                    // Fast path: check cpCache for resolved field.
-                    let cached_val = {
+                    // Fast path: check cpCache for resolved field metadata.
+                    let cached_field = {
                         let cb = cache.borrow();
                         if let Some(Some(CpCacheEntry::Field(e))) = cb.get(idx as usize) {
-                            let v = self.static_fields.get(&e.owner_class)
-                                .and_then(|m| m.get(&e.field_name))
-                                .cloned()
-                                .unwrap_or_else(|| default_value_for_descriptor(&e.field_descriptor));
-                            Some(v)
+                            Some((e.owner_class.clone(), e.field_name.clone()))
                         } else {
                             None
                         }
                     };
-                    if let Some(v) = cached_val {
-                        frame.stack.push(v);
+                    if let Some((owner, field)) = cached_field {
+                        // getstatic triggers class initialization (JVMS §5.5),
+                        // even when the field reference is already cached.
+                        self.ensure_class_init(&owner)?;
+                        if let Some(v) = self.static_fields.get(&owner).and_then(|m| m.get(&field)).cloned() {
+                            frame.stack.push(v);
+                        } else {
+                            // Cached metadata can exist before a value is materialized
+                            // (for example during initialization edge cases); resolve
+                            // through the slow path instead of returning descriptor default.
+                            let v = self.resolve_static_field(cp, idx, class_name)?;
+                            frame.stack.push(v);
+                        }
                     } else {
                         // Slow path: resolve, push, then populate cache.
-                        let v = self.resolve_static_field(cp, idx)?;
+                        let v = self.resolve_static_field(cp, idx, class_name)?;
                         frame.stack.push(v.clone());
                         // Populate cache with the resolved field owner.
-                        let (cn, fn_, fd) = resolve_fieldref_ref(cp, idx);
-                        let owner = self.find_static_field_owner_class(cn, fn_)
-                            .unwrap_or_else(|| cn.to_owned());
+                        let (declared_owner, fn_, fd) = resolve_fieldref_ref(cp, idx);
+                        let mapped_owner =
+                            self.remap_static_owner_for_field_access(class_name, declared_owner);
+                        let owner = self
+                            .find_static_field_owner_class(&mapped_owner, fn_)
+                            .unwrap_or(mapped_owner);
                         cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
                             ResolvedFieldEntry {
                                 owner_class: owner,
@@ -723,16 +827,35 @@ impl Vm {
                         }
                     };
                     if let Some((owner, field)) = cached {
+                        self.check_final_static_field_write(&owner, &field, None, class_name)?;
+                        // putstatic also triggers initialization of the declaring class.
+                        self.ensure_class_init(&owner)?;
                         self.static_fields.entry(owner).or_default().insert(field, val);
                     } else {
                         // Slow path.
-                        let (cls, fld, fd) = resolve_fieldref_ref(cp, idx);
-                        self.ensure_class_init(cls)?;
-                        self.static_fields.entry(cls.to_owned()).or_default().insert(fld.to_owned(), val);
+                        let (declared_owner, fld, fd) = resolve_fieldref_ref(cp, idx);
+                        let mapped_owner =
+                            self.remap_static_owner_for_field_access(class_name, declared_owner);
+                        let resolved =
+                            self.find_static_field_info(&mapped_owner, fld, Some(fd));
+                        let owner = resolved
+                            .as_ref()
+                            .map(|(owner, _)| owner.clone())
+                            .unwrap_or(mapped_owner);
+                        if let Some((resolved_owner, access_flags)) = resolved.as_ref() {
+                            self.check_final_static_field_write_resolved(
+                                resolved_owner,
+                                fld,
+                                *access_flags,
+                                class_name,
+                            )?;
+                        }
+                        self.ensure_class_init(&owner)?;
+                        self.static_fields.entry(owner.clone()).or_default().insert(fld.to_owned(), val);
                         // Populate cache.
                         cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
                             ResolvedFieldEntry {
-                                owner_class: cls.to_owned(),
+                                owner_class: owner,
                                 field_name: fld.to_owned(),
                                 field_descriptor: fd.to_owned(),
                             }
@@ -749,7 +872,7 @@ impl Vm {
                             "getfield {gf_field_name}: expected Ref on stack, got Void in {class_name}"
                         ));
                     }
-                    let v = self.resolve_instance_field(cp, idx, &obj_ref)?;
+                    let v = self.resolve_instance_field(cp, cache, idx, &obj_ref)?;
                     frame.stack.push(v);
                 }
                 0xb5 => { // putfield
@@ -762,7 +885,7 @@ impl Vm {
                             "putfield {pf_field_name}: expected Ref on stack, got Void in {class_name}"
                         ));
                     }
-                    self.set_instance_field(cp, idx, &obj_ref, val)?;
+                    self.set_instance_field(cp, cache, idx, &obj_ref, val)?;
                 }
 
                 // ---- Method invocation ----
@@ -771,7 +894,7 @@ impl Vm {
                 //   (b) execute native inline and push the result onto frame.stack.
                 0xb6 => { // invokevirtual
                     let idx = read_u16(code, &mut frame.pc);
-                    self.dispatch_virtual(cp, idx, frame).map_err(|e| {
+                    self.dispatch_virtual(cp, cache, idx, frame).map_err(|e| {
                         if e.starts_with("NullPointerException") { format!("{e} in {class_name}") } else { e }
                     })?;
                 }
@@ -783,12 +906,12 @@ impl Vm {
                 }
                 0xb8 => { // invokestatic
                     let idx = read_u16(code, &mut frame.pc);
-                    self.dispatch_static(cp, cache, idx, frame)?;
+                    self.dispatch_static(cp, cache, idx, class_name, frame)?;
                 }
                 0xb9 => { // invokeinterface
                     let idx = read_u16(code, &mut frame.pc);
                     frame.pc += 2; // count + 0
-                    self.dispatch_interface(cp, idx, frame).map_err(|e| {
+                    self.dispatch_interface(cp, cache, idx, frame).map_err(|e| {
                         if e.starts_with("NullPointerException") { format!("{e} in {class_name}") } else { e }
                     })?;
                 }
@@ -802,26 +925,37 @@ impl Vm {
                 // ---- Object creation ----
                 0xbb => { // new
                     let idx = read_u16(code, &mut frame.pc);
-                    let new_class = resolve_class_name_ref(cp, idx);
+                    let declared_class = resolve_class_name_ref(cp, idx);
+                    let mapped_new_class = self.remap_declared_class_for_context(class_name, declared_class);
                     // Run <clinit> for the class being instantiated.
-                    self.ensure_class_init(new_class)?;
+                    self.ensure_class_init(&mapped_new_class)?;
                     // A ParseError entry means the class was registered but malformed —
                     // surface consistently as ClassFormatError (same as Class.forName0 path).
-                    if matches!(self.classes.get(new_class), Some(super::LazyClass::ParseError(_))) {
-                        self.throw_class_format_error(new_class);
-                        return Err(format!("java/lang/ClassFormatError: malformed class file for {new_class}"));
+                    if matches!(self.classes.get(&mapped_new_class), Some(super::LazyClass::ParseError(_))) {
+                        self.throw_class_format_error(&mapped_new_class);
+                        return Err(format!(
+                            "java/lang/ClassFormatError: malformed class file for {mapped_new_class}"
+                        ));
                     }
-                    let obj = if self.get_class(new_class).is_some() {
+                    let obj = if self.get_class(&mapped_new_class).is_some() {
                         // Class is loaded (bytecode available) — use plain object.
-                        JObject::new(new_class)
+                        JObject::new(mapped_new_class.clone())
                     } else {
-                        match new_class {
+                        match mapped_new_class.as_str() {
                             // JDK collection types backed by Array payload (no shim loaded).
                             "java/util/ArrayList" | "java/util/LinkedList" =>
-                                JObject::new_array(new_class, vec![]),
-                            _ => JObject::new(new_class),
+                                JObject::new_array(mapped_new_class.clone(), vec![]),
+                            _ => JObject::new(mapped_new_class.clone()),
                         }
                     };
+                    if self.dynamically_defined_classes.contains(&mapped_new_class) {
+                        if let Some(mut class_file) = self.get_class(&mapped_new_class).cloned() {
+                            class_file.constant_pool.cache = std::rc::Rc::new(std::cell::RefCell::new(
+                                vec![None; class_file.constant_pool.entries.len()],
+                            ));
+                            obj.borrow_mut().class_snapshot = Some(class_file);
+                        }
+                    }
                     frame.stack.push(JValue::Ref(Some(obj)));
                 }
                 0xbc => { // newarray
@@ -893,7 +1027,9 @@ impl Vm {
                 // ---- instanceof / checkcast ----
                 0xc0 => { // checkcast — per JVMS §6.5.checkcast
                     let idx = read_u16(code, &mut frame.pc);
-                    let target_class = resolve_class_name_ref(cp, idx);
+                    let declared_target = resolve_class_name_ref(cp, idx);
+                    let target_class =
+                        self.remap_declared_class_for_context(class_name, declared_target);
                     // Peek at top of stack (don't pop — value stays if check passes).
                     let obj = frame.stack.last()
                         .ok_or_else(|| "checkcast: empty stack".to_owned())?;
@@ -901,7 +1037,7 @@ impl Vm {
                         None => {} // null passes checkcast
                         Some(r) => {
                             let cn = r.borrow().class_name.clone();
-                            if !self.is_instance_of(&cn, target_class) {
+                            if !self.is_instance_of(&cn, &target_class) {
                                 return Err(format!(
                                     "ClassCastException: {} cannot be cast to {}",
                                     cn.replace('/', "."),
@@ -913,13 +1049,15 @@ impl Vm {
                 }
                 0xc1 => { // instanceof
                     let idx = read_u16(code, &mut frame.pc);
-                    let target_class = resolve_class_name_ref(cp, idx);
+                    let declared_target = resolve_class_name_ref(cp, idx);
+                    let target_class =
+                        self.remap_declared_class_for_context(class_name, declared_target);
                     let obj = frame.stack.pop().unwrap();
                     let is_instance = match obj.as_ref() {
                         None => false,
                         Some(r) => {
                             let cn = r.borrow().class_name.clone();
-                            self.is_instance_of(&cn, target_class)
+                            self.is_instance_of(&cn, &target_class)
                         }
                     };
                     frame.stack.push(JValue::Int(is_instance as i32));
@@ -1047,12 +1185,20 @@ impl Vm {
         &mut self,
         cp: &[ConstantPoolEntry],
         idx: u16,
+        frame_owner: &str,
     ) -> Result<JValue, String> {
-        let (class_name, field_name, descriptor) = resolve_fieldref_ref(cp, idx);
+        let (declared_class_name, field_name, descriptor) = resolve_fieldref_ref(cp, idx);
+        let class_name_owned =
+            self.remap_static_owner_for_field_access(frame_owner, declared_class_name);
+        let class_name = class_name_owned.as_str();
         // Run <clinit> if not yet done (initialises static fields via putstatic).
         self.ensure_class_init(class_name)?;
         // Search this class and its super-class chain for the static field (JVMS §5.4.3.2).
         if let Some(v) = self.resolve_static_field_in_hierarchy(class_name, field_name) {
+            return Ok(v);
+        }
+        // Some static finals are materialized via ConstantValue rather than <clinit>.
+        if let Some(v) = self.resolve_constant_value_static_field(class_name, field_name) {
             return Ok(v);
         }
         // Well-known JDK static fields that cannot be initialised via <clinit>
@@ -1091,8 +1237,97 @@ impl Vm {
         }
     }
 
+    fn remap_static_owner_for_field_access(
+        &self,
+        frame_owner: &str,
+        declared_class_name: &str,
+    ) -> String {
+        let Some(current_class) = Self::parse_frame_owner_for_field_access(frame_owner) else {
+            return declared_class_name.to_owned();
+        };
+        if self.class_binary_name_for_lookup(current_class) == declared_class_name {
+            return current_class.to_owned();
+        }
+        declared_class_name.to_owned()
+    }
+
+    pub(in crate::interpreter) fn resolve_constant_value_static_field(&mut self, class_name: &str, field_name: &str) -> Option<JValue> {
+        self.ensure_class_ready(class_name);
+        let (constant_idx, cp_entries, super_name, iface_names) = if let Some(class) = self.get_class(class_name) {
+            let constant_idx = class.fields.iter().find_map(|field| {
+                if (field.access_flags & 0x0008) == 0 {
+                    return None;
+                }
+                let name = class.constant_pool.utf8(field.name_index);
+                if name != field_name {
+                    return None;
+                }
+                field.attributes.iter().find_map(|attr| {
+                    if let Attribute::ConstantValue { constantvalue_index } = attr {
+                        Some(*constantvalue_index)
+                    } else {
+                        None
+                    }
+                })
+            });
+            let cp_entries = Some(class.constant_pool.entries.clone());
+            let sup = if class.super_class != 0 {
+                Some(class.constant_pool.class_name(class.super_class).to_owned())
+            } else {
+                None
+            };
+            let ifaces = class
+                .interfaces
+                .iter()
+                .map(|&idx| class.constant_pool.class_name(idx).to_owned())
+                .collect::<Vec<_>>();
+            (constant_idx, cp_entries, sup, ifaces)
+        } else {
+            (None, None, None, vec![])
+        };
+        let constant = match (cp_entries.as_deref(), constant_idx) {
+            (Some(cp), Some(idx)) => self.constant_value_to_jvalue(cp, idx),
+            _ => None,
+        };
+        if let Some(value) = constant {
+            self.static_fields
+                .entry(class_name.to_owned())
+                .or_default()
+                .insert(field_name.to_owned(), value.clone());
+            return Some(value);
+        }
+        if let Some(super_name) = super_name {
+            if let Some(v) = self.resolve_constant_value_static_field(&super_name, field_name) {
+                return Some(v);
+            }
+        }
+        for iface_name in iface_names {
+            if let Some(v) = self.resolve_constant_value_static_field(&iface_name, field_name) {
+                return Some(v);
+            }
+        }
+        None
+    }
+
+    fn constant_value_to_jvalue(&mut self, cp: &[ConstantPoolEntry], idx: u16) -> Option<JValue> {
+        match cp.get(idx as usize)? {
+            ConstantPoolEntry::Integer(v) => Some(JValue::Int(*v)),
+            ConstantPoolEntry::Long(v) => Some(JValue::Long(*v)),
+            ConstantPoolEntry::Float(v) => Some(JValue::Float(*v)),
+            ConstantPoolEntry::Double(v) => Some(JValue::Double(*v)),
+            ConstantPoolEntry::String { string_index } => {
+                let s = match cp.get(*string_index as usize)? {
+                    ConstantPoolEntry::Utf8(s) => s.as_str(),
+                    _ => return None,
+                };
+                Some(JValue::Ref(Some(self.intern_string(s))))
+            }
+            _ => None,
+        }
+    }
+
     /// Walk the class hierarchy to find a static field value.
-    fn resolve_static_field_in_hierarchy(&mut self, class_name: &str, field_name: &str) -> Option<JValue> {
+    pub(in crate::interpreter) fn resolve_static_field_in_hierarchy(&mut self, class_name: &str, field_name: &str) -> Option<JValue> {
         // Check this class first.
         if let Some(v) = self.static_fields.get(class_name).and_then(|m| m.get(field_name)) {
             return Some(v.clone());
@@ -1157,33 +1392,182 @@ impl Vm {
         None
     }
 
+    fn check_final_static_field_write(
+        &mut self,
+        owner: &str,
+        field_name: &str,
+        descriptor: Option<&str>,
+        current_frame_owner: &str,
+    ) -> Result<(), String> {
+        let Some((resolved_owner, access_flags)) =
+            self.find_static_field_info(owner, field_name, descriptor)
+        else {
+            return Ok(());
+        };
+        self.check_final_static_field_write_resolved(
+            &resolved_owner,
+            field_name,
+            access_flags,
+            current_frame_owner,
+        )
+    }
+
+    fn check_final_static_field_write_resolved(
+        &self,
+        resolved_owner: &str,
+        field_name: &str,
+        access_flags: u16,
+        current_frame_owner: &str,
+    ) -> Result<(), String> {
+        if (access_flags & 0x0010) == 0 {
+            return Ok(());
+        }
+        let illegal_access = || {
+            format!(
+                "java/lang/IllegalAccessError: Update to static final field {resolved_owner}.{field_name} attempted from {current_frame_owner}"
+            )
+        };
+        let Some(current_class) = Self::parse_frame_owner_for_field_access(current_frame_owner) else {
+            return Err(illegal_access());
+        };
+        if current_class == resolved_owner {
+            return Ok(());
+        }
+        Err(illegal_access())
+    }
+
+    fn find_static_field_info(
+        &mut self,
+        class_name: &str,
+        field_name: &str,
+        descriptor: Option<&str>,
+    ) -> Option<(String, u16)> {
+        self.ensure_class_ready(class_name);
+        let (found, super_name, iface_names) = if let Some(class) = self.get_class(class_name) {
+            let found = class.fields.iter().find_map(|field| {
+                if (field.access_flags & 0x0008) == 0 {
+                    return None;
+                }
+                let name = class.constant_pool.utf8(field.name_index);
+                let desc = class.constant_pool.utf8(field.descriptor_index);
+                if name == field_name && descriptor.map(|expected| expected == desc).unwrap_or(true) {
+                    Some((class_name.to_owned(), field.access_flags))
+                } else {
+                    None
+                }
+            });
+            let sup = if class.super_class != 0 {
+                Some(class.constant_pool.class_name(class.super_class).to_owned())
+            } else {
+                None
+            };
+            let ifaces = class
+                .interfaces
+                .iter()
+                .map(|&idx| class.constant_pool.class_name(idx).to_owned())
+                .collect::<Vec<_>>();
+            (found, sup, ifaces)
+        } else {
+            (None, None, vec![])
+        };
+        if found.is_some() {
+            return found;
+        }
+        if let Some(super_name) = super_name {
+            if let Some(info) = self.find_static_field_info(&super_name, field_name, descriptor) {
+                return Some(info);
+            }
+        }
+        for iface_name in iface_names {
+            if let Some(info) = self.find_static_field_info(&iface_name, field_name, descriptor) {
+                return Some(info);
+            }
+        }
+        None
+    }
+
+    fn parse_frame_owner_for_field_access(frame_owner: &str) -> Option<&str> {
+        let descriptor_start = frame_owner.find('(')?;
+        let method_sep = frame_owner[..descriptor_start].rfind('.')?;
+        Some(&frame_owner[..method_sep])
+    }
+
     fn resolve_instance_field(
         &mut self,
         cp: &[ConstantPoolEntry],
+        cache: &CpCache,
         idx: u16,
         obj_ref: &JValue,
     ) -> Result<JValue, String> {
-        let (_, field_name, field_desc) = resolve_fieldref_ref(cp, idx);
         match obj_ref.as_ref() {
             Some(r) => {
+                {
+                    let cb = cache.borrow();
+                    if let Some(Some(CpCacheEntry::Field(e))) = cb.get(idx as usize) {
+                        let default = default_value_for_descriptor(&e.field_descriptor);
+                        return Ok(r.borrow().fields.get(e.field_name.as_str()).cloned().unwrap_or(default));
+                    }
+                }
+                let (class_name, field_name, field_desc) = resolve_fieldref_ref(cp, idx);
+                cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
+                    ResolvedFieldEntry {
+                        owner_class: class_name.to_owned(),
+                        field_name: field_name.to_owned(),
+                        field_descriptor: field_desc.to_owned(),
+                    }
+                ));
                 let default = default_value_for_descriptor(field_desc);
                 Ok(r.borrow().fields.get(field_name).cloned().unwrap_or(default))
             }
-            None => Err(format!("NullPointerException: getfield {field_name}")),
+            None => {
+                let (_, field_name, _) = resolve_fieldref_ref(cp, idx);
+                Err(format!("NullPointerException: getfield {field_name}"))
+            }
         }
     }
 
     fn set_instance_field(
         &mut self,
         cp: &[ConstantPoolEntry],
+        cache: &CpCache,
         idx: u16,
         obj_ref: &JValue,
         val: JValue,
     ) -> Result<(), String> {
-        let (_, field_name, _) = resolve_fieldref_ref(cp, idx);
         match obj_ref.as_ref() {
-            Some(r) => { r.borrow_mut().fields.insert(field_name.to_owned(), val); Ok(()) }
-            None => Err(format!("NullPointerException: putfield {field_name}")),
+            Some(r) => {
+                {
+                    let cb = cache.borrow();
+                    if let Some(Some(CpCacheEntry::Field(e))) = cb.get(idx as usize) {
+                        let mut obj = r.borrow_mut();
+                        if let Some(slot) = obj.fields.get_mut(e.field_name.as_str()) {
+                            *slot = val;
+                        } else {
+                            obj.fields.insert(e.field_name.clone(), val);
+                        }
+                        return Ok(());
+                    }
+                }
+                let (class_name, field_name, field_desc) = resolve_fieldref_ref(cp, idx);
+                cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
+                    ResolvedFieldEntry {
+                        owner_class: class_name.to_owned(),
+                        field_name: field_name.to_owned(),
+                        field_descriptor: field_desc.to_owned(),
+                    }
+                ));
+                let mut obj = r.borrow_mut();
+                if let Some(slot) = obj.fields.get_mut(field_name) {
+                    *slot = val;
+                } else {
+                    obj.fields.insert(field_name.to_owned(), val);
+                }
+                Ok(())
+            }
+            None => {
+                let (_, field_name, _) = resolve_fieldref_ref(cp, idx);
+                Err(format!("NullPointerException: putfield {field_name}"))
+            }
         }
     }
 

--- a/jvm-core/src/interpreter/bytecode.rs
+++ b/jvm-core/src/interpreter/bytecode.rs
@@ -1,5 +1,5 @@
 
-use crate::class_file::{Attribute, BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry};
+use crate::class_file::{BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry};
 use crate::heap::{JObject, JValue, NativePayload};
 
 use super::Vm;
@@ -8,65 +8,6 @@ use super::descriptors::*;
 use super::frame::*;
 
 impl Vm {
-    fn normalize_exception_class_head<'a>(raw: &'a str) -> &'a str {
-        let head = raw
-            .split(" | ")
-            .next()
-            .unwrap_or(raw)
-            .trim();
-        head
-            .split(": ")
-            .next()
-            .unwrap_or(head)
-            .split(" at ")
-            .next()
-            .unwrap_or(head)
-            .trim()
-    }
-
-    fn exception_class_from_err_msg<'a>(err_msg: &'a str) -> &'a str {
-        if err_msg.starts_with("java/") || err_msg.starts_with("javax/") {
-            return Self::normalize_exception_class_head(err_msg);
-        }
-        if let Some(rest) = err_msg.strip_prefix("Exception: ") {
-            return Self::normalize_exception_class_head(rest);
-        }
-        if err_msg.starts_with("NullPointerException") {
-            return "java/lang/NullPointerException";
-        }
-        if err_msg.starts_with("ClassCastException") {
-            return "java/lang/ClassCastException";
-        }
-        if err_msg.contains("ArithmeticException") {
-            return "java/lang/ArithmeticException";
-        }
-        if err_msg.contains("StackOverflowError") {
-            return "java/lang/StackOverflowError";
-        }
-        if err_msg.starts_with("UnsupportedOperationException") {
-            return "java/lang/UnsupportedOperationException";
-        }
-        if err_msg.contains("IndexOutOfBoundsException") {
-            return "java/lang/IndexOutOfBoundsException";
-        }
-        // Last resort: keep execution flowing through catch(Exception).
-        "java/lang/RuntimeException"
-    }
-
-    pub(super) fn ensure_pending_exception_from_err(&mut self, err_msg: &str) {
-        if self.scheduler.current_thread().pending_exception.is_some() {
-            return;
-        }
-        let exc_class = Self::exception_class_from_err_msg(err_msg);
-        // Strip "Exception: <class>: " prefix when present.
-        let msg_str = err_msg
-            .strip_prefix("Exception: ")
-            .and_then(|s| s.find(": ").map(|i| &s[i + 2..]))
-            .unwrap_or(err_msg);
-        let exc = self.new_vm_exception(exc_class, Some(JObject::new_string(msg_str)));
-        *self.pending_exception_mut() = Some(exc);
-    }
-
     /// Search exception_table for a matching handler.
     /// Returns (handler_pc, exception_object) if found.
     pub(crate) fn find_exception_handler(
@@ -79,7 +20,27 @@ impl Vm {
     ) -> Option<(usize, JValue)> {
         // Extract exception class name from error message.
         // Preferred format: "java/lang/SomeException: message" — extract the class name directly.
-        let exc_class = Self::exception_class_from_err_msg(err_msg);
+        let exc_class = if err_msg.starts_with("java/") || err_msg.starts_with("javax/") {
+            err_msg.split(':').next().unwrap_or(err_msg).trim()
+        } else if let Some(rest) = err_msg.strip_prefix("Exception: ") {
+            rest.split(':').next().unwrap_or(rest).trim()
+        } else if err_msg.starts_with("NullPointerException") {
+            "java/lang/NullPointerException"
+        } else if err_msg.starts_with("ClassCastException") {
+            "java/lang/ClassCastException"
+        } else if err_msg.contains("ArithmeticException") {
+            "java/lang/ArithmeticException"
+        } else if err_msg.contains("StackOverflowError") {
+            "java/lang/StackOverflowError"
+        } else if err_msg.starts_with("UnsupportedOperationException") {
+            "java/lang/UnsupportedOperationException"
+        } else if err_msg.contains("IndexOutOfBoundsException") {
+            "java/lang/IndexOutOfBoundsException"
+        } else {
+            // Last resort: treat any error as java/lang/RuntimeException so
+            // catch(Exception e) / catch-all can still handle it.
+            "java/lang/RuntimeException"
+        };
 
         for entry in exception_table {
             let start = entry.start_pc as usize;
@@ -89,13 +50,13 @@ impl Vm {
             }
             // catch_type == 0 means catch-all (finally).
             if entry.catch_type == 0 {
-                let exc_obj = self.take_or_create_exception(err_msg);
+                let exc_obj = self.take_or_create_exception(exc_class, err_msg);
                 return Some((entry.handler_pc as usize, exc_obj));
             }
             // Resolve catch_type to class name and check if exception is instance.
             let catch_class = resolve_class_name_ref(cp, entry.catch_type);
             if exc_class == catch_class || self.is_instance_of(exc_class, catch_class) {
-                let exc_obj = self.take_or_create_exception(err_msg);
+                let exc_obj = self.take_or_create_exception(exc_class, err_msg);
                 return Some((entry.handler_pc as usize, exc_obj));
             }
         }
@@ -105,12 +66,21 @@ impl Vm {
     }
 
     /// Take the pending exception object if set, or create a new one.
-    fn take_or_create_exception(&mut self, err_msg: &str) -> JValue {
+    fn take_or_create_exception(&mut self, exc_class: &str, err_msg: &str) -> JValue {
         if let Some(r) = self.pending_exception_mut().take() {
             JValue::Ref(Some(r))
         } else {
-            self.ensure_pending_exception_from_err(err_msg);
-            JValue::Ref(self.pending_exception_mut().take())
+            // Store the error message in a "detailMessage" field (matches JDK Throwable).
+            // Strip the "Exception: classname" prefix to get just the meaningful message.
+            let msg_str = err_msg.strip_prefix("Exception: ")
+                .and_then(|s| {
+                    // After stripping "Exception: ", the remainder is class name.
+                    // If there's a ": " after the class name, extract the actual message.
+                    s.find(": ").map(|i| &s[i + 2..])
+                })
+                .unwrap_or(err_msg);
+            let exc = self.new_vm_exception(exc_class, Some(JObject::new_string(msg_str)));
+            JValue::Ref(Some(exc))
         }
     }
 
@@ -188,17 +158,10 @@ impl Vm {
                     let arr_ref = frame.stack.pop().unwrap();
                     let idx = array_index(idx_i)?;
                     if let Some(r) = arr_ref.as_ref() {
-                        let arr = r.borrow();
-                        if !arr.class_name.starts_with('[') {
-                            return Err("java/lang/ArrayStoreException: aaload on non-array".to_owned());
-                        }
-                        let elem = match &arr.native {
-                            NativePayload::Array(v) => v.get(idx)
-                                .cloned()
+                        let elem = match &r.borrow().native {
+                            NativePayload::Array(v) => v.get(idx).cloned()
                                 .ok_or_else(|| array_oob(idx_i))?,
-                            _ => {
-                                return Err("java/lang/ArrayStoreException: aaload on non-reference array".to_owned());
-                            }
+                            _ => JValue::Ref(None),
                         };
                         frame.stack.push(elem);
                     } else {
@@ -214,11 +177,9 @@ impl Vm {
                             NativePayload::ByteArray(v) => JValue::Int(
                                 *v.get(idx).ok_or_else(|| array_oob(idx_i))? as i32
                             ),
-                            NativePayload::Array(v) => {
-                                let raw = v.get(idx).ok_or_else(|| array_oob(idx_i))?.clone();
-                                let narrowed = self.adapt_value_for_descriptor("B", raw).as_int() as i8 as i32;
-                                JValue::Int(narrowed)
-                            }
+                            NativePayload::Array(v) => JValue::Int(
+                                v.get(idx).ok_or_else(|| array_oob(idx_i))?.as_int() as i8 as i32
+                            ),
                             _ => JValue::Int(0),
                         };
                         frame.stack.push(elem);
@@ -288,61 +249,6 @@ impl Vm {
                     match arr_ref.as_ref() {
                         None => return Err("NullPointerException: aastore".to_owned()),
                         Some(r) => {
-                            let (arr_class, arr_len, is_ref_array) = {
-                                let arr = r.borrow();
-                                let class_name = arr.class_name.clone();
-                                match &arr.native {
-                                    NativePayload::Array(v) => (class_name, v.len(), true),
-                                    NativePayload::ByteArray(v) => (class_name, v.len(), false),
-                                    NativePayload::IntArray(v) => (class_name, v.len(), false),
-                                    NativePayload::LongArray(v) => (class_name, v.len(), false),
-                                    _ => (class_name, 0usize, false),
-                                }
-                            };
-                            if !arr_class.starts_with('[') {
-                                return Err("java/lang/ArrayStoreException: aastore on non-array".to_owned());
-                            }
-                            if !is_ref_array {
-                                return Err("java/lang/ArrayStoreException: aastore on primitive array".to_owned());
-                            }
-                            if idx >= arr_len {
-                                return Err(array_oob(idx_i));
-                            }
-
-                            // Reference arrays require runtime assignability checks.
-                            let component_class = if arr_class.starts_with("[L") {
-                                Some(
-                                    arr_class
-                                        .strip_prefix("[L")
-                                        .and_then(|s| s.strip_suffix(';'))
-                                        .unwrap_or("java/lang/Object")
-                                        .to_owned(),
-                                )
-                            } else if arr_class.starts_with("[[") {
-                                // Component is itself an array descriptor (e.g. [Ljava/lang/String;).
-                                descriptor_to_class_name(&arr_class[1..])
-                            } else {
-                                None
-                            };
-                            if let Some(component) = component_class {
-                                match &val {
-                                    JValue::Ref(None) => {}
-                                    JValue::Ref(Some(obj)) => {
-                                        let runtime = obj.borrow().class_name.clone();
-                                        if !self.is_instance_of(&runtime, &component) {
-                                            return Err(format!(
-                                                "java/lang/ArrayStoreException: {} into {}",
-                                                runtime.replace('/', "."),
-                                                component.replace('/', ".")
-                                            ));
-                                        }
-                                    }
-                                    _ => {
-                                        return Err("java/lang/ArrayStoreException: primitive into reference array".to_owned());
-                                    }
-                                }
-                            }
-
                             if let NativePayload::Array(ref mut v) = r.borrow_mut().native {
                                 *v.get_mut(idx).ok_or_else(|| array_oob(idx_i))? = val;
                             }
@@ -771,39 +677,29 @@ impl Vm {
                 // ---- Field access ----
                 0xb2 => { // getstatic
                     let idx = read_u16(code, &mut frame.pc);
-                    // Fast path: check cpCache for resolved field metadata.
-                    let cached_field = {
+                    // Fast path: check cpCache for resolved field.
+                    let cached_val = {
                         let cb = cache.borrow();
                         if let Some(Some(CpCacheEntry::Field(e))) = cb.get(idx as usize) {
-                            Some((e.owner_class.clone(), e.field_name.clone()))
+                            let v = self.static_fields.get(&e.owner_class)
+                                .and_then(|m| m.get(&e.field_name))
+                                .cloned()
+                                .unwrap_or_else(|| default_value_for_descriptor(&e.field_descriptor));
+                            Some(v)
                         } else {
                             None
                         }
                     };
-                    if let Some((owner, field)) = cached_field {
-                        // getstatic triggers class initialization (JVMS §5.5),
-                        // even when the field reference is already cached.
-                        self.ensure_class_init(&owner)?;
-                        if let Some(v) = self.static_fields.get(&owner).and_then(|m| m.get(&field)).cloned() {
-                            frame.stack.push(v);
-                        } else {
-                            // Cached metadata can exist before a value is materialized
-                            // (for example during initialization edge cases); resolve
-                            // through the slow path instead of returning descriptor default.
-                            let v = self.resolve_static_field(cp, idx, class_name)?;
-                            frame.stack.push(v);
-                        }
+                    if let Some(v) = cached_val {
+                        frame.stack.push(v);
                     } else {
                         // Slow path: resolve, push, then populate cache.
-                        let v = self.resolve_static_field(cp, idx, class_name)?;
+                        let v = self.resolve_static_field(cp, idx)?;
                         frame.stack.push(v.clone());
                         // Populate cache with the resolved field owner.
-                        let (declared_owner, fn_, fd) = resolve_fieldref_ref(cp, idx);
-                        let mapped_owner =
-                            self.remap_static_owner_for_field_access(class_name, declared_owner);
-                        let owner = self
-                            .find_static_field_owner_class(&mapped_owner, fn_)
-                            .unwrap_or(mapped_owner);
+                        let (cn, fn_, fd) = resolve_fieldref_ref(cp, idx);
+                        let owner = self.find_static_field_owner_class(cn, fn_)
+                            .unwrap_or_else(|| cn.to_owned());
                         cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
                             ResolvedFieldEntry {
                                 owner_class: owner,
@@ -827,35 +723,16 @@ impl Vm {
                         }
                     };
                     if let Some((owner, field)) = cached {
-                        self.check_final_static_field_write(&owner, &field, None, class_name)?;
-                        // putstatic also triggers initialization of the declaring class.
-                        self.ensure_class_init(&owner)?;
                         self.static_fields.entry(owner).or_default().insert(field, val);
                     } else {
                         // Slow path.
-                        let (declared_owner, fld, fd) = resolve_fieldref_ref(cp, idx);
-                        let mapped_owner =
-                            self.remap_static_owner_for_field_access(class_name, declared_owner);
-                        let resolved =
-                            self.find_static_field_info(&mapped_owner, fld, Some(fd));
-                        let owner = resolved
-                            .as_ref()
-                            .map(|(owner, _)| owner.clone())
-                            .unwrap_or(mapped_owner);
-                        if let Some((resolved_owner, access_flags)) = resolved.as_ref() {
-                            self.check_final_static_field_write_resolved(
-                                resolved_owner,
-                                fld,
-                                *access_flags,
-                                class_name,
-                            )?;
-                        }
-                        self.ensure_class_init(&owner)?;
-                        self.static_fields.entry(owner.clone()).or_default().insert(fld.to_owned(), val);
+                        let (cls, fld, fd) = resolve_fieldref_ref(cp, idx);
+                        self.ensure_class_init(cls)?;
+                        self.static_fields.entry(cls.to_owned()).or_default().insert(fld.to_owned(), val);
                         // Populate cache.
                         cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
                             ResolvedFieldEntry {
-                                owner_class: owner,
+                                owner_class: cls.to_owned(),
                                 field_name: fld.to_owned(),
                                 field_descriptor: fd.to_owned(),
                             }
@@ -872,7 +749,7 @@ impl Vm {
                             "getfield {gf_field_name}: expected Ref on stack, got Void in {class_name}"
                         ));
                     }
-                    let v = self.resolve_instance_field(cp, cache, idx, &obj_ref)?;
+                    let v = self.resolve_instance_field(cp, idx, &obj_ref)?;
                     frame.stack.push(v);
                 }
                 0xb5 => { // putfield
@@ -885,7 +762,7 @@ impl Vm {
                             "putfield {pf_field_name}: expected Ref on stack, got Void in {class_name}"
                         ));
                     }
-                    self.set_instance_field(cp, cache, idx, &obj_ref, val)?;
+                    self.set_instance_field(cp, idx, &obj_ref, val)?;
                 }
 
                 // ---- Method invocation ----
@@ -894,7 +771,7 @@ impl Vm {
                 //   (b) execute native inline and push the result onto frame.stack.
                 0xb6 => { // invokevirtual
                     let idx = read_u16(code, &mut frame.pc);
-                    self.dispatch_virtual(cp, cache, idx, frame).map_err(|e| {
+                    self.dispatch_virtual(cp, idx, frame).map_err(|e| {
                         if e.starts_with("NullPointerException") { format!("{e} in {class_name}") } else { e }
                     })?;
                 }
@@ -911,7 +788,7 @@ impl Vm {
                 0xb9 => { // invokeinterface
                     let idx = read_u16(code, &mut frame.pc);
                     frame.pc += 2; // count + 0
-                    self.dispatch_interface(cp, cache, idx, frame).map_err(|e| {
+                    self.dispatch_interface(cp, idx, frame).map_err(|e| {
                         if e.starts_with("NullPointerException") { format!("{e} in {class_name}") } else { e }
                     })?;
                 }
@@ -926,36 +803,26 @@ impl Vm {
                 0xbb => { // new
                     let idx = read_u16(code, &mut frame.pc);
                     let declared_class = resolve_class_name_ref(cp, idx);
-                    let mapped_new_class = self.remap_declared_class_for_context(class_name, declared_class);
+                    let new_class = self.remap_declared_class_for_context(class_name, declared_class);
                     // Run <clinit> for the class being instantiated.
-                    self.ensure_class_init(&mapped_new_class)?;
+                    self.ensure_class_init(&new_class)?;
                     // A ParseError entry means the class was registered but malformed —
                     // surface consistently as ClassFormatError (same as Class.forName0 path).
-                    if matches!(self.classes.get(&mapped_new_class), Some(super::LazyClass::ParseError(_))) {
-                        self.throw_class_format_error(&mapped_new_class);
-                        return Err(format!(
-                            "java/lang/ClassFormatError: malformed class file for {mapped_new_class}"
-                        ));
+                    if matches!(self.classes.get(&new_class), Some(super::LazyClass::ParseError(_))) {
+                        self.throw_class_format_error(&new_class);
+                        return Err(format!("java/lang/ClassFormatError: malformed class file for {new_class}"));
                     }
-                    let obj = if self.get_class(&mapped_new_class).is_some() {
+                    let obj = if self.get_class(&new_class).is_some() {
                         // Class is loaded (bytecode available) — use plain object.
-                        JObject::new(mapped_new_class.clone())
+                        JObject::new(new_class.clone())
                     } else {
-                        match mapped_new_class.as_str() {
+                        match new_class.as_str() {
                             // JDK collection types backed by Array payload (no shim loaded).
                             "java/util/ArrayList" | "java/util/LinkedList" =>
-                                JObject::new_array(mapped_new_class.clone(), vec![]),
-                            _ => JObject::new(mapped_new_class.clone()),
+                                JObject::new_array(new_class.clone(), vec![]),
+                            _ => JObject::new(new_class.clone()),
                         }
                     };
-                    if self.dynamically_defined_classes.contains(&mapped_new_class) {
-                        if let Some(mut class_file) = self.get_class(&mapped_new_class).cloned() {
-                            class_file.constant_pool.cache = std::rc::Rc::new(std::cell::RefCell::new(
-                                vec![None; class_file.constant_pool.entries.len()],
-                            ));
-                            obj.borrow_mut().class_snapshot = Some(class_file);
-                        }
-                    }
                     frame.stack.push(JValue::Ref(Some(obj)));
                 }
                 0xbc => { // newarray
@@ -1185,20 +1052,12 @@ impl Vm {
         &mut self,
         cp: &[ConstantPoolEntry],
         idx: u16,
-        frame_owner: &str,
     ) -> Result<JValue, String> {
-        let (declared_class_name, field_name, descriptor) = resolve_fieldref_ref(cp, idx);
-        let class_name_owned =
-            self.remap_static_owner_for_field_access(frame_owner, declared_class_name);
-        let class_name = class_name_owned.as_str();
+        let (class_name, field_name, descriptor) = resolve_fieldref_ref(cp, idx);
         // Run <clinit> if not yet done (initialises static fields via putstatic).
         self.ensure_class_init(class_name)?;
         // Search this class and its super-class chain for the static field (JVMS §5.4.3.2).
         if let Some(v) = self.resolve_static_field_in_hierarchy(class_name, field_name) {
-            return Ok(v);
-        }
-        // Some static finals are materialized via ConstantValue rather than <clinit>.
-        if let Some(v) = self.resolve_constant_value_static_field(class_name, field_name) {
             return Ok(v);
         }
         // Well-known JDK static fields that cannot be initialised via <clinit>
@@ -1237,97 +1096,8 @@ impl Vm {
         }
     }
 
-    fn remap_static_owner_for_field_access(
-        &self,
-        frame_owner: &str,
-        declared_class_name: &str,
-    ) -> String {
-        let Some(current_class) = Self::parse_frame_owner_for_field_access(frame_owner) else {
-            return declared_class_name.to_owned();
-        };
-        if self.class_binary_name_for_lookup(current_class) == declared_class_name {
-            return current_class.to_owned();
-        }
-        declared_class_name.to_owned()
-    }
-
-    pub(in crate::interpreter) fn resolve_constant_value_static_field(&mut self, class_name: &str, field_name: &str) -> Option<JValue> {
-        self.ensure_class_ready(class_name);
-        let (constant_idx, cp_entries, super_name, iface_names) = if let Some(class) = self.get_class(class_name) {
-            let constant_idx = class.fields.iter().find_map(|field| {
-                if (field.access_flags & 0x0008) == 0 {
-                    return None;
-                }
-                let name = class.constant_pool.utf8(field.name_index);
-                if name != field_name {
-                    return None;
-                }
-                field.attributes.iter().find_map(|attr| {
-                    if let Attribute::ConstantValue { constantvalue_index } = attr {
-                        Some(*constantvalue_index)
-                    } else {
-                        None
-                    }
-                })
-            });
-            let cp_entries = Some(class.constant_pool.entries.clone());
-            let sup = if class.super_class != 0 {
-                Some(class.constant_pool.class_name(class.super_class).to_owned())
-            } else {
-                None
-            };
-            let ifaces = class
-                .interfaces
-                .iter()
-                .map(|&idx| class.constant_pool.class_name(idx).to_owned())
-                .collect::<Vec<_>>();
-            (constant_idx, cp_entries, sup, ifaces)
-        } else {
-            (None, None, None, vec![])
-        };
-        let constant = match (cp_entries.as_deref(), constant_idx) {
-            (Some(cp), Some(idx)) => self.constant_value_to_jvalue(cp, idx),
-            _ => None,
-        };
-        if let Some(value) = constant {
-            self.static_fields
-                .entry(class_name.to_owned())
-                .or_default()
-                .insert(field_name.to_owned(), value.clone());
-            return Some(value);
-        }
-        if let Some(super_name) = super_name {
-            if let Some(v) = self.resolve_constant_value_static_field(&super_name, field_name) {
-                return Some(v);
-            }
-        }
-        for iface_name in iface_names {
-            if let Some(v) = self.resolve_constant_value_static_field(&iface_name, field_name) {
-                return Some(v);
-            }
-        }
-        None
-    }
-
-    fn constant_value_to_jvalue(&mut self, cp: &[ConstantPoolEntry], idx: u16) -> Option<JValue> {
-        match cp.get(idx as usize)? {
-            ConstantPoolEntry::Integer(v) => Some(JValue::Int(*v)),
-            ConstantPoolEntry::Long(v) => Some(JValue::Long(*v)),
-            ConstantPoolEntry::Float(v) => Some(JValue::Float(*v)),
-            ConstantPoolEntry::Double(v) => Some(JValue::Double(*v)),
-            ConstantPoolEntry::String { string_index } => {
-                let s = match cp.get(*string_index as usize)? {
-                    ConstantPoolEntry::Utf8(s) => s.as_str(),
-                    _ => return None,
-                };
-                Some(JValue::Ref(Some(self.intern_string(s))))
-            }
-            _ => None,
-        }
-    }
-
     /// Walk the class hierarchy to find a static field value.
-    pub(in crate::interpreter) fn resolve_static_field_in_hierarchy(&mut self, class_name: &str, field_name: &str) -> Option<JValue> {
+    fn resolve_static_field_in_hierarchy(&mut self, class_name: &str, field_name: &str) -> Option<JValue> {
         // Check this class first.
         if let Some(v) = self.static_fields.get(class_name).and_then(|m| m.get(field_name)) {
             return Some(v.clone());
@@ -1392,182 +1162,33 @@ impl Vm {
         None
     }
 
-    fn check_final_static_field_write(
-        &mut self,
-        owner: &str,
-        field_name: &str,
-        descriptor: Option<&str>,
-        current_frame_owner: &str,
-    ) -> Result<(), String> {
-        let Some((resolved_owner, access_flags)) =
-            self.find_static_field_info(owner, field_name, descriptor)
-        else {
-            return Ok(());
-        };
-        self.check_final_static_field_write_resolved(
-            &resolved_owner,
-            field_name,
-            access_flags,
-            current_frame_owner,
-        )
-    }
-
-    fn check_final_static_field_write_resolved(
-        &self,
-        resolved_owner: &str,
-        field_name: &str,
-        access_flags: u16,
-        current_frame_owner: &str,
-    ) -> Result<(), String> {
-        if (access_flags & 0x0010) == 0 {
-            return Ok(());
-        }
-        let illegal_access = || {
-            format!(
-                "java/lang/IllegalAccessError: Update to static final field {resolved_owner}.{field_name} attempted from {current_frame_owner}"
-            )
-        };
-        let Some(current_class) = Self::parse_frame_owner_for_field_access(current_frame_owner) else {
-            return Err(illegal_access());
-        };
-        if current_class == resolved_owner {
-            return Ok(());
-        }
-        Err(illegal_access())
-    }
-
-    fn find_static_field_info(
-        &mut self,
-        class_name: &str,
-        field_name: &str,
-        descriptor: Option<&str>,
-    ) -> Option<(String, u16)> {
-        self.ensure_class_ready(class_name);
-        let (found, super_name, iface_names) = if let Some(class) = self.get_class(class_name) {
-            let found = class.fields.iter().find_map(|field| {
-                if (field.access_flags & 0x0008) == 0 {
-                    return None;
-                }
-                let name = class.constant_pool.utf8(field.name_index);
-                let desc = class.constant_pool.utf8(field.descriptor_index);
-                if name == field_name && descriptor.map(|expected| expected == desc).unwrap_or(true) {
-                    Some((class_name.to_owned(), field.access_flags))
-                } else {
-                    None
-                }
-            });
-            let sup = if class.super_class != 0 {
-                Some(class.constant_pool.class_name(class.super_class).to_owned())
-            } else {
-                None
-            };
-            let ifaces = class
-                .interfaces
-                .iter()
-                .map(|&idx| class.constant_pool.class_name(idx).to_owned())
-                .collect::<Vec<_>>();
-            (found, sup, ifaces)
-        } else {
-            (None, None, vec![])
-        };
-        if found.is_some() {
-            return found;
-        }
-        if let Some(super_name) = super_name {
-            if let Some(info) = self.find_static_field_info(&super_name, field_name, descriptor) {
-                return Some(info);
-            }
-        }
-        for iface_name in iface_names {
-            if let Some(info) = self.find_static_field_info(&iface_name, field_name, descriptor) {
-                return Some(info);
-            }
-        }
-        None
-    }
-
-    fn parse_frame_owner_for_field_access(frame_owner: &str) -> Option<&str> {
-        let descriptor_start = frame_owner.find('(')?;
-        let method_sep = frame_owner[..descriptor_start].rfind('.')?;
-        Some(&frame_owner[..method_sep])
-    }
-
     fn resolve_instance_field(
         &mut self,
         cp: &[ConstantPoolEntry],
-        cache: &CpCache,
         idx: u16,
         obj_ref: &JValue,
     ) -> Result<JValue, String> {
+        let (_, field_name, field_desc) = resolve_fieldref_ref(cp, idx);
         match obj_ref.as_ref() {
             Some(r) => {
-                {
-                    let cb = cache.borrow();
-                    if let Some(Some(CpCacheEntry::Field(e))) = cb.get(idx as usize) {
-                        let default = default_value_for_descriptor(&e.field_descriptor);
-                        return Ok(r.borrow().fields.get(e.field_name.as_str()).cloned().unwrap_or(default));
-                    }
-                }
-                let (class_name, field_name, field_desc) = resolve_fieldref_ref(cp, idx);
-                cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
-                    ResolvedFieldEntry {
-                        owner_class: class_name.to_owned(),
-                        field_name: field_name.to_owned(),
-                        field_descriptor: field_desc.to_owned(),
-                    }
-                ));
                 let default = default_value_for_descriptor(field_desc);
                 Ok(r.borrow().fields.get(field_name).cloned().unwrap_or(default))
             }
-            None => {
-                let (_, field_name, _) = resolve_fieldref_ref(cp, idx);
-                Err(format!("NullPointerException: getfield {field_name}"))
-            }
+            None => Err(format!("NullPointerException: getfield {field_name}")),
         }
     }
 
     fn set_instance_field(
         &mut self,
         cp: &[ConstantPoolEntry],
-        cache: &CpCache,
         idx: u16,
         obj_ref: &JValue,
         val: JValue,
     ) -> Result<(), String> {
+        let (_, field_name, _) = resolve_fieldref_ref(cp, idx);
         match obj_ref.as_ref() {
-            Some(r) => {
-                {
-                    let cb = cache.borrow();
-                    if let Some(Some(CpCacheEntry::Field(e))) = cb.get(idx as usize) {
-                        let mut obj = r.borrow_mut();
-                        if let Some(slot) = obj.fields.get_mut(e.field_name.as_str()) {
-                            *slot = val;
-                        } else {
-                            obj.fields.insert(e.field_name.clone(), val);
-                        }
-                        return Ok(());
-                    }
-                }
-                let (class_name, field_name, field_desc) = resolve_fieldref_ref(cp, idx);
-                cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
-                    ResolvedFieldEntry {
-                        owner_class: class_name.to_owned(),
-                        field_name: field_name.to_owned(),
-                        field_descriptor: field_desc.to_owned(),
-                    }
-                ));
-                let mut obj = r.borrow_mut();
-                if let Some(slot) = obj.fields.get_mut(field_name) {
-                    *slot = val;
-                } else {
-                    obj.fields.insert(field_name.to_owned(), val);
-                }
-                Ok(())
-            }
-            None => {
-                let (_, field_name, _) = resolve_fieldref_ref(cp, idx);
-                Err(format!("NullPointerException: putfield {field_name}"))
-            }
+            Some(r) => { r.borrow_mut().fields.insert(field_name.to_owned(), val); Ok(()) }
+            None => Err(format!("NullPointerException: putfield {field_name}")),
         }
     }
 

--- a/jvm-core/src/interpreter/dispatch.rs
+++ b/jvm-core/src/interpreter/dispatch.rs
@@ -181,49 +181,6 @@ impl Vm {
         }
     }
 
-    /// Build a FrameInfo for an instance method from a cached ResolvedMethodEntry.
-    fn build_instance_frame_from_cache(
-        &mut self,
-        entry: &ResolvedMethodEntry,
-        this: JRef,
-        args: Vec<JValue>,
-        push_return: bool,
-    ) -> FrameInfo {
-        let req = 1 + entry.param_tokens.iter()
-            .map(|t| if t == "J" || t == "D" { 2 } else { 1 })
-            .sum::<usize>();
-        let mut locals = vec![JValue::Void; entry.max_locals.max(req)];
-        locals[0] = JValue::Ref(Some(this.clone()));
-        let mut li = 1usize;
-        for (a, t) in args.into_iter().zip(entry.param_tokens.iter()) {
-            if li >= locals.len() {
-                break;
-            }
-            locals[li] = self.adapt_value_for_descriptor(t, a);
-            li += if t == "J" || t == "D" { 2 } else { 1 };
-        }
-        let fo = format!("{}.{}{}", entry.owner_class, entry.method_name, entry.descriptor);
-        let synchronized_monitor = if entry.access_flags & 0x0020 != 0 {
-            self.monitor_enter(&this);
-            Some(this)
-        } else {
-            None
-        };
-        FrameInfo {
-            frame: Frame { locals, stack: Vec::new(), pc: 0 },
-            code: (*entry.code).clone(),
-            cp: Rc::clone(&entry.cp),
-            cache: Rc::clone(&entry.cache),
-            frame_owner: fo,
-            bootstrap_methods: (*entry.bootstrap_methods).to_vec(),
-            exception_table: (*entry.exception_table).to_vec(),
-            push_return,
-            concat_state: None,
-            lambda_return_adapt: None,
-            synchronized_monitor,
-        }
-    }
-
     /// Populate the cpCache with a resolved bytecode method entry.
     fn populate_static_method_cache(
         &self,
@@ -235,7 +192,6 @@ impl Vm {
     ) {
         let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
         let entry = ResolvedMethodEntry {
-            receiver_class: None,
             owner_class: info.class_name.clone(),
             code: Rc::new(info.code.clone()),
             exception_table: Rc::new(info.exception_table.clone()),
@@ -266,70 +222,7 @@ impl Vm {
     ) {
         let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
         let entry = ResolvedMethodEntry {
-            receiver_class: None,
             owner_class: class_name.to_owned(),
-            code: Rc::new(Vec::new()),
-            exception_table: Rc::new(Vec::new()),
-            max_locals: 0,
-            arg_slot_count: count_args(descriptor),
-            access_flags: 0,
-            has_code: false,
-            cp: Rc::new(Vec::new()),
-            cache: Rc::new(RefCell::new(Vec::new())),
-            bootstrap_methods: Rc::new(Vec::new()),
-            descriptor: descriptor.to_owned(),
-            param_tokens,
-            is_void: descriptor.ends_with(")V"),
-            is_varargs: false,
-            method_name: method_name.to_owned(),
-        };
-        cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Method(entry));
-    }
-
-    fn populate_virtual_method_cache(
-        &self,
-        cache: &CpCache,
-        idx: u16,
-        receiver_class: &str,
-        method_name: &str,
-        descriptor: &str,
-        info: &super::MethodExecInfo,
-    ) {
-        let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
-        let entry = ResolvedMethodEntry {
-            receiver_class: Some(receiver_class.to_owned()),
-            owner_class: info.class_name.clone(),
-            code: Rc::new(info.code.clone()),
-            exception_table: Rc::new(info.exception_table.clone()),
-            max_locals: info.max_locals,
-            arg_slot_count: count_args(descriptor),
-            access_flags: info.access_flags,
-            has_code: info.has_code,
-            cp: Rc::clone(&info.cp),
-            cache: Rc::clone(&info.cache),
-            bootstrap_methods: Rc::new(info.bootstrap_methods.clone()),
-            descriptor: descriptor.to_owned(),
-            param_tokens,
-            is_void: descriptor.ends_with(")V"),
-            is_varargs: info.access_flags & 0x0080 != 0,
-            method_name: method_name.to_owned(),
-        };
-        cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Method(entry));
-    }
-
-    fn populate_virtual_native_cache(
-        &self,
-        cache: &CpCache,
-        idx: u16,
-        receiver_class: &str,
-        owner_class: &str,
-        method_name: &str,
-        descriptor: &str,
-    ) {
-        let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
-        let entry = ResolvedMethodEntry {
-            receiver_class: Some(receiver_class.to_owned()),
-            owner_class: owner_class.to_owned(),
             code: Rc::new(Vec::new()),
             exception_table: Rc::new(Vec::new()),
             max_locals: 0,
@@ -351,7 +244,6 @@ impl Vm {
     pub(super) fn dispatch_virtual(
         &mut self,
         cp: &[ConstantPoolEntry],
-        cache: &CpCache,
         idx: u16,
         frame: &mut Frame,
     ) -> Result<Option<JValue>, String> {
@@ -362,7 +254,7 @@ impl Vm {
         match this_val {
             JValue::Ref(Some(r)) => {
                 let push_return = !descriptor.ends_with(")V");
-                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame, cache, idx)
+                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame)
             }
             JValue::Ref(None) => Err(format!("NullPointerException: invokevirtual {class_name}.{method_name}{descriptor}")),
             other => Err(format!(
@@ -381,8 +273,6 @@ impl Vm {
         args: Vec<JValue>,
         push_return: bool,
         frame: &mut Frame,
-        cache: &CpCache,
-        idx: u16,
     ) -> Result<Option<JValue>, String> {
         // Fast-path: intercept Object.wait/notify/notifyAll directly to avoid
         // re-entering invoke_virtual's recursive path, which doesn't check
@@ -414,201 +304,32 @@ impl Vm {
             _ => {}
         }
 
-        let (is_rust_lambda, is_bytecode_lambda, has_class_snapshot, runtime_class) = {
-            let borrow = r.borrow();
-            (
-                matches!(borrow.native, NativePayload::Lambda(_)),
-                matches!(borrow.native, NativePayload::BytecodeLambda { .. }),
-                borrow.class_snapshot.is_some(),
-                borrow.class_name.clone(),
-            )
-        };
-
-        // Force-native fast path for Thread.threadLocal* helpers.
-        // These methods have Java bytecode in newer JDKs, but running through
-        // HashMap-heavy Java paths is prohibitively expensive for Clojure's
-        // high-contention delay tests.
-        if matches!(
-            (method_name, descriptor),
-            ("threadLocalGet", "(Ljava/lang/ThreadLocal;)Ljava/lang/Object;")
-                | ("threadLocalContains", "(Ljava/lang/ThreadLocal;)Z")
-                | ("threadLocalSet", "(Ljava/lang/ThreadLocal;Ljava/lang/Object;)V")
-                | ("threadLocalRemove", "(Ljava/lang/ThreadLocal;)V")
-        ) && (runtime_class == "java/lang/Thread"
-            || self.is_instance_of(&runtime_class, "java/lang/Thread"))
-        {
-            if let Some(result) = self.native_virtual(
-                &r,
-                "java/lang/Thread",
-                method_name,
-                descriptor,
-                &args,
-            ) {
-                if let Some(err) = self.pending_exception_err() {
-                    return Err(err);
-                }
-                if push_return && !matches!(result, JValue::Void) {
-                    frame.stack.push(result);
-                }
-                return Ok(None);
+        match self.build_virtual_frame_inner(r.clone(), class_name, method_name, descriptor, args.clone(), push_return)? {
+            Some(fi) => {
+                *self.pending_frame_mut() = Some(fi);
+                Ok(None)
             }
-        }
-
-        // Lightweight annotation-object dispatch:
-        // runtime-visible annotation payloads are represented as plain objects
-        // carrying `__ann_*` fields parsed from class attributes.
-        if args.is_empty() {
-            let ann_slot = if method_name == "annotationType" && descriptor == "()Ljava/lang/Class;" {
-                Some("__ann_annotationType".to_owned())
-            } else if descriptor.starts_with("()") {
-                Some(format!("__ann_{method_name}"))
-            } else {
-                None
-            };
-            if let Some(slot) = ann_slot {
-                if let Some(v) = r.borrow().fields.get(&slot).cloned() {
-                    if push_return && !matches!(v, JValue::Void) {
-                        frame.stack.push(v);
-                    }
-                    return Ok(None);
-                }
-            }
-        }
-
-        if !is_rust_lambda {
-            if has_class_snapshot && !is_bytecode_lambda {
-                if let Some(fi) = self.build_virtual_frame_inner(
-                    r.clone(),
-                    class_name,
-                    method_name,
-                    descriptor,
-                    args.clone(),
-                    push_return,
-                )? {
+            None => {
+                // Try to handle BytecodeLambda SAM dispatch via the trampoline
+                // (instead of the recursive invoke_virtual path which uses
+                // run_trampoline — the non-time-sliced variant that ignores
+                // thread state changes like WaitingOnCondition).
+                if let Some(fi) = self.try_build_lambda_sam_frame(&r, method_name, descriptor, args.clone(), push_return)? {
                     *self.pending_frame_mut() = Some(fi);
                     return Ok(None);
                 }
+                // Native, NativePayload::Lambda (Rust closure), or unresolved —
+                // fall back to recursive invoke_virtual. This runs outside the
+                // time-sliced trampoline, so thread state changes (e.g.
+                // WaitingOnCondition) won't cause a yield. This is acceptable
+                // because Rust closures don't call Java wait/notify.
                 let result = self.invoke_virtual(r, class_name, method_name, descriptor, args)?;
                 if !matches!(result, JValue::Void) {
                     frame.stack.push(result);
                 }
-                return Ok(None);
-            }
-
-            let cached_entry = {
-                let cb = cache.borrow();
-                match cb.get(idx as usize) {
-                    Some(Some(CpCacheEntry::Method(entry)))
-                        if entry.receiver_class.as_deref() == Some(runtime_class.as_str()) =>
-                    {
-                        Some(entry.clone())
-                    }
-                    _ => None,
-                }
-            };
-            if let Some(entry) = cached_entry {
-                if entry.has_code {
-                    let fi = self.build_instance_frame_from_cache(&entry, r.clone(), args.clone(), push_return);
-                    *self.pending_frame_mut() = Some(fi);
-                    return Ok(None);
-                }
-                let result = self.native_virtual(&r, &entry.owner_class, &entry.method_name, &entry.descriptor, &args);
-                if let Some(err) = self.pending_exception_err() {
-                    return Err(err);
-                }
-                if let Some(result) = result {
-                    if !entry.is_void {
-                        frame.stack.push(result);
-                    }
-                    return Ok(None);
-                }
-            }
-
-            let resolve_class = if is_bytecode_lambda {
-                class_name.to_owned()
-            } else if self.classes.contains_key(&runtime_class) {
-                runtime_class.clone()
-            } else {
-                class_name.to_owned()
-            };
-
-            let resolved = if self.method_exists(&resolve_class, method_name, descriptor) {
-                descriptor.to_owned()
-            } else {
-                self.find_method_real_descriptor(&resolve_class, method_name, descriptor)
-                    .unwrap_or_else(|| descriptor.to_owned())
-            };
-            let desc = resolved.as_str();
-
-            let has_method = self.method_exists(&resolve_class, method_name, desc);
-            if has_method {
-                let info = self.resolve_method_exec_info(&resolve_class, method_name, desc).unwrap();
-                if info.access_flags & 0x0400 != 0 {
-                    if is_bytecode_lambda {
-                        if let Some(fi) = self.try_build_lambda_sam_frame(&r, method_name, descriptor, args.clone(), push_return)? {
-                            *self.pending_frame_mut() = Some(fi);
-                            return Ok(None);
-                        }
-                    } else {
-                        let ms = format!("{}.{method_name}{}", info.class_name, info.descriptor);
-                        let exc = self.new_vm_exception_message("java/lang/AbstractMethodError", ms.clone());
-                        *self.pending_exception_mut() = Some(exc);
-                        return Err(format!("java/lang/AbstractMethodError: {ms}"));
-                    }
-                } else if info.has_code {
-                    self.populate_virtual_method_cache(cache, idx, &runtime_class, method_name, desc, &info);
-                    let cached_entry = {
-                        let cb = cache.borrow();
-                        match cb.get(idx as usize) {
-                            Some(Some(CpCacheEntry::Method(entry))) => Some(entry.clone()),
-                            _ => None,
-                        }
-                    };
-                    if let Some(entry) = cached_entry {
-                        let fi = self.build_instance_frame_from_cache(&entry, r.clone(), args, push_return);
-                        *self.pending_frame_mut() = Some(fi);
-                        return Ok(None);
-                    }
-                } else {
-                    self.populate_virtual_native_cache(
-                        cache,
-                        idx,
-                        &runtime_class,
-                        &info.class_name,
-                        method_name,
-                        &info.descriptor,
-                    );
-                    if let Some(result) = self.native_virtual(&r, &info.class_name, method_name, &info.descriptor, &args) {
-                        if let Some(err) = self.pending_exception_err() {
-                            return Err(err);
-                        }
-                        if !matches!(result, JValue::Void) {
-                            frame.stack.push(result);
-                        }
-                        return Ok(None);
-                    }
-                }
+                Ok(None)
             }
         }
-
-        // Try to handle BytecodeLambda SAM dispatch via the trampoline
-        // (instead of the recursive invoke_virtual path which uses
-        // run_trampoline — the non-time-sliced variant that ignores
-        // thread state changes like WaitingOnCondition).
-        if let Some(fi) = self.try_build_lambda_sam_frame(&r, method_name, descriptor, args.clone(), push_return)? {
-            *self.pending_frame_mut() = Some(fi);
-            return Ok(None);
-        }
-        // Native, NativePayload::Lambda (Rust closure), or unresolved —
-        // fall back to recursive invoke_virtual. This runs outside the
-        // time-sliced trampoline, so thread state changes (e.g.
-        // WaitingOnCondition) won't cause a yield. This is acceptable
-        // because Rust closures don't call Java wait/notify.
-        let result = self.invoke_virtual(r, class_name, method_name, descriptor, args)?;
-        if !matches!(result, JValue::Void) {
-            frame.stack.push(result);
-        }
-        Ok(None)
     }
 
     pub(super) fn dispatch_special(
@@ -628,32 +349,13 @@ impl Vm {
                     self.remap_declared_class_for_context(&receiver_class, declared_class_name);
                 if method_name == "<init>" {
                     if class_name == "java/lang/String" {
-                        if matches!(
-                            descriptor,
-                            "([C)V"
-                                | "([CII)V"
-                                | "([B)V"
-                                | "([BII)V"
-                                | "([BIILjava/lang/String;)V"
-                                | "([BIILjava/nio/charset/Charset;)V"
-                                | "([BLjava/lang/String;)V"
-                                | "([BLjava/nio/charset/Charset;)V"
-                                | "([BIII)V"
-                                | "(Ljava/lang/String;)V"
-                        ) && args.first().and_then(|a| a.as_ref()).is_none()
-                        {
-                            return Err(format!("java/lang/NullPointerException: {class_name}.{method_name}{descriptor}"));
-                        }
                         let s = self.string_from_init_args(&descriptor, &args, &r);
                         r.borrow_mut().native = NativePayload::JavaString(s);
                         return Ok(None); // void
                     }
                     let has_method = self.method_exists(&class_name, &method_name, &descriptor);
                     if !has_method {
-                        let detail = format!("{class_name}.{method_name}{descriptor}");
-                        let exc = self.new_vm_exception_message("java/lang/NoSuchMethodError", detail.clone());
-                        *self.pending_exception_mut() = Some(exc);
-                        return Err(format!("java/lang/NoSuchMethodError: {detail}"));
+                        return Ok(None); // no-op
                     }
                 }
                 let push_return = !descriptor.ends_with(")V");
@@ -671,9 +373,7 @@ impl Vm {
                     }
                 }
             }
-            JValue::Ref(None) => Err(format!(
-                "NullPointerException: invokespecial {declared_class_name}.{method_name}{descriptor}"
-            )),
+            JValue::Ref(None) => Err(format!("NullPointerException: invokespecial {declared_class_name}.{method_name}{descriptor}")),
             other => Err(format!(
                 "Expected reference for invokespecial {declared_class_name}.{method_name}{descriptor}, got {other:?}"
             )),
@@ -683,7 +383,6 @@ impl Vm {
     pub(super) fn dispatch_interface(
         &mut self,
         cp: &[ConstantPoolEntry],
-        cache: &CpCache,
         idx: u16,
         frame: &mut Frame,
     ) -> Result<Option<JValue>, String> {
@@ -715,7 +414,7 @@ impl Vm {
         match this_val {
             JValue::Ref(Some(r)) => {
                 let push_return = !descriptor.ends_with(")V");
-                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame, cache, idx)
+                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame)
             }
             JValue::Ref(None) => Err(format!("NullPointerException: invokeinterface {class_name}.{method_name}{descriptor}")),
             other => Err(format!(
@@ -903,15 +602,10 @@ impl Vm {
                         _ => None,
                     }
                 }).unwrap_or_default();
-                let lambda_class_name = method_return_descriptor(&descriptor)
-                    .and_then(|ret| ret.strip_prefix('L').and_then(|name| name.strip_suffix(';')))
-                    .unwrap_or("$$Lambda")
-                    .to_owned();
 
                 let lambda = if let Some((ref_kind, impl_class, impl_method, impl_desc)) = impl_info {
                     let obj = Rc::new(RefCell::new(JObject {
-                        class_name: lambda_class_name,
-                        class_snapshot: None,
+                        class_name: "$$Lambda".to_owned(),
                         fields: std::collections::HashMap::new(),
                         native: NativePayload::BytecodeLambda {
                             sam_method: method_name,
@@ -1174,7 +868,6 @@ impl Vm {
 
                 let obj = Rc::new(RefCell::new(JObject {
                     class_name: "$$RecordMethod".to_owned(),
-                    class_snapshot: None,
                     fields: std::collections::HashMap::new(),
                     native: NativePayload::RecordMethod {
                         method: method_name,

--- a/jvm-core/src/interpreter/dispatch.rs
+++ b/jvm-core/src/interpreter/dispatch.rs
@@ -32,6 +32,7 @@ impl Vm {
         cp: &[ConstantPoolEntry],
         cache: &CpCache,
         idx: u16,
+        caller_class: &str,
         frame: &mut Frame,
     ) -> Result<Option<JValue>, String> {
         // ---- FAST PATH: check cpCache for a previously resolved method ----
@@ -61,18 +62,20 @@ impl Vm {
         }
 
         // ---- SLOW PATH: first invocation — resolve and populate cache ----
-        let (class_name, method_name, descriptor) = resolve_methodref_ref(cp, idx);
-        self.ensure_class_init(class_name)?;
+        let (declared_class_name, method_name, descriptor) = resolve_methodref_ref(cp, idx);
+        let class_name =
+            self.remap_declared_class_for_context(caller_class, declared_class_name);
+        self.ensure_class_init(&class_name)?;
         let n_args = count_args(descriptor);
         let args = pop_args(frame, n_args);
 
         // Normalize descriptor and args (varargs synthesis) before branching.
         let orig_args = args.clone();
-        let (desc, args) = match self.prepare_static_args(class_name, method_name, descriptor, args) {
+        let (desc, args) = match self.prepare_static_args(&class_name, method_name, descriptor, args) {
             Some(pair) => pair,
             None => {
                 // Method flags not found — fall back to invoke_static with original args.
-                let result = self.invoke_static(class_name, method_name, descriptor, orig_args)?;
+                let result = self.invoke_static(&class_name, method_name, descriptor, orig_args)?;
                 if !matches!(result, JValue::Void) { frame.stack.push(result); }
                 return Ok(None);
             }
@@ -80,7 +83,7 @@ impl Vm {
 
         let push_return = !desc.ends_with(")V");
         // Resolve method exec info once (used for both frame building and cache population).
-        match self.resolve_method_exec_info(class_name, method_name, &desc) {
+        match self.resolve_method_exec_info(&class_name, method_name, &desc) {
             Some(info) if info.has_code => {
                 // Bytecode method — build frame and populate cache.
                 let fi = self.build_static_frame_from_exec_info(&info, method_name, &desc, args, push_return);
@@ -90,8 +93,8 @@ impl Vm {
             }
             _ => {
                 // Native or unresolved — cache and fall back to invoke_static.
-                self.populate_static_native_cache(cache, idx, class_name, method_name, &desc);
-                let result = self.invoke_static(class_name, method_name, &desc, args)?;
+                self.populate_static_native_cache(cache, idx, &class_name, method_name, &desc);
+                let result = self.invoke_static(&class_name, method_name, &desc, args)?;
                 if !matches!(result, JValue::Void) {
                     frame.stack.push(result);
                 }
@@ -178,6 +181,49 @@ impl Vm {
         }
     }
 
+    /// Build a FrameInfo for an instance method from a cached ResolvedMethodEntry.
+    fn build_instance_frame_from_cache(
+        &mut self,
+        entry: &ResolvedMethodEntry,
+        this: JRef,
+        args: Vec<JValue>,
+        push_return: bool,
+    ) -> FrameInfo {
+        let req = 1 + entry.param_tokens.iter()
+            .map(|t| if t == "J" || t == "D" { 2 } else { 1 })
+            .sum::<usize>();
+        let mut locals = vec![JValue::Void; entry.max_locals.max(req)];
+        locals[0] = JValue::Ref(Some(this.clone()));
+        let mut li = 1usize;
+        for (a, t) in args.into_iter().zip(entry.param_tokens.iter()) {
+            if li >= locals.len() {
+                break;
+            }
+            locals[li] = self.adapt_value_for_descriptor(t, a);
+            li += if t == "J" || t == "D" { 2 } else { 1 };
+        }
+        let fo = format!("{}.{}{}", entry.owner_class, entry.method_name, entry.descriptor);
+        let synchronized_monitor = if entry.access_flags & 0x0020 != 0 {
+            self.monitor_enter(&this);
+            Some(this)
+        } else {
+            None
+        };
+        FrameInfo {
+            frame: Frame { locals, stack: Vec::new(), pc: 0 },
+            code: (*entry.code).clone(),
+            cp: Rc::clone(&entry.cp),
+            cache: Rc::clone(&entry.cache),
+            frame_owner: fo,
+            bootstrap_methods: (*entry.bootstrap_methods).to_vec(),
+            exception_table: (*entry.exception_table).to_vec(),
+            push_return,
+            concat_state: None,
+            lambda_return_adapt: None,
+            synchronized_monitor,
+        }
+    }
+
     /// Populate the cpCache with a resolved bytecode method entry.
     fn populate_static_method_cache(
         &self,
@@ -189,6 +235,7 @@ impl Vm {
     ) {
         let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
         let entry = ResolvedMethodEntry {
+            receiver_class: None,
             owner_class: info.class_name.clone(),
             code: Rc::new(info.code.clone()),
             exception_table: Rc::new(info.exception_table.clone()),
@@ -219,7 +266,70 @@ impl Vm {
     ) {
         let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
         let entry = ResolvedMethodEntry {
+            receiver_class: None,
             owner_class: class_name.to_owned(),
+            code: Rc::new(Vec::new()),
+            exception_table: Rc::new(Vec::new()),
+            max_locals: 0,
+            arg_slot_count: count_args(descriptor),
+            access_flags: 0,
+            has_code: false,
+            cp: Rc::new(Vec::new()),
+            cache: Rc::new(RefCell::new(Vec::new())),
+            bootstrap_methods: Rc::new(Vec::new()),
+            descriptor: descriptor.to_owned(),
+            param_tokens,
+            is_void: descriptor.ends_with(")V"),
+            is_varargs: false,
+            method_name: method_name.to_owned(),
+        };
+        cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Method(entry));
+    }
+
+    fn populate_virtual_method_cache(
+        &self,
+        cache: &CpCache,
+        idx: u16,
+        receiver_class: &str,
+        method_name: &str,
+        descriptor: &str,
+        info: &super::MethodExecInfo,
+    ) {
+        let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
+        let entry = ResolvedMethodEntry {
+            receiver_class: Some(receiver_class.to_owned()),
+            owner_class: info.class_name.clone(),
+            code: Rc::new(info.code.clone()),
+            exception_table: Rc::new(info.exception_table.clone()),
+            max_locals: info.max_locals,
+            arg_slot_count: count_args(descriptor),
+            access_flags: info.access_flags,
+            has_code: info.has_code,
+            cp: Rc::clone(&info.cp),
+            cache: Rc::clone(&info.cache),
+            bootstrap_methods: Rc::new(info.bootstrap_methods.clone()),
+            descriptor: descriptor.to_owned(),
+            param_tokens,
+            is_void: descriptor.ends_with(")V"),
+            is_varargs: info.access_flags & 0x0080 != 0,
+            method_name: method_name.to_owned(),
+        };
+        cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Method(entry));
+    }
+
+    fn populate_virtual_native_cache(
+        &self,
+        cache: &CpCache,
+        idx: u16,
+        receiver_class: &str,
+        owner_class: &str,
+        method_name: &str,
+        descriptor: &str,
+    ) {
+        let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
+        let entry = ResolvedMethodEntry {
+            receiver_class: Some(receiver_class.to_owned()),
+            owner_class: owner_class.to_owned(),
             code: Rc::new(Vec::new()),
             exception_table: Rc::new(Vec::new()),
             max_locals: 0,
@@ -241,6 +351,7 @@ impl Vm {
     pub(super) fn dispatch_virtual(
         &mut self,
         cp: &[ConstantPoolEntry],
+        cache: &CpCache,
         idx: u16,
         frame: &mut Frame,
     ) -> Result<Option<JValue>, String> {
@@ -251,7 +362,7 @@ impl Vm {
         match this_val {
             JValue::Ref(Some(r)) => {
                 let push_return = !descriptor.ends_with(")V");
-                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame)
+                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame, cache, idx)
             }
             JValue::Ref(None) => Err(format!("NullPointerException: invokevirtual {class_name}.{method_name}{descriptor}")),
             other => Err(format!(
@@ -270,6 +381,8 @@ impl Vm {
         args: Vec<JValue>,
         push_return: bool,
         frame: &mut Frame,
+        cache: &CpCache,
+        idx: u16,
     ) -> Result<Option<JValue>, String> {
         // Fast-path: intercept Object.wait/notify/notifyAll directly to avoid
         // re-entering invoke_virtual's recursive path, which doesn't check
@@ -301,32 +414,201 @@ impl Vm {
             _ => {}
         }
 
-        match self.build_virtual_frame_inner(r.clone(), class_name, method_name, descriptor, args.clone(), push_return)? {
-            Some(fi) => {
-                *self.pending_frame_mut() = Some(fi);
-                Ok(None)
+        let (is_rust_lambda, is_bytecode_lambda, has_class_snapshot, runtime_class) = {
+            let borrow = r.borrow();
+            (
+                matches!(borrow.native, NativePayload::Lambda(_)),
+                matches!(borrow.native, NativePayload::BytecodeLambda { .. }),
+                borrow.class_snapshot.is_some(),
+                borrow.class_name.clone(),
+            )
+        };
+
+        // Force-native fast path for Thread.threadLocal* helpers.
+        // These methods have Java bytecode in newer JDKs, but running through
+        // HashMap-heavy Java paths is prohibitively expensive for Clojure's
+        // high-contention delay tests.
+        if matches!(
+            (method_name, descriptor),
+            ("threadLocalGet", "(Ljava/lang/ThreadLocal;)Ljava/lang/Object;")
+                | ("threadLocalContains", "(Ljava/lang/ThreadLocal;)Z")
+                | ("threadLocalSet", "(Ljava/lang/ThreadLocal;Ljava/lang/Object;)V")
+                | ("threadLocalRemove", "(Ljava/lang/ThreadLocal;)V")
+        ) && (runtime_class == "java/lang/Thread"
+            || self.is_instance_of(&runtime_class, "java/lang/Thread"))
+        {
+            if let Some(result) = self.native_virtual(
+                &r,
+                "java/lang/Thread",
+                method_name,
+                descriptor,
+                &args,
+            ) {
+                if let Some(err) = self.pending_exception_err() {
+                    return Err(err);
+                }
+                if push_return && !matches!(result, JValue::Void) {
+                    frame.stack.push(result);
+                }
+                return Ok(None);
             }
-            None => {
-                // Try to handle BytecodeLambda SAM dispatch via the trampoline
-                // (instead of the recursive invoke_virtual path which uses
-                // run_trampoline — the non-time-sliced variant that ignores
-                // thread state changes like WaitingOnCondition).
-                if let Some(fi) = self.try_build_lambda_sam_frame(&r, method_name, descriptor, args.clone(), push_return)? {
+        }
+
+        // Lightweight annotation-object dispatch:
+        // runtime-visible annotation payloads are represented as plain objects
+        // carrying `__ann_*` fields parsed from class attributes.
+        if args.is_empty() {
+            let ann_slot = if method_name == "annotationType" && descriptor == "()Ljava/lang/Class;" {
+                Some("__ann_annotationType".to_owned())
+            } else if descriptor.starts_with("()") {
+                Some(format!("__ann_{method_name}"))
+            } else {
+                None
+            };
+            if let Some(slot) = ann_slot {
+                if let Some(v) = r.borrow().fields.get(&slot).cloned() {
+                    if push_return && !matches!(v, JValue::Void) {
+                        frame.stack.push(v);
+                    }
+                    return Ok(None);
+                }
+            }
+        }
+
+        if !is_rust_lambda {
+            if has_class_snapshot && !is_bytecode_lambda {
+                if let Some(fi) = self.build_virtual_frame_inner(
+                    r.clone(),
+                    class_name,
+                    method_name,
+                    descriptor,
+                    args.clone(),
+                    push_return,
+                )? {
                     *self.pending_frame_mut() = Some(fi);
                     return Ok(None);
                 }
-                // Native, NativePayload::Lambda (Rust closure), or unresolved —
-                // fall back to recursive invoke_virtual. This runs outside the
-                // time-sliced trampoline, so thread state changes (e.g.
-                // WaitingOnCondition) won't cause a yield. This is acceptable
-                // because Rust closures don't call Java wait/notify.
                 let result = self.invoke_virtual(r, class_name, method_name, descriptor, args)?;
                 if !matches!(result, JValue::Void) {
                     frame.stack.push(result);
                 }
-                Ok(None)
+                return Ok(None);
+            }
+
+            let cached_entry = {
+                let cb = cache.borrow();
+                match cb.get(idx as usize) {
+                    Some(Some(CpCacheEntry::Method(entry)))
+                        if entry.receiver_class.as_deref() == Some(runtime_class.as_str()) =>
+                    {
+                        Some(entry.clone())
+                    }
+                    _ => None,
+                }
+            };
+            if let Some(entry) = cached_entry {
+                if entry.has_code {
+                    let fi = self.build_instance_frame_from_cache(&entry, r.clone(), args.clone(), push_return);
+                    *self.pending_frame_mut() = Some(fi);
+                    return Ok(None);
+                }
+                let result = self.native_virtual(&r, &entry.owner_class, &entry.method_name, &entry.descriptor, &args);
+                if let Some(err) = self.pending_exception_err() {
+                    return Err(err);
+                }
+                if let Some(result) = result {
+                    if !entry.is_void {
+                        frame.stack.push(result);
+                    }
+                    return Ok(None);
+                }
+            }
+
+            let resolve_class = if is_bytecode_lambda {
+                class_name.to_owned()
+            } else if self.classes.contains_key(&runtime_class) {
+                runtime_class.clone()
+            } else {
+                class_name.to_owned()
+            };
+
+            let resolved = if self.method_exists(&resolve_class, method_name, descriptor) {
+                descriptor.to_owned()
+            } else {
+                self.find_method_real_descriptor(&resolve_class, method_name, descriptor)
+                    .unwrap_or_else(|| descriptor.to_owned())
+            };
+            let desc = resolved.as_str();
+
+            let has_method = self.method_exists(&resolve_class, method_name, desc);
+            if has_method {
+                let info = self.resolve_method_exec_info(&resolve_class, method_name, desc).unwrap();
+                if info.access_flags & 0x0400 != 0 {
+                    if is_bytecode_lambda {
+                        if let Some(fi) = self.try_build_lambda_sam_frame(&r, method_name, descriptor, args.clone(), push_return)? {
+                            *self.pending_frame_mut() = Some(fi);
+                            return Ok(None);
+                        }
+                    } else {
+                        let ms = format!("{}.{method_name}{}", info.class_name, info.descriptor);
+                        let exc = self.new_vm_exception_message("java/lang/AbstractMethodError", ms.clone());
+                        *self.pending_exception_mut() = Some(exc);
+                        return Err(format!("java/lang/AbstractMethodError: {ms}"));
+                    }
+                } else if info.has_code {
+                    self.populate_virtual_method_cache(cache, idx, &runtime_class, method_name, desc, &info);
+                    let cached_entry = {
+                        let cb = cache.borrow();
+                        match cb.get(idx as usize) {
+                            Some(Some(CpCacheEntry::Method(entry))) => Some(entry.clone()),
+                            _ => None,
+                        }
+                    };
+                    if let Some(entry) = cached_entry {
+                        let fi = self.build_instance_frame_from_cache(&entry, r.clone(), args, push_return);
+                        *self.pending_frame_mut() = Some(fi);
+                        return Ok(None);
+                    }
+                } else {
+                    self.populate_virtual_native_cache(
+                        cache,
+                        idx,
+                        &runtime_class,
+                        &info.class_name,
+                        method_name,
+                        &info.descriptor,
+                    );
+                    if let Some(result) = self.native_virtual(&r, &info.class_name, method_name, &info.descriptor, &args) {
+                        if let Some(err) = self.pending_exception_err() {
+                            return Err(err);
+                        }
+                        if !matches!(result, JValue::Void) {
+                            frame.stack.push(result);
+                        }
+                        return Ok(None);
+                    }
+                }
             }
         }
+
+        // Try to handle BytecodeLambda SAM dispatch via the trampoline
+        // (instead of the recursive invoke_virtual path which uses
+        // run_trampoline — the non-time-sliced variant that ignores
+        // thread state changes like WaitingOnCondition).
+        if let Some(fi) = self.try_build_lambda_sam_frame(&r, method_name, descriptor, args.clone(), push_return)? {
+            *self.pending_frame_mut() = Some(fi);
+            return Ok(None);
+        }
+        // Native, NativePayload::Lambda (Rust closure), or unresolved —
+        // fall back to recursive invoke_virtual. This runs outside the
+        // time-sliced trampoline, so thread state changes (e.g.
+        // WaitingOnCondition) won't cause a yield. This is acceptable
+        // because Rust closures don't call Java wait/notify.
+        let result = self.invoke_virtual(r, class_name, method_name, descriptor, args)?;
+        if !matches!(result, JValue::Void) {
+            frame.stack.push(result);
+        }
+        Ok(None)
     }
 
     pub(super) fn dispatch_special(
@@ -335,21 +617,43 @@ impl Vm {
         idx: u16,
         frame: &mut Frame,
     ) -> Result<Option<JValue>, String> {
-        let (class_name, method_name, descriptor) = resolve_methodref_ref(cp, idx);
+        let (declared_class_name, method_name, descriptor) = resolve_methodref_ref(cp, idx);
         let n_args = count_args(descriptor);
         let args = pop_args(frame, n_args);
         let this_val = frame.stack.pop().unwrap();
         match this_val {
             JValue::Ref(Some(r)) => {
+                let receiver_class = r.borrow().class_name.clone();
+                let class_name =
+                    self.remap_declared_class_for_context(&receiver_class, declared_class_name);
                 if method_name == "<init>" {
                     if class_name == "java/lang/String" {
+                        if matches!(
+                            descriptor,
+                            "([C)V"
+                                | "([CII)V"
+                                | "([B)V"
+                                | "([BII)V"
+                                | "([BIILjava/lang/String;)V"
+                                | "([BIILjava/nio/charset/Charset;)V"
+                                | "([BLjava/lang/String;)V"
+                                | "([BLjava/nio/charset/Charset;)V"
+                                | "([BIII)V"
+                                | "(Ljava/lang/String;)V"
+                        ) && args.first().and_then(|a| a.as_ref()).is_none()
+                        {
+                            return Err(format!("java/lang/NullPointerException: {class_name}.{method_name}{descriptor}"));
+                        }
                         let s = self.string_from_init_args(&descriptor, &args, &r);
                         r.borrow_mut().native = NativePayload::JavaString(s);
                         return Ok(None); // void
                     }
                     let has_method = self.method_exists(&class_name, &method_name, &descriptor);
                     if !has_method {
-                        return Ok(None); // no-op
+                        let detail = format!("{class_name}.{method_name}{descriptor}");
+                        let exc = self.new_vm_exception_message("java/lang/NoSuchMethodError", detail.clone());
+                        *self.pending_exception_mut() = Some(exc);
+                        return Err(format!("java/lang/NoSuchMethodError: {detail}"));
                     }
                 }
                 let push_return = !descriptor.ends_with(")V");
@@ -367,9 +671,11 @@ impl Vm {
                     }
                 }
             }
-            JValue::Ref(None) => Err(format!("NullPointerException: invokespecial {class_name}.{method_name}{descriptor}")),
+            JValue::Ref(None) => Err(format!(
+                "NullPointerException: invokespecial {declared_class_name}.{method_name}{descriptor}"
+            )),
             other => Err(format!(
-                "Expected reference for invokespecial {class_name}.{method_name}{descriptor}, got {other:?}"
+                "Expected reference for invokespecial {declared_class_name}.{method_name}{descriptor}, got {other:?}"
             )),
         }
     }
@@ -377,6 +683,7 @@ impl Vm {
     pub(super) fn dispatch_interface(
         &mut self,
         cp: &[ConstantPoolEntry],
+        cache: &CpCache,
         idx: u16,
         frame: &mut Frame,
     ) -> Result<Option<JValue>, String> {
@@ -408,7 +715,7 @@ impl Vm {
         match this_val {
             JValue::Ref(Some(r)) => {
                 let push_return = !descriptor.ends_with(")V");
-                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame)
+                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame, cache, idx)
             }
             JValue::Ref(None) => Err(format!("NullPointerException: invokeinterface {class_name}.{method_name}{descriptor}")),
             other => Err(format!(
@@ -596,10 +903,15 @@ impl Vm {
                         _ => None,
                     }
                 }).unwrap_or_default();
+                let lambda_class_name = method_return_descriptor(&descriptor)
+                    .and_then(|ret| ret.strip_prefix('L').and_then(|name| name.strip_suffix(';')))
+                    .unwrap_or("$$Lambda")
+                    .to_owned();
 
                 let lambda = if let Some((ref_kind, impl_class, impl_method, impl_desc)) = impl_info {
                     let obj = Rc::new(RefCell::new(JObject {
-                        class_name: "$$Lambda".to_owned(),
+                        class_name: lambda_class_name,
+                        class_snapshot: None,
                         fields: std::collections::HashMap::new(),
                         native: NativePayload::BytecodeLambda {
                             sam_method: method_name,
@@ -862,6 +1174,7 @@ impl Vm {
 
                 let obj = Rc::new(RefCell::new(JObject {
                     class_name: "$$RecordMethod".to_owned(),
+                    class_snapshot: None,
                     fields: std::collections::HashMap::new(),
                     native: NativePayload::RecordMethod {
                         method: method_name,

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -9,7 +9,9 @@
 //! - Native stubs for `java.lang.*` and `java.util.*`
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
 use std::rc::Rc;
+use std::time::Instant;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -358,6 +360,8 @@ pub(crate) struct ThreadContext {
     pub instruction_count: usize,
     /// Saved monitor reentrant count for Object.wait() — restored after notify.
     pub saved_monitor_count: usize,
+    /// Wake-up deadline for `Thread.sleep` in host monotonic time.
+    pub sleep_until: Option<Instant>,
 }
 
 impl ThreadContext {
@@ -371,6 +375,7 @@ impl ThreadContext {
             thread_object: None,
             instruction_count: 0,
             saved_monitor_count: 0,
+            sleep_until: None,
         }
     }
 }
@@ -384,7 +389,10 @@ pub(crate) struct Scheduler {
 }
 
 /// Maximum instructions per thread before yielding to the next runnable thread.
-const TIME_SLICE: usize = 1000;
+///
+/// A larger slice reduces scheduler churn when many runnable green threads are
+/// CPU-bound (for example, test harnesses that spawn many short-lived futures).
+const TIME_SLICE: usize = 10_000;
 
 impl Scheduler {
     pub(in crate::interpreter) fn new() -> Self {
@@ -469,6 +477,27 @@ impl Scheduler {
         }
     }
 
+    /// Wake sleeping threads whose deadlines have elapsed.
+    pub fn wake_sleepers(&mut self) {
+        let now = Instant::now();
+        for t in &mut self.threads {
+            if t.state != ThreadState::Sleeping {
+                continue;
+            }
+            if let Some(deadline) = t.sleep_until {
+                if now >= deadline {
+                    t.sleep_until = None;
+                    t.state = ThreadState::Runnable;
+                }
+            }
+        }
+    }
+
+    /// Returns true when at least one thread is currently sleeping.
+    pub fn has_sleeping_threads(&self) -> bool {
+        self.threads.iter().any(|t| t.state == ThreadState::Sleeping)
+    }
+
     /// Return the number of runnable threads.
     pub fn runnable_count(&self) -> usize {
         self.threads.iter().filter(|t| t.state == ThreadState::Runnable).count()
@@ -528,6 +557,9 @@ pub struct Vm {
     pub(in crate::interpreter) clinit_failed: HashSet<String>,
     /// Canonical Class objects keyed by internal class name or descriptor.
     pub(in crate::interpreter) class_pool: HashMap<String, JRef>,
+    /// Class names defined through ClassLoader#defineClass in this VM session.
+    /// Used to scope per-instance class snapshots to dynamic/redefinable classes.
+    pub(in crate::interpreter) dynamically_defined_classes: HashSet<String>,
     /// Buffered `System.out.print` content until newline/println.
     pub(in crate::interpreter) stdout_buffer: String,
     /// Buffered `System.err.print` content until newline/println.
@@ -550,6 +582,19 @@ pub struct Vm {
     pub(in crate::interpreter) system_stdin: Option<JRef>,
     /// Singleton system ClassLoader instance (created on first access).
     pub(in crate::interpreter) system_classloader: Option<JRef>,
+    /// ClassLoader object registry by object identity.
+    pub(in crate::interpreter) loader_objects: HashMap<usize, JRef>,
+    /// Per-loader class registry: (loader identity, binary internal name) -> class lookup key.
+    /// Needed because class identity is loader-scoped even when VM-internal storage is keyed differently.
+    pub(in crate::interpreter) loader_defined_classes: HashMap<(usize, String), String>,
+    /// Defining loader identity by class lookup key.
+    pub(in crate::interpreter) class_defining_loader_ids: HashMap<String, usize>,
+    /// Binary internal class name by VM lookup key.
+    pub(in crate::interpreter) class_binary_names: HashMap<String, String>,
+    /// Snapshot class lookup key by object identity.
+    pub(in crate::interpreter) snapshot_lookup_keys: HashMap<usize, String>,
+    /// Monotonic counter for dynamic class lookup keys.
+    pub(in crate::interpreter) next_dynamic_lookup_id: u64,
     /// Green thread scheduler.
     pub(in crate::interpreter) scheduler: Scheduler,
     /// Object monitors keyed by object identity (Rc pointer address).
@@ -559,15 +604,57 @@ pub struct Vm {
     method_owner_cache: HashMap<(String, String, String), Option<String>>,
     /// Bounded LRU cache for compiled host-side regular expressions.
     regex_cache: RegexCache,
+    /// Assignability cache: (runtime_class, target_class) -> result.
+    /// Speeds up repeated `instanceof` / `Class.isAssignableFrom` checks.
+    instanceof_cache: HashMap<(String, String), bool>,
     /// Materialized non-class resources from loaded JARs, keyed by path.
     pub resources: HashMap<String, Vec<u8>>,
     /// Non-class resources that still point at compressed JAR entries.
     pending_resources: HashMap<String, JarEntryRef>,
+    /// Host filesystem roots checked when a resource is not present in loaded JARs.
+    filesystem_resource_roots: Vec<PathBuf>,
     /// Parsed ZIP archives kept alive so lazy entry reads do not re-scan the central directory.
     jar_archives: Vec<OwnedJarArchive>,
 }
 
 impl Vm {
+    fn ensure_clojure_compiler_loader_root(&mut self) {
+        let loader_var = self
+            .static_fields
+            .get("clojure/lang/Compiler")
+            .and_then(|m| m.get("LOADER"))
+            .and_then(|v| v.as_ref())
+            .cloned();
+        let Some(loader_var) = loader_var else {
+            return;
+        };
+        let is_unbound = loader_var
+            .borrow()
+            .fields
+            .get("root")
+            .and_then(|v| v.as_ref())
+            .map(|r| r.borrow().class_name == "clojure/lang/Var$Unbound")
+            .unwrap_or(false);
+        if !is_unbound {
+            return;
+        }
+        let Ok(loader) = self.invoke_static(
+            "clojure/lang/RT",
+            "makeClassLoader",
+            "()Ljava/lang/ClassLoader;",
+            vec![],
+        ) else {
+            return;
+        };
+        let _ = self.invoke_virtual(
+            loader_var,
+            "clojure/lang/Var",
+            "bindRoot",
+            "(Ljava/lang/Object;)V",
+            vec![loader],
+        );
+    }
+
     /// Create an empty VM with a main thread.
     pub fn new() -> Self {
         Vm {
@@ -577,6 +664,7 @@ impl Vm {
             clinit_done: HashSet::new(),
             clinit_failed: HashSet::new(),
             class_pool: HashMap::new(),
+            dynamically_defined_classes: HashSet::new(),
             stdout_buffer: String::new(),
             stderr_buffer: String::new(),
             stdin_mode: StdioMode::Pipe,
@@ -588,12 +676,21 @@ impl Vm {
             stdin_closed: false,
             system_stdin: None,
             system_classloader: None,
+            loader_objects: HashMap::new(),
+            loader_defined_classes: HashMap::new(),
+            class_defining_loader_ids: HashMap::new(),
+            class_binary_names: HashMap::new(),
+            snapshot_lookup_keys: HashMap::new(),
+            next_dynamic_lookup_id: 1,
             scheduler: Scheduler::new(),
             monitors: HashMap::new(),
             method_owner_cache: HashMap::new(),
             regex_cache: RegexCache::new(64),
+            instanceof_cache: HashMap::new(),
+            regex_cache: RegexCache::new(64),
             resources: HashMap::new(),
             pending_resources: HashMap::new(),
+            filesystem_resource_roots: vec![PathBuf::from("."), PathBuf::from("test")],
             jar_archives: Vec::new(),
         }
     }
@@ -704,12 +801,13 @@ impl Vm {
         // Set the woken thread to Runnable (outside the monitor borrow).
         if let Some(wid) = wake_thread {
             // Check if the woken thread needs saved_monitor_count restored.
-            let restore_count = self.scheduler.thread(wid).and_then(|t| {
-                if matches!(t.state, ThreadState::WaitingOnCondition(_)) && t.saved_monitor_count > 0 {
+            let restore_count = self.scheduler.thread(wid).and_then(|t| match t.state {
+                ThreadState::WaitingOnCondition(wait_obj_id)
+                    if wait_obj_id == id && t.saved_monitor_count > 0 =>
+                {
                     Some(t.saved_monitor_count)
-                } else {
-                    None
                 }
+                _ => None,
             });
             if let Some(count) = restore_count {
                 if let Some(m) = self.monitors.get_mut(&id) {
@@ -1027,6 +1125,8 @@ impl Vm {
         }
         self.jar_archives.push(archive);
         for (class_name, entry) in class_entries {
+            self.pending_resources
+                .insert(format!("{class_name}.class"), entry.clone());
             self.load_lazy_jar_entry(class_name, entry);
         }
         for (name, entry) in resource_entries {
@@ -1049,10 +1149,16 @@ impl Vm {
             return;
         }
         let pending = self.classes.remove(name);
+        let mut class_bytes: Option<Vec<u8>> = None;
         let result = match pending {
-            Some(LazyClass::PendingBytes(bytes)) => class_file::parse(&bytes).map_err(|e| e.to_string()),
+            Some(LazyClass::PendingBytes(bytes)) => {
+                class_bytes = Some(bytes.clone());
+                class_file::parse(&bytes).map_err(|e| e.to_string())
+            }
             Some(LazyClass::PendingJarEntry(entry)) => match self.read_jar_entry(&entry) {
-                Ok(bytes) => match class_file::parse(&bytes) {
+                Ok(bytes) => {
+                    class_bytes = Some(bytes.clone());
+                    match class_file::parse(&bytes) {
                     Ok(cf) => {
                         let actual_name = cf.constant_pool.class_name(cf.this_class);
                         if actual_name == name {
@@ -1068,7 +1174,8 @@ impl Vm {
                         }
                     }
                     Err(e) => Err(e.to_string()),
-                },
+                }
+                }
                 Err(e) => Err(e),
             },
             Some(other) => {
@@ -1078,7 +1185,14 @@ impl Vm {
             None => return,
         };
         match result {
-            Ok(cf) => { self.classes.insert(name.to_owned(), LazyClass::Ready(cf)); }
+            Ok(cf) => {
+                if let Some(bytes) = class_bytes {
+                    self.resources
+                        .entry(format!("{name}.class"))
+                        .or_insert(bytes);
+                }
+                self.classes.insert(name.to_owned(), LazyClass::Ready(cf));
+            }
             Err(e) => {
                 eprintln!("Warning: failed to parse class '{name}': {e}");
                 self.classes.insert(name.to_owned(), LazyClass::ParseError(e));
@@ -1086,9 +1200,42 @@ impl Vm {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    fn read_resource_from_filesystem(&self, normalized: &str) -> Result<Option<Vec<u8>>, String> {
+        use std::io::ErrorKind;
+        use std::path::Path;
+
+        let relative = Path::new(normalized);
+        for root in &self.filesystem_resource_roots {
+            let candidate = root.join(relative);
+            match std::fs::read(&candidate) {
+                Ok(bytes) => return Ok(Some(bytes)),
+                Err(err) if err.kind() == ErrorKind::NotFound => continue,
+                Err(err) => {
+                    return Err(format!(
+                        "filesystem resource read failed for {}: {err}",
+                        candidate.display()
+                    ));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn read_resource_from_filesystem(&self, _normalized: &str) -> Result<Option<Vec<u8>>, String> {
+        Ok(None)
+    }
+
     pub fn has_resource(&self, name: &str) -> bool {
         let normalized = name.strip_prefix('/').unwrap_or(name);
-        self.resources.contains_key(normalized) || self.pending_resources.contains_key(normalized)
+        self.resources.contains_key(normalized)
+            || self.pending_resources.contains_key(normalized)
+            || self
+                .read_resource_from_filesystem(normalized)
+                .ok()
+                .flatten()
+                .is_some()
     }
 
     pub fn read_resource(&mut self, name: &str) -> Result<Option<Vec<u8>>, String> {
@@ -1096,13 +1243,16 @@ impl Vm {
         if let Some(data) = self.resources.get(normalized) {
             return Ok(Some(data.clone()));
         }
-        let Some(entry) = self.pending_resources.get(normalized).cloned() else {
-            return Ok(None);
-        };
-        let data = self.read_jar_entry(&entry)?;
-        self.pending_resources.remove(normalized);
-        self.resources.insert(normalized.to_owned(), data.clone());
-        Ok(Some(data))
+        if let Some(entry) = self.pending_resources.get(normalized).cloned() {
+            let data = self.read_jar_entry(&entry)?;
+            self.pending_resources.remove(normalized);
+            self.resources.insert(normalized.to_owned(), data.clone());
+            return Ok(Some(data));
+        }
+        if let Some(bytes) = self.read_resource_from_filesystem(normalized)? {
+            return Ok(Some(bytes));
+        }
+        Ok(None)
     }
 
     /// Return a reference to a parsed class.
@@ -1340,18 +1490,174 @@ impl Vm {
     }
 
     fn class_object(&mut self, internal_name: impl Into<String>) -> JRef {
-        let internal_name = internal_name.into();
-        if let Some(r) = self.class_pool.get(&internal_name) {
+        let lookup_name = internal_name.into();
+        if let Some(r) = self.class_pool.get(&lookup_name) {
             return Rc::clone(r);
         }
+        let binary_name = self
+            .class_binary_names
+            .get(&lookup_name)
+            .cloned()
+            .unwrap_or_else(|| lookup_name.clone());
+        self.class_binary_names
+            .entry(lookup_name.clone())
+            .or_insert_with(|| binary_name.clone());
         let obj = JObject::new("java/lang/Class");
-        obj.borrow_mut().fields.insert(
-            "__name_internal".to_owned(),
-            JValue::Ref(Some(self.intern_string(internal_name.clone()))),
-        );
-        self.class_pool.insert(internal_name, Rc::clone(&obj));
+        let display_name = Self::class_display_name(&binary_name);
+        let defining_loader = self
+            .class_defining_loader_ids
+            .get(&lookup_name)
+            .and_then(|id| self.loader_objects.get(id))
+            .cloned();
+        {
+            let mut b = obj.borrow_mut();
+            b.fields.insert(
+                "__name_internal".to_owned(),
+                JValue::Ref(Some(self.intern_string(binary_name.clone()))),
+            );
+            b.fields.insert(
+                "__name_display".to_owned(),
+                JValue::Ref(Some(self.intern_string(display_name))),
+            );
+            if lookup_name != binary_name {
+                b.fields.insert(
+                    "__lookup_internal".to_owned(),
+                    JValue::Ref(Some(self.intern_string(lookup_name.clone()))),
+                );
+            }
+            b.fields
+                .insert("__defining_loader".to_owned(), JValue::Ref(defining_loader));
+        }
+        self.class_pool.insert(lookup_name, Rc::clone(&obj));
         obj
     }
+
+    pub(in crate::interpreter) fn class_object_with_lookup(
+        &mut self,
+        lookup_internal: &str,
+        display_internal: &str,
+    ) -> JRef {
+        self.class_binary_names
+            .insert(lookup_internal.to_owned(), display_internal.to_owned());
+        let class_obj = self.class_object(lookup_internal.to_owned());
+        if let Some(loader_ref) = self
+            .class_defining_loader_ids
+            .get(lookup_internal)
+            .and_then(|id| self.loader_objects.get(id))
+            .cloned()
+        {
+            class_obj
+                .borrow_mut()
+                .fields
+                .insert("__defining_loader".to_owned(), JValue::Ref(Some(loader_ref)));
+        }
+        class_obj
+    }
+
+    pub(in crate::interpreter) fn loader_lookup_internal_name(
+        &self,
+        loader_id: usize,
+        class_internal: &str,
+    ) -> Option<String> {
+        self.loader_defined_classes
+            .get(&(loader_id, class_internal.to_owned()))
+            .cloned()
+    }
+
+    pub(in crate::interpreter) fn has_loader_specific_definition(
+        &self,
+        class_internal: &str,
+    ) -> bool {
+        self.loader_defined_classes
+            .keys()
+            .any(|(_, defined)| defined == class_internal)
+    }
+
+    pub(in crate::interpreter) fn remap_declared_class_for_context(
+        &mut self,
+        context_class: &str,
+        declared_class: &str,
+    ) -> String {
+        let context_lookup_name = if let Some(desc_start) = context_class.find('(') {
+            if let Some(method_sep) = context_class[..desc_start].rfind('.') {
+                &context_class[..method_sep]
+            } else {
+                context_class
+            }
+        } else {
+            context_class
+        };
+        let Some(loader_id) = self.class_defining_loader_ids.get(context_lookup_name).copied() else {
+            return declared_class.to_owned();
+        };
+        if let Some(mapped) = self.loader_lookup_internal_name(loader_id, declared_class) {
+            return mapped;
+        }
+        if !self.has_loader_specific_definition(declared_class) {
+            return declared_class.to_owned();
+        }
+        let Some(loader_ref) = self.loader_objects.get(&loader_id).cloned() else {
+            return declared_class.to_owned();
+        };
+        let loader_class = loader_ref.borrow().class_name.clone();
+        let runtime_name = Self::class_display_name(declared_class);
+        let runtime_name_ref = self.intern_string(runtime_name);
+        let load_result = self.invoke_virtual(
+            loader_ref,
+            &loader_class,
+            "loadClass",
+            "(Ljava/lang/String;)Ljava/lang/Class;",
+            vec![JValue::Ref(Some(runtime_name_ref))],
+        );
+        match load_result {
+            Ok(JValue::Ref(Some(class_ref))) => self
+                .class_internal_name_from_obj(&class_ref)
+                .unwrap_or_else(|| declared_class.to_owned()),
+            _ => declared_class.to_owned(),
+        }
+    }
+
+    pub(in crate::interpreter) fn class_binary_name_for_lookup(&self, class_name: &str) -> String {
+        self.class_binary_names
+            .get(class_name)
+            .cloned()
+            .unwrap_or_else(|| class_name.to_owned())
+    }
+
+    pub(in crate::interpreter) fn next_dynamic_lookup_key(&mut self) -> String {
+        let id = self.next_dynamic_lookup_id;
+        self.next_dynamic_lookup_id = self.next_dynamic_lookup_id.saturating_add(1);
+        format!("__199xvm/dyn/{id}")
+    }
+
+    pub(in crate::interpreter) fn ensure_snapshot_lookup_class(
+        &mut self,
+        obj: &JRef,
+        runtime_class: &str,
+        snapshot: &ClassFile,
+    ) -> String {
+        let object_id = Rc::as_ptr(obj) as usize;
+        if let Some(key) = self.snapshot_lookup_keys.get(&object_id) {
+            if !matches!(self.classes.get(key), Some(LazyClass::Ready(_))) {
+                self.classes
+                    .insert(key.clone(), LazyClass::Ready(snapshot.clone()));
+            }
+            return key.clone();
+        }
+        let lookup_key = self.next_dynamic_lookup_key();
+        let binary_name = self.class_binary_name_for_lookup(runtime_class);
+        self.class_binary_names
+            .insert(lookup_key.clone(), binary_name);
+        if let Some(loader_id) = self.class_defining_loader_ids.get(runtime_class).copied() {
+            self.class_defining_loader_ids
+                .insert(lookup_key.clone(), loader_id);
+        }
+        self.classes
+            .insert(lookup_key.clone(), LazyClass::Ready(snapshot.clone()));
+        self.snapshot_lookup_keys.insert(object_id, lookup_key.clone());
+        lookup_key
+    }
+
 
     /// Look up a loaded class by internal name (triggers lazy parse if needed).
     pub fn class(&mut self, name: &str) -> Option<&ClassFile> {
@@ -1421,7 +1727,7 @@ impl Vm {
             class.constant_pool.utf8(m.name_index) == method_name
                 && class.constant_pool.utf8(m.descriptor_index) == descriptor
         })?;
-        let class_name_out = class.constant_pool.class_name(class.this_class).to_owned();
+        let class_name_out = owner.clone();
         let descriptor_out = class.constant_pool.utf8(class.methods[method_idx].descriptor_index).to_owned();
         let access_flags = class.methods[method_idx].access_flags;
         let (max_locals, has_code, code, exception_table) =
@@ -1482,7 +1788,7 @@ impl Vm {
             let n = class.constant_pool.utf8(m.name_index);
             let d = class.constant_pool.utf8(m.descriptor_index);
             if n == method_name && d == descriptor {
-                return Some(class.constant_pool.class_name(class.this_class).to_owned());
+                return Some(class_name.to_owned());
             }
         }
         // Resolve names while holding the borrow; allocation is skipped on the fast path.
@@ -1653,6 +1959,9 @@ impl Vm {
                 return Err("java/lang/ExceptionInInitializerError".to_owned());
             }
         }
+        if class_name == "clojure/lang/Compiler" {
+            self.ensure_clojure_compiler_loader_root();
+        }
         Ok(())
     }
 
@@ -1684,11 +1993,41 @@ impl Vm {
     /// Check if `runtime_class` is an instance of `target_class` (by name).
     /// Handles array types per JVMS §6.5.instanceof / §6.5.checkcast.
     fn is_instance_of(&mut self, runtime_class: &str, target_class: &str) -> bool {
-        if runtime_class == target_class { return true; }
-        if target_class == "java/lang/Object" { return true; }
+        let cache_key = (runtime_class.to_owned(), target_class.to_owned());
+        if let Some(cached) = self.instanceof_cache.get(&cache_key) {
+            return *cached;
+        }
+        let mut visited = std::collections::HashSet::new();
+        let result = self.is_instance_of_inner(runtime_class, target_class, &mut visited);
+        self.instanceof_cache.insert(cache_key, result);
+        result
+    }
+
+    fn is_instance_of_inner(
+        &mut self,
+        runtime_class: &str,
+        target_class: &str,
+        visited: &mut std::collections::HashSet<(String, String)>,
+    ) -> bool {
+        let cache_key = (runtime_class.to_owned(), target_class.to_owned());
+        if let Some(cached) = self.instanceof_cache.get(&cache_key) {
+            return *cached;
+        }
+        if !visited.insert(cache_key.clone()) {
+            return false;
+        }
+        if runtime_class == target_class {
+            self.instanceof_cache.insert(cache_key, true);
+            return true;
+        }
+        if target_class == "java/lang/Object" {
+            self.instanceof_cache.insert(cache_key, true);
+            return true;
+        }
 
         if runtime_class.starts_with('[') {
             if target_class == "java/lang/Cloneable" || target_class == "java/io/Serializable" {
+                self.instanceof_cache.insert(cache_key, true);
                 return true;
             }
             if target_class.starts_with('[') {
@@ -1697,10 +2036,14 @@ impl Vm {
                 let rc_class = descriptor_to_class_name(rc);
                 let tc_class = descriptor_to_class_name(tc);
                 if let (Some(r), Some(t)) = (rc_class, tc_class) {
-                    return self.is_instance_of(&r, &t);
+                    let result = self.is_instance_of_inner(&r, &t, visited);
+                    self.instanceof_cache.insert(cache_key, result);
+                    return result;
                 }
+                self.instanceof_cache.insert(cache_key, false);
                 return false;
             }
+            self.instanceof_cache.insert(cache_key, false);
             return false;
         }
 
@@ -1716,16 +2059,22 @@ impl Vm {
             };
             (ifaces, sup)
         } else {
+            self.instanceof_cache.insert(cache_key, false);
             return false;
         };
         for iface_name in &iface_names {
-            if self.is_instance_of(iface_name, target_class) { return true; }
-        }
-        if let Some(super_name) = super_name {
-            if self.is_instance_of(&super_name, target_class) {
+            if self.is_instance_of_inner(iface_name, target_class, visited) {
+                self.instanceof_cache.insert(cache_key, true);
                 return true;
             }
         }
+        if let Some(super_name) = super_name {
+            if self.is_instance_of_inner(&super_name, target_class, visited) {
+                self.instanceof_cache.insert(cache_key, true);
+                return true;
+            }
+        }
+        self.instanceof_cache.insert(cache_key, false);
         false
     }
 }

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -9,9 +9,7 @@
 //! - Native stubs for `java.lang.*` and `java.util.*`
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::PathBuf;
 use std::rc::Rc;
-use std::time::Instant;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -360,8 +358,6 @@ pub(crate) struct ThreadContext {
     pub instruction_count: usize,
     /// Saved monitor reentrant count for Object.wait() — restored after notify.
     pub saved_monitor_count: usize,
-    /// Wake-up deadline for `Thread.sleep` in host monotonic time.
-    pub sleep_until: Option<Instant>,
 }
 
 impl ThreadContext {
@@ -375,7 +371,6 @@ impl ThreadContext {
             thread_object: None,
             instruction_count: 0,
             saved_monitor_count: 0,
-            sleep_until: None,
         }
     }
 }
@@ -389,10 +384,7 @@ pub(crate) struct Scheduler {
 }
 
 /// Maximum instructions per thread before yielding to the next runnable thread.
-///
-/// A larger slice reduces scheduler churn when many runnable green threads are
-/// CPU-bound (for example, test harnesses that spawn many short-lived futures).
-const TIME_SLICE: usize = 10_000;
+const TIME_SLICE: usize = 1000;
 
 impl Scheduler {
     pub(in crate::interpreter) fn new() -> Self {
@@ -477,27 +469,6 @@ impl Scheduler {
         }
     }
 
-    /// Wake sleeping threads whose deadlines have elapsed.
-    pub fn wake_sleepers(&mut self) {
-        let now = Instant::now();
-        for t in &mut self.threads {
-            if t.state != ThreadState::Sleeping {
-                continue;
-            }
-            if let Some(deadline) = t.sleep_until {
-                if now >= deadline {
-                    t.sleep_until = None;
-                    t.state = ThreadState::Runnable;
-                }
-            }
-        }
-    }
-
-    /// Returns true when at least one thread is currently sleeping.
-    pub fn has_sleeping_threads(&self) -> bool {
-        self.threads.iter().any(|t| t.state == ThreadState::Sleeping)
-    }
-
     /// Return the number of runnable threads.
     pub fn runnable_count(&self) -> usize {
         self.threads.iter().filter(|t| t.state == ThreadState::Runnable).count()
@@ -557,9 +528,6 @@ pub struct Vm {
     pub(in crate::interpreter) clinit_failed: HashSet<String>,
     /// Canonical Class objects keyed by internal class name or descriptor.
     pub(in crate::interpreter) class_pool: HashMap<String, JRef>,
-    /// Class names defined through ClassLoader#defineClass in this VM session.
-    /// Used to scope per-instance class snapshots to dynamic/redefinable classes.
-    pub(in crate::interpreter) dynamically_defined_classes: HashSet<String>,
     /// Buffered `System.out.print` content until newline/println.
     pub(in crate::interpreter) stdout_buffer: String,
     /// Buffered `System.err.print` content until newline/println.
@@ -582,17 +550,14 @@ pub struct Vm {
     pub(in crate::interpreter) system_stdin: Option<JRef>,
     /// Singleton system ClassLoader instance (created on first access).
     pub(in crate::interpreter) system_classloader: Option<JRef>,
-    /// ClassLoader object registry by object identity.
+    /// ClassLoader objects by VM object identity.
     pub(in crate::interpreter) loader_objects: HashMap<usize, JRef>,
-    /// Per-loader class registry: (loader identity, binary internal name) -> class lookup key.
-    /// Needed because class identity is loader-scoped even when VM-internal storage is keyed differently.
+    /// Loader-scoped class registry: (loader identity, binary internal name) -> VM lookup key.
     pub(in crate::interpreter) loader_defined_classes: HashMap<(usize, String), String>,
-    /// Defining loader identity by class lookup key.
+    /// Defining loader identity by VM lookup key.
     pub(in crate::interpreter) class_defining_loader_ids: HashMap<String, usize>,
     /// Binary internal class name by VM lookup key.
     pub(in crate::interpreter) class_binary_names: HashMap<String, String>,
-    /// Snapshot class lookup key by object identity.
-    pub(in crate::interpreter) snapshot_lookup_keys: HashMap<usize, String>,
     /// Monotonic counter for dynamic class lookup keys.
     pub(in crate::interpreter) next_dynamic_lookup_id: u64,
     /// Green thread scheduler.
@@ -604,57 +569,15 @@ pub struct Vm {
     method_owner_cache: HashMap<(String, String, String), Option<String>>,
     /// Bounded LRU cache for compiled host-side regular expressions.
     regex_cache: RegexCache,
-    /// Assignability cache: (runtime_class, target_class) -> result.
-    /// Speeds up repeated `instanceof` / `Class.isAssignableFrom` checks.
-    instanceof_cache: HashMap<(String, String), bool>,
     /// Materialized non-class resources from loaded JARs, keyed by path.
     pub resources: HashMap<String, Vec<u8>>,
     /// Non-class resources that still point at compressed JAR entries.
     pending_resources: HashMap<String, JarEntryRef>,
-    /// Host filesystem roots checked when a resource is not present in loaded JARs.
-    filesystem_resource_roots: Vec<PathBuf>,
     /// Parsed ZIP archives kept alive so lazy entry reads do not re-scan the central directory.
     jar_archives: Vec<OwnedJarArchive>,
 }
 
 impl Vm {
-    fn ensure_clojure_compiler_loader_root(&mut self) {
-        let loader_var = self
-            .static_fields
-            .get("clojure/lang/Compiler")
-            .and_then(|m| m.get("LOADER"))
-            .and_then(|v| v.as_ref())
-            .cloned();
-        let Some(loader_var) = loader_var else {
-            return;
-        };
-        let is_unbound = loader_var
-            .borrow()
-            .fields
-            .get("root")
-            .and_then(|v| v.as_ref())
-            .map(|r| r.borrow().class_name == "clojure/lang/Var$Unbound")
-            .unwrap_or(false);
-        if !is_unbound {
-            return;
-        }
-        let Ok(loader) = self.invoke_static(
-            "clojure/lang/RT",
-            "makeClassLoader",
-            "()Ljava/lang/ClassLoader;",
-            vec![],
-        ) else {
-            return;
-        };
-        let _ = self.invoke_virtual(
-            loader_var,
-            "clojure/lang/Var",
-            "bindRoot",
-            "(Ljava/lang/Object;)V",
-            vec![loader],
-        );
-    }
-
     /// Create an empty VM with a main thread.
     pub fn new() -> Self {
         Vm {
@@ -664,7 +587,6 @@ impl Vm {
             clinit_done: HashSet::new(),
             clinit_failed: HashSet::new(),
             class_pool: HashMap::new(),
-            dynamically_defined_classes: HashSet::new(),
             stdout_buffer: String::new(),
             stderr_buffer: String::new(),
             stdin_mode: StdioMode::Pipe,
@@ -680,17 +602,13 @@ impl Vm {
             loader_defined_classes: HashMap::new(),
             class_defining_loader_ids: HashMap::new(),
             class_binary_names: HashMap::new(),
-            snapshot_lookup_keys: HashMap::new(),
             next_dynamic_lookup_id: 1,
             scheduler: Scheduler::new(),
             monitors: HashMap::new(),
             method_owner_cache: HashMap::new(),
             regex_cache: RegexCache::new(64),
-            instanceof_cache: HashMap::new(),
-            regex_cache: RegexCache::new(64),
             resources: HashMap::new(),
             pending_resources: HashMap::new(),
-            filesystem_resource_roots: vec![PathBuf::from("."), PathBuf::from("test")],
             jar_archives: Vec::new(),
         }
     }
@@ -801,13 +719,12 @@ impl Vm {
         // Set the woken thread to Runnable (outside the monitor borrow).
         if let Some(wid) = wake_thread {
             // Check if the woken thread needs saved_monitor_count restored.
-            let restore_count = self.scheduler.thread(wid).and_then(|t| match t.state {
-                ThreadState::WaitingOnCondition(wait_obj_id)
-                    if wait_obj_id == id && t.saved_monitor_count > 0 =>
-                {
+            let restore_count = self.scheduler.thread(wid).and_then(|t| {
+                if matches!(t.state, ThreadState::WaitingOnCondition(_)) && t.saved_monitor_count > 0 {
                     Some(t.saved_monitor_count)
+                } else {
+                    None
                 }
-                _ => None,
             });
             if let Some(count) = restore_count {
                 if let Some(m) = self.monitors.get_mut(&id) {
@@ -1125,8 +1042,6 @@ impl Vm {
         }
         self.jar_archives.push(archive);
         for (class_name, entry) in class_entries {
-            self.pending_resources
-                .insert(format!("{class_name}.class"), entry.clone());
             self.load_lazy_jar_entry(class_name, entry);
         }
         for (name, entry) in resource_entries {
@@ -1149,16 +1064,10 @@ impl Vm {
             return;
         }
         let pending = self.classes.remove(name);
-        let mut class_bytes: Option<Vec<u8>> = None;
         let result = match pending {
-            Some(LazyClass::PendingBytes(bytes)) => {
-                class_bytes = Some(bytes.clone());
-                class_file::parse(&bytes).map_err(|e| e.to_string())
-            }
+            Some(LazyClass::PendingBytes(bytes)) => class_file::parse(&bytes).map_err(|e| e.to_string()),
             Some(LazyClass::PendingJarEntry(entry)) => match self.read_jar_entry(&entry) {
-                Ok(bytes) => {
-                    class_bytes = Some(bytes.clone());
-                    match class_file::parse(&bytes) {
+                Ok(bytes) => match class_file::parse(&bytes) {
                     Ok(cf) => {
                         let actual_name = cf.constant_pool.class_name(cf.this_class);
                         if actual_name == name {
@@ -1174,8 +1083,7 @@ impl Vm {
                         }
                     }
                     Err(e) => Err(e.to_string()),
-                }
-                }
+                },
                 Err(e) => Err(e),
             },
             Some(other) => {
@@ -1185,14 +1093,7 @@ impl Vm {
             None => return,
         };
         match result {
-            Ok(cf) => {
-                if let Some(bytes) = class_bytes {
-                    self.resources
-                        .entry(format!("{name}.class"))
-                        .or_insert(bytes);
-                }
-                self.classes.insert(name.to_owned(), LazyClass::Ready(cf));
-            }
+            Ok(cf) => { self.classes.insert(name.to_owned(), LazyClass::Ready(cf)); }
             Err(e) => {
                 eprintln!("Warning: failed to parse class '{name}': {e}");
                 self.classes.insert(name.to_owned(), LazyClass::ParseError(e));
@@ -1200,42 +1101,9 @@ impl Vm {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    fn read_resource_from_filesystem(&self, normalized: &str) -> Result<Option<Vec<u8>>, String> {
-        use std::io::ErrorKind;
-        use std::path::Path;
-
-        let relative = Path::new(normalized);
-        for root in &self.filesystem_resource_roots {
-            let candidate = root.join(relative);
-            match std::fs::read(&candidate) {
-                Ok(bytes) => return Ok(Some(bytes)),
-                Err(err) if err.kind() == ErrorKind::NotFound => continue,
-                Err(err) => {
-                    return Err(format!(
-                        "filesystem resource read failed for {}: {err}",
-                        candidate.display()
-                    ));
-                }
-            }
-        }
-        Ok(None)
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn read_resource_from_filesystem(&self, _normalized: &str) -> Result<Option<Vec<u8>>, String> {
-        Ok(None)
-    }
-
     pub fn has_resource(&self, name: &str) -> bool {
         let normalized = name.strip_prefix('/').unwrap_or(name);
-        self.resources.contains_key(normalized)
-            || self.pending_resources.contains_key(normalized)
-            || self
-                .read_resource_from_filesystem(normalized)
-                .ok()
-                .flatten()
-                .is_some()
+        self.resources.contains_key(normalized) || self.pending_resources.contains_key(normalized)
     }
 
     pub fn read_resource(&mut self, name: &str) -> Result<Option<Vec<u8>>, String> {
@@ -1243,16 +1111,13 @@ impl Vm {
         if let Some(data) = self.resources.get(normalized) {
             return Ok(Some(data.clone()));
         }
-        if let Some(entry) = self.pending_resources.get(normalized).cloned() {
-            let data = self.read_jar_entry(&entry)?;
-            self.pending_resources.remove(normalized);
-            self.resources.insert(normalized.to_owned(), data.clone());
-            return Ok(Some(data));
-        }
-        if let Some(bytes) = self.read_resource_from_filesystem(normalized)? {
-            return Ok(Some(bytes));
-        }
-        Ok(None)
+        let Some(entry) = self.pending_resources.get(normalized).cloned() else {
+            return Ok(None);
+        };
+        let data = self.read_jar_entry(&entry)?;
+        self.pending_resources.remove(normalized);
+        self.resources.insert(normalized.to_owned(), data.clone());
+        Ok(Some(data))
     }
 
     /// Return a reference to a parsed class.
@@ -1490,87 +1355,57 @@ impl Vm {
     }
 
     fn class_object(&mut self, internal_name: impl Into<String>) -> JRef {
-        let lookup_name = internal_name.into();
-        if let Some(r) = self.class_pool.get(&lookup_name) {
+        let internal_name = internal_name.into();
+        if let Some(r) = self.class_pool.get(&internal_name) {
             return Rc::clone(r);
         }
-        let binary_name = self
-            .class_binary_names
-            .get(&lookup_name)
-            .cloned()
-            .unwrap_or_else(|| lookup_name.clone());
         self.class_binary_names
-            .entry(lookup_name.clone())
-            .or_insert_with(|| binary_name.clone());
+            .entry(internal_name.clone())
+            .or_insert_with(|| internal_name.clone());
         let obj = JObject::new("java/lang/Class");
-        let display_name = Self::class_display_name(&binary_name);
         let defining_loader = self
             .class_defining_loader_ids
-            .get(&lookup_name)
+            .get(&internal_name)
             .and_then(|id| self.loader_objects.get(id))
             .cloned();
-        {
-            let mut b = obj.borrow_mut();
-            b.fields.insert(
-                "__name_internal".to_owned(),
-                JValue::Ref(Some(self.intern_string(binary_name.clone()))),
-            );
-            b.fields.insert(
-                "__name_display".to_owned(),
-                JValue::Ref(Some(self.intern_string(display_name))),
-            );
-            if lookup_name != binary_name {
-                b.fields.insert(
-                    "__lookup_internal".to_owned(),
-                    JValue::Ref(Some(self.intern_string(lookup_name.clone()))),
-                );
-            }
-            b.fields
-                .insert("__defining_loader".to_owned(), JValue::Ref(defining_loader));
-        }
-        self.class_pool.insert(lookup_name, Rc::clone(&obj));
+        obj.borrow_mut().fields.insert(
+            "__name_internal".to_owned(),
+            JValue::Ref(Some(self.intern_string(internal_name.clone()))),
+        );
+        obj.borrow_mut()
+            .fields
+            .insert("__defining_loader".to_owned(), JValue::Ref(defining_loader));
+        self.class_pool.insert(internal_name, Rc::clone(&obj));
         obj
     }
 
     pub(in crate::interpreter) fn class_object_with_lookup(
         &mut self,
         lookup_internal: &str,
-        display_internal: &str,
+        binary_internal: &str,
     ) -> JRef {
         self.class_binary_names
-            .insert(lookup_internal.to_owned(), display_internal.to_owned());
-        let class_obj = self.class_object(lookup_internal.to_owned());
-        if let Some(loader_ref) = self
-            .class_defining_loader_ids
-            .get(lookup_internal)
-            .and_then(|id| self.loader_objects.get(id))
-            .cloned()
-        {
-            class_obj
-                .borrow_mut()
-                .fields
-                .insert("__defining_loader".to_owned(), JValue::Ref(Some(loader_ref)));
-        }
-        class_obj
+            .insert(lookup_internal.to_owned(), binary_internal.to_owned());
+        self.class_object(lookup_internal.to_owned())
     }
 
     pub(in crate::interpreter) fn loader_lookup_internal_name(
         &self,
         loader_id: usize,
-        class_internal: &str,
+        binary_internal: &str,
     ) -> Option<String> {
         self.loader_defined_classes
-            .get(&(loader_id, class_internal.to_owned()))
+            .get(&(loader_id, binary_internal.to_owned()))
             .cloned()
     }
 
     pub(in crate::interpreter) fn has_loader_specific_definition(
         &self,
-        class_internal: &str,
+        binary_internal: &str,
     ) -> bool {
         self.loader_defined_classes
             .keys()
-            .any(|(_, defined)| defined == class_internal)
+            .any(|(_, defined)| defined == binary_internal)
     }
 
     pub(in crate::interpreter) fn remap_declared_class_for_context(
@@ -1578,16 +1413,15 @@ impl Vm {
         context_class: &str,
         declared_class: &str,
     ) -> String {
-        let context_lookup_name = if let Some(desc_start) = context_class.find('(') {
-            if let Some(method_sep) = context_class[..desc_start].rfind('.') {
-                &context_class[..method_sep]
-            } else {
-                context_class
-            }
+        let context_lookup = if let Some(desc_start) = context_class.find('(') {
+            context_class[..desc_start]
+                .rfind('.')
+                .map(|sep| &context_class[..sep])
+                .unwrap_or(context_class)
         } else {
             context_class
         };
-        let Some(loader_id) = self.class_defining_loader_ids.get(context_lookup_name).copied() else {
+        let Some(loader_id) = self.class_defining_loader_ids.get(context_lookup).copied() else {
             return declared_class.to_owned();
         };
         if let Some(mapped) = self.loader_lookup_internal_name(loader_id, declared_class) {
@@ -1600,16 +1434,14 @@ impl Vm {
             return declared_class.to_owned();
         };
         let loader_class = loader_ref.borrow().class_name.clone();
-        let runtime_name = Self::class_display_name(declared_class);
-        let runtime_name_ref = self.intern_string(runtime_name);
-        let load_result = self.invoke_virtual(
+        let runtime_name_ref = self.intern_string(Self::class_display_name(declared_class));
+        match self.invoke_virtual(
             loader_ref,
             &loader_class,
             "loadClass",
             "(Ljava/lang/String;)Ljava/lang/Class;",
             vec![JValue::Ref(Some(runtime_name_ref))],
-        );
-        match load_result {
+        ) {
             Ok(JValue::Ref(Some(class_ref))) => self
                 .class_internal_name_from_obj(&class_ref)
                 .unwrap_or_else(|| declared_class.to_owned()),
@@ -1629,35 +1461,6 @@ impl Vm {
         self.next_dynamic_lookup_id = self.next_dynamic_lookup_id.saturating_add(1);
         format!("__199xvm/dyn/{id}")
     }
-
-    pub(in crate::interpreter) fn ensure_snapshot_lookup_class(
-        &mut self,
-        obj: &JRef,
-        runtime_class: &str,
-        snapshot: &ClassFile,
-    ) -> String {
-        let object_id = Rc::as_ptr(obj) as usize;
-        if let Some(key) = self.snapshot_lookup_keys.get(&object_id) {
-            if !matches!(self.classes.get(key), Some(LazyClass::Ready(_))) {
-                self.classes
-                    .insert(key.clone(), LazyClass::Ready(snapshot.clone()));
-            }
-            return key.clone();
-        }
-        let lookup_key = self.next_dynamic_lookup_key();
-        let binary_name = self.class_binary_name_for_lookup(runtime_class);
-        self.class_binary_names
-            .insert(lookup_key.clone(), binary_name);
-        if let Some(loader_id) = self.class_defining_loader_ids.get(runtime_class).copied() {
-            self.class_defining_loader_ids
-                .insert(lookup_key.clone(), loader_id);
-        }
-        self.classes
-            .insert(lookup_key.clone(), LazyClass::Ready(snapshot.clone()));
-        self.snapshot_lookup_keys.insert(object_id, lookup_key.clone());
-        lookup_key
-    }
-
 
     /// Look up a loaded class by internal name (triggers lazy parse if needed).
     pub fn class(&mut self, name: &str) -> Option<&ClassFile> {
@@ -1727,7 +1530,7 @@ impl Vm {
             class.constant_pool.utf8(m.name_index) == method_name
                 && class.constant_pool.utf8(m.descriptor_index) == descriptor
         })?;
-        let class_name_out = owner.clone();
+        let class_name_out = class.constant_pool.class_name(class.this_class).to_owned();
         let descriptor_out = class.constant_pool.utf8(class.methods[method_idx].descriptor_index).to_owned();
         let access_flags = class.methods[method_idx].access_flags;
         let (max_locals, has_code, code, exception_table) =
@@ -1788,7 +1591,7 @@ impl Vm {
             let n = class.constant_pool.utf8(m.name_index);
             let d = class.constant_pool.utf8(m.descriptor_index);
             if n == method_name && d == descriptor {
-                return Some(class_name.to_owned());
+                return Some(class.constant_pool.class_name(class.this_class).to_owned());
             }
         }
         // Resolve names while holding the borrow; allocation is skipped on the fast path.
@@ -1959,9 +1762,6 @@ impl Vm {
                 return Err("java/lang/ExceptionInInitializerError".to_owned());
             }
         }
-        if class_name == "clojure/lang/Compiler" {
-            self.ensure_clojure_compiler_loader_root();
-        }
         Ok(())
     }
 
@@ -1993,41 +1793,11 @@ impl Vm {
     /// Check if `runtime_class` is an instance of `target_class` (by name).
     /// Handles array types per JVMS §6.5.instanceof / §6.5.checkcast.
     fn is_instance_of(&mut self, runtime_class: &str, target_class: &str) -> bool {
-        let cache_key = (runtime_class.to_owned(), target_class.to_owned());
-        if let Some(cached) = self.instanceof_cache.get(&cache_key) {
-            return *cached;
-        }
-        let mut visited = std::collections::HashSet::new();
-        let result = self.is_instance_of_inner(runtime_class, target_class, &mut visited);
-        self.instanceof_cache.insert(cache_key, result);
-        result
-    }
-
-    fn is_instance_of_inner(
-        &mut self,
-        runtime_class: &str,
-        target_class: &str,
-        visited: &mut std::collections::HashSet<(String, String)>,
-    ) -> bool {
-        let cache_key = (runtime_class.to_owned(), target_class.to_owned());
-        if let Some(cached) = self.instanceof_cache.get(&cache_key) {
-            return *cached;
-        }
-        if !visited.insert(cache_key.clone()) {
-            return false;
-        }
-        if runtime_class == target_class {
-            self.instanceof_cache.insert(cache_key, true);
-            return true;
-        }
-        if target_class == "java/lang/Object" {
-            self.instanceof_cache.insert(cache_key, true);
-            return true;
-        }
+        if runtime_class == target_class { return true; }
+        if target_class == "java/lang/Object" { return true; }
 
         if runtime_class.starts_with('[') {
             if target_class == "java/lang/Cloneable" || target_class == "java/io/Serializable" {
-                self.instanceof_cache.insert(cache_key, true);
                 return true;
             }
             if target_class.starts_with('[') {
@@ -2036,14 +1806,10 @@ impl Vm {
                 let rc_class = descriptor_to_class_name(rc);
                 let tc_class = descriptor_to_class_name(tc);
                 if let (Some(r), Some(t)) = (rc_class, tc_class) {
-                    let result = self.is_instance_of_inner(&r, &t, visited);
-                    self.instanceof_cache.insert(cache_key, result);
-                    return result;
+                    return self.is_instance_of(&r, &t);
                 }
-                self.instanceof_cache.insert(cache_key, false);
                 return false;
             }
-            self.instanceof_cache.insert(cache_key, false);
             return false;
         }
 
@@ -2059,22 +1825,16 @@ impl Vm {
             };
             (ifaces, sup)
         } else {
-            self.instanceof_cache.insert(cache_key, false);
             return false;
         };
         for iface_name in &iface_names {
-            if self.is_instance_of_inner(iface_name, target_class, visited) {
-                self.instanceof_cache.insert(cache_key, true);
-                return true;
-            }
+            if self.is_instance_of(iface_name, target_class) { return true; }
         }
         if let Some(super_name) = super_name {
-            if self.is_instance_of_inner(&super_name, target_class, visited) {
-                self.instanceof_cache.insert(cache_key, true);
+            if self.is_instance_of(&super_name, target_class) {
                 return true;
             }
         }
-        self.instanceof_cache.insert(cache_key, false);
         false
     }
 }

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -333,11 +333,24 @@ impl super::Vm {
         }
     }
 
+    fn classloader_object_id(loader: &JRef) -> usize {
+        Rc::as_ptr(loader) as usize
+    }
+
     /// Handle ClassLoader instance methods that must dispatch by resolved owner, not runtime class.
     /// Returns `Some(value)` if the method was handled, `None` to fall through.
-    fn native_classloader(&mut self, method_name: &str, args: &[JValue]) -> Option<JValue> {
+    fn native_classloader(&mut self, this: &JRef, method_name: &str, args: &[JValue]) -> Option<JValue> {
+        let loader_id = Self::classloader_object_id(this);
+        let is_system_loader = self
+            .system_classloader
+            .as_ref()
+            .map(|sys| Rc::ptr_eq(sys, this))
+            .unwrap_or(false);
+        self.loader_objects
+            .entry(loader_id)
+            .or_insert_with(|| this.clone());
         match method_name {
-            "loadClass" | "findClass" => {
+            "findClass" => {
                 // A null or missing name argument must surface as NullPointerException.
                 // (`defineClass` accepts a null name per JDK spec, so the check is here only.)
                 let name_str = match args
@@ -352,20 +365,55 @@ impl super::Vm {
                     }
                 };
                 let internal = Self::class_internal_name_from_runtime_name(&name_str);
+                if let Some(lookup_key) = self.loader_lookup_internal_name(loader_id, &internal) {
+                    self.ensure_class_ready(&lookup_key);
+                    return match self.classes.get(&lookup_key) {
+                        Some(LazyClass::Ready(_)) => {
+                            Some(JValue::Ref(Some(self.class_object_with_lookup(&lookup_key, &internal))))
+                        }
+                        Some(LazyClass::ParseError(msg)) => {
+                            let msg = msg.clone();
+                            self.throw_class_format_error(&msg);
+                            Some(JValue::Void)
+                        }
+                        _ => {
+                            self.throw_class_not_found(&name_str);
+                            Some(JValue::Void)
+                        }
+                    };
+                }
+                if !is_system_loader && self.has_loader_specific_definition(&internal) {
+                    self.throw_class_not_found(&name_str);
+                    return Some(JValue::Void);
+                }
                 self.ensure_class_ready(&internal);
-                match self.classes.get(&internal) {
-                    Some(LazyClass::Ready(_)) => {}
+                let resolved_name = match self.classes.get(&internal) {
+                    Some(LazyClass::Ready(_)) => Some(internal.clone()),
                     Some(LazyClass::ParseError(msg)) => {
                         let msg = msg.clone();
                         self.throw_class_format_error(&msg);
                         return Some(JValue::Void);
                     }
                     _ => {
+                        self.ensure_class_ready(&name_str);
+                        match self.classes.get(&name_str) {
+                            Some(LazyClass::Ready(_)) => Some(name_str.clone()),
+                            Some(LazyClass::ParseError(msg)) => {
+                                let msg = msg.clone();
+                                self.throw_class_format_error(&msg);
+                                return Some(JValue::Void);
+                            }
+                            _ => None,
+                        }
+                    }
+                };
+                match resolved_name {
+                    Some(name) => Some(JValue::Ref(Some(self.class_object(name)))),
+                    None => {
                         self.throw_class_not_found(&name_str);
-                        return Some(JValue::Void);
+                        Some(JValue::Void)
                     }
                 }
-                Some(JValue::Ref(Some(self.class_object(internal))))
             }
             "findLoadedClass" => {
                 let name_str = args
@@ -374,8 +422,29 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
                     .unwrap_or_default();
                 let internal = Self::class_internal_name_from_runtime_name(&name_str);
-                if matches!(self.classes.get(&internal), Some(LazyClass::Ready(_))) {
+                if let Some(lookup_key) = self.loader_lookup_internal_name(loader_id, &internal) {
+                    if matches!(self.classes.get(&lookup_key), Some(LazyClass::Ready(_))) {
+                        return Some(JValue::Ref(Some(
+                            self.class_object_with_lookup(&lookup_key, &internal),
+                        )));
+                    }
+                }
+                if self.class_defining_loader_ids.get(&internal).copied() == Some(loader_id)
+                    && matches!(self.classes.get(&internal), Some(LazyClass::Ready(_)))
+                {
                     Some(JValue::Ref(Some(self.class_object(internal))))
+                } else if self.class_defining_loader_ids.get(&name_str).copied() == Some(loader_id)
+                    && matches!(self.classes.get(&name_str), Some(LazyClass::Ready(_)))
+                {
+                    Some(JValue::Ref(Some(self.class_object(name_str))))
+                } else if is_system_loader {
+                    if matches!(self.classes.get(&internal), Some(LazyClass::Ready(_))) {
+                        Some(JValue::Ref(Some(self.class_object(internal))))
+                    } else if matches!(self.classes.get(&name_str), Some(LazyClass::Ready(_))) {
+                        Some(JValue::Ref(Some(self.class_object(name_str))))
+                    } else {
+                        Some(JValue::Ref(None))
+                    }
                 } else {
                     Some(JValue::Ref(None))
                 }
@@ -383,6 +452,10 @@ impl super::Vm {
             "defineClass" => {
                 // Extract byte[] argument (2nd arg), off (3rd), len (4th).
                 // Supports both 4-arg and 5-arg (with ProtectionDomain) variants.
+                let requested_name = args
+                    .first()
+                    .and_then(|v| v.as_ref())
+                    .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()));
                 let byte_array = args.get(1)
                     .and_then(|v| v.as_ref())
                     .and_then(|r| {
@@ -410,15 +483,44 @@ impl super::Vm {
                     let len = len_raw as usize;
                     let class_bytes = bytes[off..off + len].to_vec();
                     if let Some(class_name) = crate::class_file::parse_class_name(&class_bytes) {
-                        self.load_lazy(class_name.clone(), class_bytes);
-                        self.ensure_class_ready(&class_name);
+                        if let Some(requested) = requested_name.as_deref() {
+                            let requested_internal =
+                                Self::class_internal_name_from_runtime_name(requested);
+                            if requested_internal != class_name {
+                                self.throw_no_class_def_found(&requested_internal);
+                                return Some(JValue::Void);
+                            }
+                        }
+                        if self
+                            .loader_defined_classes
+                            .contains_key(&(loader_id, class_name.clone()))
+                        {
+                            let detail =
+                                format!("loader attempted duplicate class definition: {class_name}");
+                            let exc =
+                                self.new_vm_exception_message("java/lang/LinkageError", detail);
+                            *self.pending_exception_mut() = Some(exc);
+                            return Some(JValue::Void);
+                        }
+                        let lookup_key = self.next_dynamic_lookup_key();
+                        self.class_binary_names
+                            .insert(lookup_key.clone(), class_name.clone());
+                        self.load_lazy(lookup_key.clone(), class_bytes);
+                        self.loader_defined_classes
+                            .insert((loader_id, class_name.clone()), lookup_key.clone());
+                        self.class_defining_loader_ids
+                            .insert(lookup_key.clone(), loader_id);
+                        self.dynamically_defined_classes.insert(lookup_key.clone());
+                        self.ensure_class_ready(&lookup_key);
                         // Check if parsing actually succeeded
-                        if let Some(super::LazyClass::ParseError(msg)) = self.classes.get(&class_name) {
+                        if let Some(super::LazyClass::ParseError(msg)) = self.classes.get(&lookup_key) {
                             let msg = msg.clone();
                             self.throw_class_format_error(&msg);
                             return Some(JValue::Void);
                         }
-                        Some(JValue::Ref(Some(self.class_object(class_name))))
+                        Some(JValue::Ref(Some(
+                            self.class_object_with_lookup(&lookup_key, &class_name),
+                        )))
                     } else {
                         self.throw_class_format_error("defineClass: cannot parse class");
                         Some(JValue::Void)
@@ -435,7 +537,32 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
                     .unwrap_or_default();
                 let normalized = name.strip_prefix('/').unwrap_or(&name);
-                if self.has_resource(normalized) {
+                // Keep class-byte resources available only via getResourceAsStream.
+                // Returning URL objects for *.class made RT bootstrap paths treat
+                // them as external URLs and attempt unsupported network I/O.
+                if normalized.ends_with(".class") {
+                    return Some(JValue::Ref(None));
+                }
+                let mut found = self.has_resource(normalized);
+                if !found {
+                    for candidate in [
+                        normalized.to_owned(),
+                        format!("test/{normalized}"),
+                        format!("/test/{normalized}"),
+                    ] {
+                        let arg = JValue::Ref(Some(self.intern_string(candidate)));
+                        if let Ok(JValue::Ref(Some(_))) = self.invoke_static(
+                            "java/io/FileOutputStream",
+                            "__readVirtualFile",
+                            "(Ljava/lang/String;)[B",
+                            vec![arg],
+                        ) {
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+                if found {
                     let url = JObject::new("java/net/URL");
                     url.borrow_mut().fields.insert("protocol".to_owned(),
                         JValue::Ref(Some(self.intern_string("bundle"))));
@@ -470,7 +597,58 @@ impl super::Vm {
                         bais.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
                         Some(JValue::Ref(Some(bais)))
                     }
-                    Ok(None) => Some(JValue::Ref(None)),
+                    Ok(None) => {
+                        let mut from_virtual: Option<Vec<u8>> = None;
+                        for candidate in [
+                            normalized.to_owned(),
+                            format!("test/{normalized}"),
+                            format!("/test/{normalized}"),
+                        ] {
+                            let arg = JValue::Ref(Some(self.intern_string(candidate)));
+                            let Ok(value) = self.invoke_static(
+                                "java/io/FileOutputStream",
+                                "__readVirtualFile",
+                                "(Ljava/lang/String;)[B",
+                                vec![arg],
+                            ) else {
+                                continue;
+                            };
+                            let JValue::Ref(Some(arr)) = value else {
+                                continue;
+                            };
+                            let bytes = {
+                                let arr_b = arr.borrow();
+                                match &arr_b.native {
+                                    NativePayload::ByteArray(v) => Some(v.clone()),
+                                    NativePayload::Array(v) => {
+                                        Some(v.iter().map(|e| e.as_int() as u8).collect())
+                                    }
+                                    _ => None,
+                                }
+                            };
+                            if let Some(bytes) = bytes {
+                                from_virtual = Some(bytes);
+                                break;
+                            }
+                        }
+                        if let Some(data) = from_virtual {
+                            let elems: Vec<JValue> =
+                                data.iter().map(|&b| JValue::Int(b as i8 as i32)).collect();
+                            let byte_array = JObject::new_array("[B", elems);
+                            let bais = JObject::new("java/io/ByteArrayInputStream");
+                            bais.borrow_mut()
+                                .fields
+                                .insert("buf".to_owned(), JValue::Ref(Some(byte_array)));
+                            bais.borrow_mut().fields.insert("pos".to_owned(), JValue::Int(0));
+                            bais.borrow_mut()
+                                .fields
+                                .insert("count".to_owned(), JValue::Int(data.len() as i32));
+                            bais.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
+                            Some(JValue::Ref(Some(bais)))
+                        } else {
+                            Some(JValue::Ref(None))
+                        }
+                    }
                     Err(err) => {
                         self.throw_runtime_exception(&format!(
                             "getResourceAsStream({normalized}): {err}"
@@ -519,7 +697,19 @@ impl super::Vm {
                 return Some(JValue::Ref(self.intern_existing_string_ref(this)));
             }
             "getClass" if _descriptor == "()Ljava/lang/Class;" => {
-                let runtime_class = this.borrow().class_name.clone();
+                let (runtime_class, class_snapshot) = {
+                    let obj = this.borrow();
+                    (obj.class_name.clone(), obj.class_snapshot.clone())
+                };
+                if self.dynamically_defined_classes.contains(&runtime_class) {
+                    if let Some(snapshot) = class_snapshot {
+                        // Preserve per-instance class identity across defineClass redefinitions.
+                        let lookup_key =
+                            self.ensure_snapshot_lookup_class(this, &runtime_class, &snapshot);
+                        let class_obj = self.class_object(lookup_key);
+                        return Some(JValue::Ref(Some(class_obj)));
+                    }
+                }
                 return Some(JValue::Ref(Some(self.class_object(runtime_class))));
             }
             _ => {}
@@ -537,6 +727,79 @@ impl super::Vm {
                     self.throw_illegal_monitor_state(&e);
                 }
                 return Some(JValue::Void);
+            }
+        }
+        let runtime_class = this.borrow().class_name.clone();
+        let is_thread_local_target = matches!(method_name, "get" | "set" | "remove")
+            && (runtime_class == "java/lang/ThreadLocal"
+                || self.is_instance_of(&runtime_class, "java/lang/ThreadLocal"));
+        if is_thread_local_target {
+            let thread_id = self.scheduler.current_thread().id;
+            match (method_name, _descriptor) {
+                ("get", "()Ljava/lang/Object;") => {
+                    {
+                        let this_borrow = this.borrow();
+                        if let NativePayload::ThreadLocalStorage(values) = &this_borrow.native {
+                            if let Some(value) = values.get(&thread_id) {
+                                return Some(value.clone());
+                            }
+                        }
+                    }
+
+                    let initial = match self.invoke_virtual(
+                        Rc::clone(this),
+                        &runtime_class,
+                        "initialValue",
+                        "()Ljava/lang/Object;",
+                        vec![],
+                    ) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            let exc = self.new_vm_exception_message("java/lang/RuntimeException", err);
+                            *self.pending_exception_mut() = Some(exc);
+                            return Some(JValue::Void);
+                        }
+                    };
+                    {
+                        let mut this_borrow = this.borrow_mut();
+                        match &mut this_borrow.native {
+                            NativePayload::ThreadLocalStorage(values) => {
+                                values.insert(thread_id, initial.clone());
+                            }
+                            NativePayload::None => {
+                                let mut values = HashMap::new();
+                                values.insert(thread_id, initial.clone());
+                                this_borrow.native = NativePayload::ThreadLocalStorage(values);
+                            }
+                            _ => {}
+                        }
+                    }
+                    return Some(initial);
+                }
+                ("set", "(Ljava/lang/Object;)V") => {
+                    let value = _args.first().cloned().unwrap_or(JValue::Ref(None));
+                    let mut this_borrow = this.borrow_mut();
+                    match &mut this_borrow.native {
+                        NativePayload::ThreadLocalStorage(values) => {
+                            values.insert(thread_id, value);
+                        }
+                        NativePayload::None => {
+                            let mut values = HashMap::new();
+                            values.insert(thread_id, value);
+                            this_borrow.native = NativePayload::ThreadLocalStorage(values);
+                        }
+                        _ => {}
+                    }
+                    return Some(JValue::Void);
+                }
+                ("remove", "()V") => {
+                    let mut this_borrow = this.borrow_mut();
+                    if let NativePayload::ThreadLocalStorage(values) = &mut this_borrow.native {
+                        values.remove(&thread_id);
+                    }
+                    return Some(JValue::Void);
+                }
+                _ => {}
             }
         }
         if matches!(this.borrow().native, NativePayload::PrintStream(_)) {
@@ -605,6 +868,71 @@ impl super::Vm {
             || self.is_instance_of(&this.borrow().class_name.clone(), "java/lang/Thread")
         {
             match (method_name, _descriptor) {
+                ("threadLocalGet", "(Ljava/lang/ThreadLocal;)Ljava/lang/Object;") => {
+                    let key = _args
+                        .first()
+                        .and_then(JValue::as_ref)
+                        .map(|r| Rc::as_ptr(r) as usize as u64)
+                        .unwrap_or(0);
+                    let value = {
+                        let this_borrow = this.borrow();
+                        match &this_borrow.native {
+                            NativePayload::ThreadLocalMap(values) => values
+                                .get(&key)
+                                .cloned()
+                                .unwrap_or(JValue::Ref(None)),
+                            _ => JValue::Ref(None),
+                        }
+                    };
+                    return Some(value);
+                }
+                ("threadLocalContains", "(Ljava/lang/ThreadLocal;)Z") => {
+                    let key = _args
+                        .first()
+                        .and_then(JValue::as_ref)
+                        .map(|r| Rc::as_ptr(r) as usize as u64)
+                        .unwrap_or(0);
+                    let contains = {
+                        let this_borrow = this.borrow();
+                        match &this_borrow.native {
+                            NativePayload::ThreadLocalMap(values) => values.contains_key(&key),
+                            _ => false,
+                        }
+                    };
+                    return Some(JValue::Int(if contains { 1 } else { 0 }));
+                }
+                ("threadLocalSet", "(Ljava/lang/ThreadLocal;Ljava/lang/Object;)V") => {
+                    let key = _args
+                        .first()
+                        .and_then(JValue::as_ref)
+                        .map(|r| Rc::as_ptr(r) as usize as u64)
+                        .unwrap_or(0);
+                    let value = _args.get(1).cloned().unwrap_or(JValue::Ref(None));
+                    let mut this_borrow = this.borrow_mut();
+                    match &mut this_borrow.native {
+                        NativePayload::ThreadLocalMap(values) => {
+                            values.insert(key, value);
+                        }
+                        _ => {
+                            let mut values = HashMap::new();
+                            values.insert(key, value);
+                            this_borrow.native = NativePayload::ThreadLocalMap(values);
+                        }
+                    }
+                    return Some(JValue::Void);
+                }
+                ("threadLocalRemove", "(Ljava/lang/ThreadLocal;)V") => {
+                    let key = _args
+                        .first()
+                        .and_then(JValue::as_ref)
+                        .map(|r| Rc::as_ptr(r) as usize as u64)
+                        .unwrap_or(0);
+                    let mut this_borrow = this.borrow_mut();
+                    if let NativePayload::ThreadLocalMap(values) = &mut this_borrow.native {
+                        values.remove(&key);
+                    }
+                    return Some(JValue::Void);
+                }
                 ("start", "()V") => {
                     match self.thread_start(Rc::clone(this)) {
                         Ok(_) => {}
@@ -633,10 +961,10 @@ impl super::Vm {
         // ClassLoader methods must dispatch on the resolved owner (`_class_name`), not the
         // runtime class of `this`, so that subclasses of ClassLoader also hit these stubs.
         // Guard on method name first to avoid super-chain walks on unrelated calls.
-        if matches!(method_name, "loadClass" | "findClass" | "findLoadedClass" | "defineClass" | "getResource" | "getResourceAsStream" | "findResource" | "findResources")
+        if matches!(method_name, "findClass" | "findLoadedClass" | "defineClass" | "getResource" | "getResourceAsStream" | "findResource" | "findResources")
             && self.is_classloader_subtype(_class_name)
         {
-            if let Some(v) = self.native_classloader(method_name, _args) {
+            if let Some(v) = self.native_classloader(this, method_name, _args) {
                 return Some(v);
             }
         }
@@ -879,18 +1207,19 @@ impl super::Vm {
                 Some(JValue::Int(0))
             }
             ("java/util/regex/Matcher", "group") => {
-                // group(int) — return captured group from __groups array
-                let idx = _args.first().map(|v| v.as_int().max(0) as usize).unwrap_or(0);
-                let mb = this.borrow();
-                if let Some(JValue::Ref(Some(groups_ref))) = mb.fields.get("__groups") {
-                    if let NativePayload::Array(groups) = &groups_ref.borrow().native {
-                        if let Some(g) = groups.get(idx) {
-                            return Some(g.clone());
+                // group()/group(int)
+                let idx_raw = _args.first().map(JValue::as_int).unwrap_or(0);
+                let (groups, start, end, input) = {
+                    let mb = this.borrow();
+                    let groups = if let Some(JValue::Ref(Some(groups_ref))) = mb.fields.get("__groups") {
+                        if let NativePayload::Array(groups) = &groups_ref.borrow().native {
+                            Some(groups.clone())
+                        } else {
+                            None
                         }
-                    }
-                }
-                // Fallback: group 0 from __match fields
-                if idx == 0 {
+                    } else {
+                        None
+                    };
                     let start = mb.fields.get("matchStart").map(|v| v.as_int()).unwrap_or(-1);
                     let end = mb.fields.get("matchEnd").map(|v| v.as_int()).unwrap_or(-1);
                     let input = mb.fields.get("input")
@@ -898,22 +1227,72 @@ impl super::Vm {
                         .and_then(|v| v.as_ref())
                         .and_then(|s| s.borrow().as_java_string_value().cloned())
                         .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
-                    drop(mb);
-                    if start >= 0 && end >= 0 && (end as usize) <= input.len_utf16() {
-                        return Some(JValue::Ref(Some(JObject::new_string_value(
-                            string_slice_value(&input, start as usize, end as usize),
-                        ))));
-                    }
-                } else {
-                    drop(mb);
+                    (groups, start, end, input)
+                };
+
+                // Matcher.group* must report IllegalStateException first when no
+                // successful match has been established.
+                let has_match = (start >= 0 && end >= 0) || groups.is_some();
+                if !has_match {
+                    let exc = self.new_vm_exception_message(
+                        "java/lang/IllegalStateException",
+                        "No match found".to_owned(),
+                    );
+                    *self.pending_exception_mut() = Some(exc);
+                    return Some(JValue::Ref(None));
                 }
+
+                if idx_raw < 0 {
+                    let exc = self.new_vm_exception_message(
+                        "java/lang/IndexOutOfBoundsException",
+                        format!("No group {}", idx_raw),
+                    );
+                    *self.pending_exception_mut() = Some(exc);
+                    return Some(JValue::Ref(None));
+                }
+                let idx = idx_raw as usize;
+
+                if let Some(groups) = &groups {
+                    if idx >= groups.len() {
+                        let exc = self.new_vm_exception_message(
+                            "java/lang/IndexOutOfBoundsException",
+                            format!("No group {}", idx),
+                        );
+                        *self.pending_exception_mut() = Some(exc);
+                        return Some(JValue::Ref(None));
+                    }
+                    return Some(groups[idx].clone());
+                }
+                // Fallback: group 0 from matchStart/matchEnd when captures were not materialized.
+                if idx == 0 && start >= 0 && end >= 0 && (end as usize) <= input.len_utf16() {
+                    return Some(JValue::Ref(Some(JObject::new_string_value(
+                        string_slice_value(&input, start as usize, end as usize),
+                    ))));
+                }
+                let exc = self.new_vm_exception_message(
+                    "java/lang/IllegalStateException",
+                    "No match found".to_owned(),
+                );
+                *self.pending_exception_mut() = Some(exc);
                 Some(JValue::Ref(None))
             }
             ("java/lang/Class", "getName") => {
+                if let Some(v) = this.borrow().fields.get("__name_display") {
+                    return Some(v.clone());
+                }
                 let internal = self
                     .class_internal_name_from_obj(this)
                     .unwrap_or_else(|| "java/lang/Object".to_owned());
                 Some(JValue::Ref(Some(self.intern_string(Self::class_display_name(&internal)))))
+            }
+            ("java/lang/Class", "getClassLoader") => {
+                Some(
+                    this.borrow()
+                        .fields
+                        .get("__defining_loader")
+                        .cloned()
+                        .unwrap_or(JValue::Ref(None)),
+                )
             }
             ("java/lang/Class", "getModifiers") => {
                 let target = self
@@ -992,6 +1371,9 @@ impl super::Vm {
                 let super_name = if target.starts_with('[') {
                     Some("java/lang/Object".to_owned())
                 } else if let Some(cf) = self.get_class(&target) {
+                    if (cf.access_flags & 0x0200) != 0 {
+                        None
+                    } else
                     if cf.super_class == 0 {
                         None
                     } else {
@@ -1141,6 +1523,9 @@ impl super::Vm {
                         }
                         let name = cf.constant_pool.utf8(m.name_index).to_owned();
                         if name == "<init>" || name == "<clinit>" {
+                            continue;
+                        }
+                        if target == "java/lang/Deprecated" && (name == "since" || name == "forRemoval") {
                             continue;
                         }
                         let desc = cf.constant_pool.utf8(m.descriptor_index).to_owned();
@@ -1303,14 +1688,41 @@ impl super::Vm {
                 let mut call_args = Vec::with_capacity(param_tokens.len());
                 for (i, p) in param_tokens.iter().enumerate() {
                     let src = raw_args.get(i).cloned().unwrap_or_else(|| default_value_for_descriptor(p));
-                    call_args.push(self.adapt_value_for_descriptor(p, src));
+                    call_args.push(self.adapt_reflection_arg_for_descriptor(p, src));
+                }
+
+                if (modifiers & 0x0008) == 0 && call_args.is_empty() {
+                    if let JValue::Ref(Some(r)) = &recv {
+                        let slot = if name == "annotationType" {
+                            "__ann_annotationType".to_owned()
+                        } else {
+                            format!("__ann_{name}")
+                        };
+                        let ann_value = if let Some(v) = r.borrow().fields.get(&slot).cloned() {
+                            Some(v)
+                        } else if r.borrow().fields.contains_key("__ann_annotationType") {
+                            self.resolve_annotation_method_default(&owner, &name, &desc)
+                        } else {
+                            None
+                        };
+                        if let Some(v) = ann_value {
+                            let ret = if ret_token == "V" {
+                                JValue::Ref(None)
+                            } else if !matches!(ret_token.as_bytes().first(), Some(b'L' | b'[')) {
+                                self.wrap_primitive_value_for_descriptor(&ret_token, v)
+                            } else {
+                                v
+                            };
+                            return Some(ret);
+                        }
+                    }
                 }
 
                 let result = if (modifiers & 0x0008) != 0 {
                     self.invoke_static(&owner, &name, &desc, call_args)
                 } else {
                     match recv {
-                        JValue::Ref(Some(r)) => self.invoke_virtual(r, &owner, &name, &desc, call_args),
+                        JValue::Ref(Some(ref r)) => self.invoke_virtual(r.clone(), &owner, &name, &desc, call_args),
                         _ => Ok(JValue::Ref(None)),
                     }
                 };
@@ -1382,7 +1794,7 @@ impl super::Vm {
                 let mut call_args = Vec::with_capacity(param_tokens.len());
                 for (i, p) in param_tokens.iter().enumerate() {
                     let src = raw_args.get(i).cloned().unwrap_or_else(|| default_value_for_descriptor(p));
-                    call_args.push(self.adapt_value_for_descriptor(p, src));
+                    call_args.push(self.adapt_reflection_arg_for_descriptor(p, src));
                 }
                 let obj = JObject::new(owner.clone());
                 if let Err(e) = self.invoke_virtual(obj.clone(), &owner, "<init>", &desc, call_args) {
@@ -1440,9 +1852,9 @@ impl super::Vm {
                 };
 
                 let raw = if (modifiers & 0x0008) != 0 {
-                    self.static_fields
-                        .get(&owner).and_then(|m| m.get(&name))
-                        .cloned()
+                    let _ = self.ensure_class_init(&owner);
+                    self.resolve_static_field_in_hierarchy(&owner, &name)
+                        .or_else(|| self.resolve_constant_value_static_field(&owner, &name))
                         .unwrap_or_else(|| default_value_for_descriptor(&desc))
                 } else {
                     match _args.first().and_then(|v| v.as_ref()) {
@@ -1477,6 +1889,7 @@ impl super::Vm {
                 let val = _args.get(1).cloned().unwrap_or(JValue::Ref(None));
                 let adapted = self.adapt_value_for_descriptor(&desc, val);
                 if (modifiers & 0x0008) != 0 {
+                    let _ = self.ensure_class_init(&owner);
                     self.static_fields.entry(owner).or_default().insert(name, adapted);
                 } else if let Some(target) = _args.first().and_then(|v| v.as_ref()) {
                     target.borrow_mut().fields.insert(name, adapted);
@@ -1642,13 +2055,22 @@ impl super::Vm {
                 Some(JValue::Int(len))
             }
             ("java/lang/String", "charAt") => {
-                let idx = _args.first().map(|v| v.as_int() as usize).unwrap_or(0);
-                let ch = this
-                    .borrow()
-                    .as_java_string_value()
-                    .and_then(|s| s.code_unit_at(idx))
-                    .unwrap_or(0) as i32;
-                Some(JValue::Int(ch))
+                let idx_i = _args.first().map(|v| v.as_int()).unwrap_or(0);
+                if idx_i < 0 {
+                    let exc = self.new_vm_exception("java/lang/StringIndexOutOfBoundsException", None);
+                    *self.pending_exception_mut() = Some(exc);
+                    return Some(JValue::Int(0));
+                }
+                let idx = idx_i as usize;
+                let Some(value) = this.borrow().as_java_string_value().cloned() else {
+                    return Some(JValue::Int(0));
+                };
+                let Some(ch) = value.code_unit_at(idx) else {
+                    let exc = self.new_vm_exception("java/lang/StringIndexOutOfBoundsException", None);
+                    *self.pending_exception_mut() = Some(exc);
+                    return Some(JValue::Int(0));
+                };
+                Some(JValue::Int(ch as i32))
             }
             ("java/lang/String", "isEmpty") => {
                 let empty = this
@@ -1688,6 +2110,66 @@ impl super::Vm {
                     .map(JavaStringValue::hash_code)
                     .unwrap_or(0);
                 Some(JValue::Int(hash))
+            }
+            ("java/net/URL", "openStream") => {
+                let (protocol, file) = {
+                    let b = this.borrow();
+                    let protocol = b
+                        .fields
+                        .get("protocol")
+                        .and_then(|v| v.as_ref())
+                        .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                        .unwrap_or_default();
+                    let file = b
+                        .fields
+                        .get("file")
+                        .and_then(|v| v.as_ref())
+                        .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
+                        .unwrap_or_default();
+                    (protocol, file)
+                };
+                if protocol != "bundle" {
+                    let exc = self.new_vm_exception_message(
+                        "java/lang/UnsupportedOperationException",
+                        format!("URL.openStream unsupported protocol: {protocol}"),
+                    );
+                    *self.pending_exception_mut() = Some(exc);
+                    return Some(JValue::Ref(None));
+                }
+                let normalized = file.strip_prefix('/').unwrap_or(&file);
+                match self.read_resource(normalized) {
+                    Ok(Some(data)) => {
+                        let elems: Vec<JValue> =
+                            data.iter().map(|&b| JValue::Int(b as i8 as i32)).collect();
+                        let byte_array = JObject::new_array("[B", elems);
+                        let bais = JObject::new("java/io/ByteArrayInputStream");
+                        bais.borrow_mut()
+                            .fields
+                            .insert("buf".to_owned(), JValue::Ref(Some(byte_array)));
+                        bais.borrow_mut().fields.insert("pos".to_owned(), JValue::Int(0));
+                        bais.borrow_mut()
+                            .fields
+                            .insert("count".to_owned(), JValue::Int(data.len() as i32));
+                        bais.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
+                        Some(JValue::Ref(Some(bais)))
+                    }
+                    Ok(None) => {
+                        let exc = self.new_vm_exception_message(
+                            "java/io/FileNotFoundException",
+                            format!("Resource not found: {normalized}"),
+                        );
+                        *self.pending_exception_mut() = Some(exc);
+                        Some(JValue::Ref(None))
+                    }
+                    Err(err) => {
+                        let exc = self.new_vm_exception_message(
+                            "java/io/IOException",
+                            format!("Failed to open resource {normalized}: {err}"),
+                        );
+                        *self.pending_exception_mut() = Some(exc);
+                        Some(JValue::Ref(None))
+                    }
+                }
             }
             ("java/lang/String", "substring") => {
                 let this_borrow = this.borrow();
@@ -1841,13 +2323,23 @@ impl super::Vm {
                 Some(JValue::Int(idx))
             }
             ("java/lang/String", "trim") => {
-                let s = this
+                let value = this
                     .borrow()
-                    .java_string_to_string_lossy()
-                    .unwrap_or_default()
-                    .trim()
-                    .to_owned();
-                Some(JValue::Ref(Some(JObject::new_string(s))))
+                    .as_java_string_value()
+                    .cloned()
+                    .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
+                let units = value.utf16();
+                let mut start = 0usize;
+                let mut end = units.len();
+                while start < end && units[start] <= 0x20 {
+                    start += 1;
+                }
+                while end > start && units[end - 1] <= 0x20 {
+                    end -= 1;
+                }
+                Some(JValue::Ref(Some(JObject::new_string_utf16(
+                    units[start..end].to_vec(),
+                ))))
             }
             ("java/lang/String", "toLowerCase") => {
                 let s = this
@@ -1930,6 +2422,8 @@ impl super::Vm {
                     NativePayload::ByteArray(v) => NativePayload::ByteArray(v.clone()),
                     NativePayload::IntArray(v) => NativePayload::IntArray(v.clone()),
                     NativePayload::LongArray(v) => NativePayload::LongArray(v.clone()),
+                    NativePayload::ThreadLocalStorage(values) => NativePayload::ThreadLocalStorage(values.clone()),
+                    NativePayload::ThreadLocalMap(values) => NativePayload::ThreadLocalMap(values.clone()),
                     NativePayload::PrintStream(is_err) => NativePayload::PrintStream(*is_err),
                     NativePayload::ProcessPipeInputStream => NativePayload::ProcessPipeInputStream,
                     NativePayload::Lambda(f) => NativePayload::Lambda(f.clone()),
@@ -1961,6 +2455,7 @@ impl super::Vm {
                 };
                 let cloned = Rc::new(RefCell::new(crate::heap::JObject {
                     class_name: src.class_name.clone(),
+                    class_snapshot: src.class_snapshot.clone(),
                     fields,
                     native,
                 }));
@@ -1978,6 +2473,32 @@ impl super::Vm {
             }
             _ => None,
         }
+    }
+
+    fn resolve_annotation_method_default(
+        &mut self,
+        owner: &str,
+        method_name: &str,
+        descriptor: &str,
+    ) -> Option<JValue> {
+        self.ensure_class_ready(owner);
+        let (attrs, cp) = {
+            let cf = self.get_class(owner)?;
+            let method = cf.methods.iter().find(|m| {
+                cf.constant_pool.utf8(m.name_index) == method_name
+                    && cf.constant_pool.utf8(m.descriptor_index) == descriptor
+            })?;
+            (method.attributes.clone(), cf.constant_pool.clone())
+        };
+        for attr in attrs {
+            if let Attribute::Unknown { name, data } = attr {
+                if name == "AnnotationDefault" {
+                    let mut p = 0usize;
+                    return self.parse_annotation_element_value(&data, &mut p, &cp);
+                }
+            }
+        }
+        None
     }
 }
 

--- a/jvm-core/src/interpreter/native_virtual.rs
+++ b/jvm-core/src/interpreter/native_virtual.rs
@@ -333,12 +333,12 @@ impl super::Vm {
         }
     }
 
+    /// Handle ClassLoader instance methods that must dispatch by resolved owner, not runtime class.
+    /// Returns `Some(value)` if the method was handled, `None` to fall through.
     fn classloader_object_id(loader: &JRef) -> usize {
         Rc::as_ptr(loader) as usize
     }
 
-    /// Handle ClassLoader instance methods that must dispatch by resolved owner, not runtime class.
-    /// Returns `Some(value)` if the method was handled, `None` to fall through.
     fn native_classloader(&mut self, this: &JRef, method_name: &str, args: &[JValue]) -> Option<JValue> {
         let loader_id = Self::classloader_object_id(this);
         let is_system_loader = self
@@ -350,7 +350,7 @@ impl super::Vm {
             .entry(loader_id)
             .or_insert_with(|| this.clone());
         match method_name {
-            "findClass" => {
+            "loadClass" | "findClass" => {
                 // A null or missing name argument must surface as NullPointerException.
                 // (`defineClass` accepts a null name per JDK spec, so the check is here only.)
                 let name_str = match args
@@ -368,9 +368,9 @@ impl super::Vm {
                 if let Some(lookup_key) = self.loader_lookup_internal_name(loader_id, &internal) {
                     self.ensure_class_ready(&lookup_key);
                     return match self.classes.get(&lookup_key) {
-                        Some(LazyClass::Ready(_)) => {
-                            Some(JValue::Ref(Some(self.class_object_with_lookup(&lookup_key, &internal))))
-                        }
+                        Some(LazyClass::Ready(_)) => Some(JValue::Ref(Some(
+                            self.class_object_with_lookup(&lookup_key, &internal),
+                        ))),
                         Some(LazyClass::ParseError(msg)) => {
                             let msg = msg.clone();
                             self.throw_class_format_error(&msg);
@@ -387,33 +387,19 @@ impl super::Vm {
                     return Some(JValue::Void);
                 }
                 self.ensure_class_ready(&internal);
-                let resolved_name = match self.classes.get(&internal) {
-                    Some(LazyClass::Ready(_)) => Some(internal.clone()),
+                match self.classes.get(&internal) {
+                    Some(LazyClass::Ready(_)) => {}
                     Some(LazyClass::ParseError(msg)) => {
                         let msg = msg.clone();
                         self.throw_class_format_error(&msg);
                         return Some(JValue::Void);
                     }
                     _ => {
-                        self.ensure_class_ready(&name_str);
-                        match self.classes.get(&name_str) {
-                            Some(LazyClass::Ready(_)) => Some(name_str.clone()),
-                            Some(LazyClass::ParseError(msg)) => {
-                                let msg = msg.clone();
-                                self.throw_class_format_error(&msg);
-                                return Some(JValue::Void);
-                            }
-                            _ => None,
-                        }
-                    }
-                };
-                match resolved_name {
-                    Some(name) => Some(JValue::Ref(Some(self.class_object(name)))),
-                    None => {
                         self.throw_class_not_found(&name_str);
-                        Some(JValue::Void)
+                        return Some(JValue::Void);
                     }
                 }
+                Some(JValue::Ref(Some(self.class_object(internal))))
             }
             "findLoadedClass" => {
                 let name_str = args
@@ -433,18 +419,10 @@ impl super::Vm {
                     && matches!(self.classes.get(&internal), Some(LazyClass::Ready(_)))
                 {
                     Some(JValue::Ref(Some(self.class_object(internal))))
-                } else if self.class_defining_loader_ids.get(&name_str).copied() == Some(loader_id)
-                    && matches!(self.classes.get(&name_str), Some(LazyClass::Ready(_)))
+                } else if is_system_loader
+                    && matches!(self.classes.get(&internal), Some(LazyClass::Ready(_)))
                 {
-                    Some(JValue::Ref(Some(self.class_object(name_str))))
-                } else if is_system_loader {
-                    if matches!(self.classes.get(&internal), Some(LazyClass::Ready(_))) {
-                        Some(JValue::Ref(Some(self.class_object(internal))))
-                    } else if matches!(self.classes.get(&name_str), Some(LazyClass::Ready(_))) {
-                        Some(JValue::Ref(Some(self.class_object(name_str))))
-                    } else {
-                        Some(JValue::Ref(None))
-                    }
+                    Some(JValue::Ref(Some(self.class_object(internal))))
                 } else {
                     Some(JValue::Ref(None))
                 }
@@ -510,7 +488,6 @@ impl super::Vm {
                             .insert((loader_id, class_name.clone()), lookup_key.clone());
                         self.class_defining_loader_ids
                             .insert(lookup_key.clone(), loader_id);
-                        self.dynamically_defined_classes.insert(lookup_key.clone());
                         self.ensure_class_ready(&lookup_key);
                         // Check if parsing actually succeeded
                         if let Some(super::LazyClass::ParseError(msg)) = self.classes.get(&lookup_key) {
@@ -537,32 +514,7 @@ impl super::Vm {
                     .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
                     .unwrap_or_default();
                 let normalized = name.strip_prefix('/').unwrap_or(&name);
-                // Keep class-byte resources available only via getResourceAsStream.
-                // Returning URL objects for *.class made RT bootstrap paths treat
-                // them as external URLs and attempt unsupported network I/O.
-                if normalized.ends_with(".class") {
-                    return Some(JValue::Ref(None));
-                }
-                let mut found = self.has_resource(normalized);
-                if !found {
-                    for candidate in [
-                        normalized.to_owned(),
-                        format!("test/{normalized}"),
-                        format!("/test/{normalized}"),
-                    ] {
-                        let arg = JValue::Ref(Some(self.intern_string(candidate)));
-                        if let Ok(JValue::Ref(Some(_))) = self.invoke_static(
-                            "java/io/FileOutputStream",
-                            "__readVirtualFile",
-                            "(Ljava/lang/String;)[B",
-                            vec![arg],
-                        ) {
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-                if found {
+                if self.has_resource(normalized) {
                     let url = JObject::new("java/net/URL");
                     url.borrow_mut().fields.insert("protocol".to_owned(),
                         JValue::Ref(Some(self.intern_string("bundle"))));
@@ -597,58 +549,7 @@ impl super::Vm {
                         bais.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
                         Some(JValue::Ref(Some(bais)))
                     }
-                    Ok(None) => {
-                        let mut from_virtual: Option<Vec<u8>> = None;
-                        for candidate in [
-                            normalized.to_owned(),
-                            format!("test/{normalized}"),
-                            format!("/test/{normalized}"),
-                        ] {
-                            let arg = JValue::Ref(Some(self.intern_string(candidate)));
-                            let Ok(value) = self.invoke_static(
-                                "java/io/FileOutputStream",
-                                "__readVirtualFile",
-                                "(Ljava/lang/String;)[B",
-                                vec![arg],
-                            ) else {
-                                continue;
-                            };
-                            let JValue::Ref(Some(arr)) = value else {
-                                continue;
-                            };
-                            let bytes = {
-                                let arr_b = arr.borrow();
-                                match &arr_b.native {
-                                    NativePayload::ByteArray(v) => Some(v.clone()),
-                                    NativePayload::Array(v) => {
-                                        Some(v.iter().map(|e| e.as_int() as u8).collect())
-                                    }
-                                    _ => None,
-                                }
-                            };
-                            if let Some(bytes) = bytes {
-                                from_virtual = Some(bytes);
-                                break;
-                            }
-                        }
-                        if let Some(data) = from_virtual {
-                            let elems: Vec<JValue> =
-                                data.iter().map(|&b| JValue::Int(b as i8 as i32)).collect();
-                            let byte_array = JObject::new_array("[B", elems);
-                            let bais = JObject::new("java/io/ByteArrayInputStream");
-                            bais.borrow_mut()
-                                .fields
-                                .insert("buf".to_owned(), JValue::Ref(Some(byte_array)));
-                            bais.borrow_mut().fields.insert("pos".to_owned(), JValue::Int(0));
-                            bais.borrow_mut()
-                                .fields
-                                .insert("count".to_owned(), JValue::Int(data.len() as i32));
-                            bais.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
-                            Some(JValue::Ref(Some(bais)))
-                        } else {
-                            Some(JValue::Ref(None))
-                        }
-                    }
+                    Ok(None) => Some(JValue::Ref(None)),
                     Err(err) => {
                         self.throw_runtime_exception(&format!(
                             "getResourceAsStream({normalized}): {err}"
@@ -697,19 +598,7 @@ impl super::Vm {
                 return Some(JValue::Ref(self.intern_existing_string_ref(this)));
             }
             "getClass" if _descriptor == "()Ljava/lang/Class;" => {
-                let (runtime_class, class_snapshot) = {
-                    let obj = this.borrow();
-                    (obj.class_name.clone(), obj.class_snapshot.clone())
-                };
-                if self.dynamically_defined_classes.contains(&runtime_class) {
-                    if let Some(snapshot) = class_snapshot {
-                        // Preserve per-instance class identity across defineClass redefinitions.
-                        let lookup_key =
-                            self.ensure_snapshot_lookup_class(this, &runtime_class, &snapshot);
-                        let class_obj = self.class_object(lookup_key);
-                        return Some(JValue::Ref(Some(class_obj)));
-                    }
-                }
+                let runtime_class = this.borrow().class_name.clone();
                 return Some(JValue::Ref(Some(self.class_object(runtime_class))));
             }
             _ => {}
@@ -727,79 +616,6 @@ impl super::Vm {
                     self.throw_illegal_monitor_state(&e);
                 }
                 return Some(JValue::Void);
-            }
-        }
-        let runtime_class = this.borrow().class_name.clone();
-        let is_thread_local_target = matches!(method_name, "get" | "set" | "remove")
-            && (runtime_class == "java/lang/ThreadLocal"
-                || self.is_instance_of(&runtime_class, "java/lang/ThreadLocal"));
-        if is_thread_local_target {
-            let thread_id = self.scheduler.current_thread().id;
-            match (method_name, _descriptor) {
-                ("get", "()Ljava/lang/Object;") => {
-                    {
-                        let this_borrow = this.borrow();
-                        if let NativePayload::ThreadLocalStorage(values) = &this_borrow.native {
-                            if let Some(value) = values.get(&thread_id) {
-                                return Some(value.clone());
-                            }
-                        }
-                    }
-
-                    let initial = match self.invoke_virtual(
-                        Rc::clone(this),
-                        &runtime_class,
-                        "initialValue",
-                        "()Ljava/lang/Object;",
-                        vec![],
-                    ) {
-                        Ok(value) => value,
-                        Err(err) => {
-                            let exc = self.new_vm_exception_message("java/lang/RuntimeException", err);
-                            *self.pending_exception_mut() = Some(exc);
-                            return Some(JValue::Void);
-                        }
-                    };
-                    {
-                        let mut this_borrow = this.borrow_mut();
-                        match &mut this_borrow.native {
-                            NativePayload::ThreadLocalStorage(values) => {
-                                values.insert(thread_id, initial.clone());
-                            }
-                            NativePayload::None => {
-                                let mut values = HashMap::new();
-                                values.insert(thread_id, initial.clone());
-                                this_borrow.native = NativePayload::ThreadLocalStorage(values);
-                            }
-                            _ => {}
-                        }
-                    }
-                    return Some(initial);
-                }
-                ("set", "(Ljava/lang/Object;)V") => {
-                    let value = _args.first().cloned().unwrap_or(JValue::Ref(None));
-                    let mut this_borrow = this.borrow_mut();
-                    match &mut this_borrow.native {
-                        NativePayload::ThreadLocalStorage(values) => {
-                            values.insert(thread_id, value);
-                        }
-                        NativePayload::None => {
-                            let mut values = HashMap::new();
-                            values.insert(thread_id, value);
-                            this_borrow.native = NativePayload::ThreadLocalStorage(values);
-                        }
-                        _ => {}
-                    }
-                    return Some(JValue::Void);
-                }
-                ("remove", "()V") => {
-                    let mut this_borrow = this.borrow_mut();
-                    if let NativePayload::ThreadLocalStorage(values) = &mut this_borrow.native {
-                        values.remove(&thread_id);
-                    }
-                    return Some(JValue::Void);
-                }
-                _ => {}
             }
         }
         if matches!(this.borrow().native, NativePayload::PrintStream(_)) {
@@ -868,71 +684,6 @@ impl super::Vm {
             || self.is_instance_of(&this.borrow().class_name.clone(), "java/lang/Thread")
         {
             match (method_name, _descriptor) {
-                ("threadLocalGet", "(Ljava/lang/ThreadLocal;)Ljava/lang/Object;") => {
-                    let key = _args
-                        .first()
-                        .and_then(JValue::as_ref)
-                        .map(|r| Rc::as_ptr(r) as usize as u64)
-                        .unwrap_or(0);
-                    let value = {
-                        let this_borrow = this.borrow();
-                        match &this_borrow.native {
-                            NativePayload::ThreadLocalMap(values) => values
-                                .get(&key)
-                                .cloned()
-                                .unwrap_or(JValue::Ref(None)),
-                            _ => JValue::Ref(None),
-                        }
-                    };
-                    return Some(value);
-                }
-                ("threadLocalContains", "(Ljava/lang/ThreadLocal;)Z") => {
-                    let key = _args
-                        .first()
-                        .and_then(JValue::as_ref)
-                        .map(|r| Rc::as_ptr(r) as usize as u64)
-                        .unwrap_or(0);
-                    let contains = {
-                        let this_borrow = this.borrow();
-                        match &this_borrow.native {
-                            NativePayload::ThreadLocalMap(values) => values.contains_key(&key),
-                            _ => false,
-                        }
-                    };
-                    return Some(JValue::Int(if contains { 1 } else { 0 }));
-                }
-                ("threadLocalSet", "(Ljava/lang/ThreadLocal;Ljava/lang/Object;)V") => {
-                    let key = _args
-                        .first()
-                        .and_then(JValue::as_ref)
-                        .map(|r| Rc::as_ptr(r) as usize as u64)
-                        .unwrap_or(0);
-                    let value = _args.get(1).cloned().unwrap_or(JValue::Ref(None));
-                    let mut this_borrow = this.borrow_mut();
-                    match &mut this_borrow.native {
-                        NativePayload::ThreadLocalMap(values) => {
-                            values.insert(key, value);
-                        }
-                        _ => {
-                            let mut values = HashMap::new();
-                            values.insert(key, value);
-                            this_borrow.native = NativePayload::ThreadLocalMap(values);
-                        }
-                    }
-                    return Some(JValue::Void);
-                }
-                ("threadLocalRemove", "(Ljava/lang/ThreadLocal;)V") => {
-                    let key = _args
-                        .first()
-                        .and_then(JValue::as_ref)
-                        .map(|r| Rc::as_ptr(r) as usize as u64)
-                        .unwrap_or(0);
-                    let mut this_borrow = this.borrow_mut();
-                    if let NativePayload::ThreadLocalMap(values) = &mut this_borrow.native {
-                        values.remove(&key);
-                    }
-                    return Some(JValue::Void);
-                }
                 ("start", "()V") => {
                     match self.thread_start(Rc::clone(this)) {
                         Ok(_) => {}
@@ -961,7 +712,7 @@ impl super::Vm {
         // ClassLoader methods must dispatch on the resolved owner (`_class_name`), not the
         // runtime class of `this`, so that subclasses of ClassLoader also hit these stubs.
         // Guard on method name first to avoid super-chain walks on unrelated calls.
-        if matches!(method_name, "findClass" | "findLoadedClass" | "defineClass" | "getResource" | "getResourceAsStream" | "findResource" | "findResources")
+        if matches!(method_name, "loadClass" | "findClass" | "findLoadedClass" | "defineClass" | "getResource" | "getResourceAsStream" | "findResource" | "findResources")
             && self.is_classloader_subtype(_class_name)
         {
             if let Some(v) = self.native_classloader(this, method_name, _args) {
@@ -1207,19 +958,18 @@ impl super::Vm {
                 Some(JValue::Int(0))
             }
             ("java/util/regex/Matcher", "group") => {
-                // group()/group(int)
-                let idx_raw = _args.first().map(JValue::as_int).unwrap_or(0);
-                let (groups, start, end, input) = {
-                    let mb = this.borrow();
-                    let groups = if let Some(JValue::Ref(Some(groups_ref))) = mb.fields.get("__groups") {
-                        if let NativePayload::Array(groups) = &groups_ref.borrow().native {
-                            Some(groups.clone())
-                        } else {
-                            None
+                // group(int) — return captured group from __groups array
+                let idx = _args.first().map(|v| v.as_int().max(0) as usize).unwrap_or(0);
+                let mb = this.borrow();
+                if let Some(JValue::Ref(Some(groups_ref))) = mb.fields.get("__groups") {
+                    if let NativePayload::Array(groups) = &groups_ref.borrow().native {
+                        if let Some(g) = groups.get(idx) {
+                            return Some(g.clone());
                         }
-                    } else {
-                        None
-                    };
+                    }
+                }
+                // Fallback: group 0 from __match fields
+                if idx == 0 {
                     let start = mb.fields.get("matchStart").map(|v| v.as_int()).unwrap_or(-1);
                     let end = mb.fields.get("matchEnd").map(|v| v.as_int()).unwrap_or(-1);
                     let input = mb.fields.get("input")
@@ -1227,72 +977,23 @@ impl super::Vm {
                         .and_then(|v| v.as_ref())
                         .and_then(|s| s.borrow().as_java_string_value().cloned())
                         .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
-                    (groups, start, end, input)
-                };
-
-                // Matcher.group* must report IllegalStateException first when no
-                // successful match has been established.
-                let has_match = (start >= 0 && end >= 0) || groups.is_some();
-                if !has_match {
-                    let exc = self.new_vm_exception_message(
-                        "java/lang/IllegalStateException",
-                        "No match found".to_owned(),
-                    );
-                    *self.pending_exception_mut() = Some(exc);
-                    return Some(JValue::Ref(None));
-                }
-
-                if idx_raw < 0 {
-                    let exc = self.new_vm_exception_message(
-                        "java/lang/IndexOutOfBoundsException",
-                        format!("No group {}", idx_raw),
-                    );
-                    *self.pending_exception_mut() = Some(exc);
-                    return Some(JValue::Ref(None));
-                }
-                let idx = idx_raw as usize;
-
-                if let Some(groups) = &groups {
-                    if idx >= groups.len() {
-                        let exc = self.new_vm_exception_message(
-                            "java/lang/IndexOutOfBoundsException",
-                            format!("No group {}", idx),
-                        );
-                        *self.pending_exception_mut() = Some(exc);
-                        return Some(JValue::Ref(None));
+                    drop(mb);
+                    if start >= 0 && end >= 0 && (end as usize) <= input.len_utf16() {
+                        return Some(JValue::Ref(Some(JObject::new_string_value(
+                            string_slice_value(&input, start as usize, end as usize),
+                        ))));
                     }
-                    return Some(groups[idx].clone());
+                } else {
+                    drop(mb);
                 }
-                // Fallback: group 0 from matchStart/matchEnd when captures were not materialized.
-                if idx == 0 && start >= 0 && end >= 0 && (end as usize) <= input.len_utf16() {
-                    return Some(JValue::Ref(Some(JObject::new_string_value(
-                        string_slice_value(&input, start as usize, end as usize),
-                    ))));
-                }
-                let exc = self.new_vm_exception_message(
-                    "java/lang/IllegalStateException",
-                    "No match found".to_owned(),
-                );
-                *self.pending_exception_mut() = Some(exc);
                 Some(JValue::Ref(None))
             }
             ("java/lang/Class", "getName") => {
-                if let Some(v) = this.borrow().fields.get("__name_display") {
-                    return Some(v.clone());
-                }
                 let internal = self
                     .class_internal_name_from_obj(this)
                     .unwrap_or_else(|| "java/lang/Object".to_owned());
-                Some(JValue::Ref(Some(self.intern_string(Self::class_display_name(&internal)))))
-            }
-            ("java/lang/Class", "getClassLoader") => {
-                Some(
-                    this.borrow()
-                        .fields
-                        .get("__defining_loader")
-                        .cloned()
-                        .unwrap_or(JValue::Ref(None)),
-                )
+                let binary = self.class_binary_name_for_lookup(&internal);
+                Some(JValue::Ref(Some(self.intern_string(Self::class_display_name(&binary)))))
             }
             ("java/lang/Class", "getModifiers") => {
                 let target = self
@@ -1371,9 +1072,6 @@ impl super::Vm {
                 let super_name = if target.starts_with('[') {
                     Some("java/lang/Object".to_owned())
                 } else if let Some(cf) = self.get_class(&target) {
-                    if (cf.access_flags & 0x0200) != 0 {
-                        None
-                    } else
                     if cf.super_class == 0 {
                         None
                     } else {
@@ -1523,9 +1221,6 @@ impl super::Vm {
                         }
                         let name = cf.constant_pool.utf8(m.name_index).to_owned();
                         if name == "<init>" || name == "<clinit>" {
-                            continue;
-                        }
-                        if target == "java/lang/Deprecated" && (name == "since" || name == "forRemoval") {
                             continue;
                         }
                         let desc = cf.constant_pool.utf8(m.descriptor_index).to_owned();
@@ -1688,41 +1383,14 @@ impl super::Vm {
                 let mut call_args = Vec::with_capacity(param_tokens.len());
                 for (i, p) in param_tokens.iter().enumerate() {
                     let src = raw_args.get(i).cloned().unwrap_or_else(|| default_value_for_descriptor(p));
-                    call_args.push(self.adapt_reflection_arg_for_descriptor(p, src));
-                }
-
-                if (modifiers & 0x0008) == 0 && call_args.is_empty() {
-                    if let JValue::Ref(Some(r)) = &recv {
-                        let slot = if name == "annotationType" {
-                            "__ann_annotationType".to_owned()
-                        } else {
-                            format!("__ann_{name}")
-                        };
-                        let ann_value = if let Some(v) = r.borrow().fields.get(&slot).cloned() {
-                            Some(v)
-                        } else if r.borrow().fields.contains_key("__ann_annotationType") {
-                            self.resolve_annotation_method_default(&owner, &name, &desc)
-                        } else {
-                            None
-                        };
-                        if let Some(v) = ann_value {
-                            let ret = if ret_token == "V" {
-                                JValue::Ref(None)
-                            } else if !matches!(ret_token.as_bytes().first(), Some(b'L' | b'[')) {
-                                self.wrap_primitive_value_for_descriptor(&ret_token, v)
-                            } else {
-                                v
-                            };
-                            return Some(ret);
-                        }
-                    }
+                    call_args.push(self.adapt_value_for_descriptor(p, src));
                 }
 
                 let result = if (modifiers & 0x0008) != 0 {
                     self.invoke_static(&owner, &name, &desc, call_args)
                 } else {
                     match recv {
-                        JValue::Ref(Some(ref r)) => self.invoke_virtual(r.clone(), &owner, &name, &desc, call_args),
+                        JValue::Ref(Some(r)) => self.invoke_virtual(r, &owner, &name, &desc, call_args),
                         _ => Ok(JValue::Ref(None)),
                     }
                 };
@@ -1794,7 +1462,7 @@ impl super::Vm {
                 let mut call_args = Vec::with_capacity(param_tokens.len());
                 for (i, p) in param_tokens.iter().enumerate() {
                     let src = raw_args.get(i).cloned().unwrap_or_else(|| default_value_for_descriptor(p));
-                    call_args.push(self.adapt_reflection_arg_for_descriptor(p, src));
+                    call_args.push(self.adapt_value_for_descriptor(p, src));
                 }
                 let obj = JObject::new(owner.clone());
                 if let Err(e) = self.invoke_virtual(obj.clone(), &owner, "<init>", &desc, call_args) {
@@ -1852,9 +1520,9 @@ impl super::Vm {
                 };
 
                 let raw = if (modifiers & 0x0008) != 0 {
-                    let _ = self.ensure_class_init(&owner);
-                    self.resolve_static_field_in_hierarchy(&owner, &name)
-                        .or_else(|| self.resolve_constant_value_static_field(&owner, &name))
+                    self.static_fields
+                        .get(&owner).and_then(|m| m.get(&name))
+                        .cloned()
                         .unwrap_or_else(|| default_value_for_descriptor(&desc))
                 } else {
                     match _args.first().and_then(|v| v.as_ref()) {
@@ -1889,7 +1557,6 @@ impl super::Vm {
                 let val = _args.get(1).cloned().unwrap_or(JValue::Ref(None));
                 let adapted = self.adapt_value_for_descriptor(&desc, val);
                 if (modifiers & 0x0008) != 0 {
-                    let _ = self.ensure_class_init(&owner);
                     self.static_fields.entry(owner).or_default().insert(name, adapted);
                 } else if let Some(target) = _args.first().and_then(|v| v.as_ref()) {
                     target.borrow_mut().fields.insert(name, adapted);
@@ -2055,22 +1722,13 @@ impl super::Vm {
                 Some(JValue::Int(len))
             }
             ("java/lang/String", "charAt") => {
-                let idx_i = _args.first().map(|v| v.as_int()).unwrap_or(0);
-                if idx_i < 0 {
-                    let exc = self.new_vm_exception("java/lang/StringIndexOutOfBoundsException", None);
-                    *self.pending_exception_mut() = Some(exc);
-                    return Some(JValue::Int(0));
-                }
-                let idx = idx_i as usize;
-                let Some(value) = this.borrow().as_java_string_value().cloned() else {
-                    return Some(JValue::Int(0));
-                };
-                let Some(ch) = value.code_unit_at(idx) else {
-                    let exc = self.new_vm_exception("java/lang/StringIndexOutOfBoundsException", None);
-                    *self.pending_exception_mut() = Some(exc);
-                    return Some(JValue::Int(0));
-                };
-                Some(JValue::Int(ch as i32))
+                let idx = _args.first().map(|v| v.as_int() as usize).unwrap_or(0);
+                let ch = this
+                    .borrow()
+                    .as_java_string_value()
+                    .and_then(|s| s.code_unit_at(idx))
+                    .unwrap_or(0) as i32;
+                Some(JValue::Int(ch))
             }
             ("java/lang/String", "isEmpty") => {
                 let empty = this
@@ -2110,66 +1768,6 @@ impl super::Vm {
                     .map(JavaStringValue::hash_code)
                     .unwrap_or(0);
                 Some(JValue::Int(hash))
-            }
-            ("java/net/URL", "openStream") => {
-                let (protocol, file) = {
-                    let b = this.borrow();
-                    let protocol = b
-                        .fields
-                        .get("protocol")
-                        .and_then(|v| v.as_ref())
-                        .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                        .unwrap_or_default();
-                    let file = b
-                        .fields
-                        .get("file")
-                        .and_then(|v| v.as_ref())
-                        .and_then(|r| r.borrow().as_java_string().map(|s| s.to_owned()))
-                        .unwrap_or_default();
-                    (protocol, file)
-                };
-                if protocol != "bundle" {
-                    let exc = self.new_vm_exception_message(
-                        "java/lang/UnsupportedOperationException",
-                        format!("URL.openStream unsupported protocol: {protocol}"),
-                    );
-                    *self.pending_exception_mut() = Some(exc);
-                    return Some(JValue::Ref(None));
-                }
-                let normalized = file.strip_prefix('/').unwrap_or(&file);
-                match self.read_resource(normalized) {
-                    Ok(Some(data)) => {
-                        let elems: Vec<JValue> =
-                            data.iter().map(|&b| JValue::Int(b as i8 as i32)).collect();
-                        let byte_array = JObject::new_array("[B", elems);
-                        let bais = JObject::new("java/io/ByteArrayInputStream");
-                        bais.borrow_mut()
-                            .fields
-                            .insert("buf".to_owned(), JValue::Ref(Some(byte_array)));
-                        bais.borrow_mut().fields.insert("pos".to_owned(), JValue::Int(0));
-                        bais.borrow_mut()
-                            .fields
-                            .insert("count".to_owned(), JValue::Int(data.len() as i32));
-                        bais.borrow_mut().fields.insert("mark".to_owned(), JValue::Int(0));
-                        Some(JValue::Ref(Some(bais)))
-                    }
-                    Ok(None) => {
-                        let exc = self.new_vm_exception_message(
-                            "java/io/FileNotFoundException",
-                            format!("Resource not found: {normalized}"),
-                        );
-                        *self.pending_exception_mut() = Some(exc);
-                        Some(JValue::Ref(None))
-                    }
-                    Err(err) => {
-                        let exc = self.new_vm_exception_message(
-                            "java/io/IOException",
-                            format!("Failed to open resource {normalized}: {err}"),
-                        );
-                        *self.pending_exception_mut() = Some(exc);
-                        Some(JValue::Ref(None))
-                    }
-                }
             }
             ("java/lang/String", "substring") => {
                 let this_borrow = this.borrow();
@@ -2323,23 +1921,13 @@ impl super::Vm {
                 Some(JValue::Int(idx))
             }
             ("java/lang/String", "trim") => {
-                let value = this
+                let s = this
                     .borrow()
-                    .as_java_string_value()
-                    .cloned()
-                    .unwrap_or_else(|| JavaStringValue::from_utf16(Vec::new()));
-                let units = value.utf16();
-                let mut start = 0usize;
-                let mut end = units.len();
-                while start < end && units[start] <= 0x20 {
-                    start += 1;
-                }
-                while end > start && units[end - 1] <= 0x20 {
-                    end -= 1;
-                }
-                Some(JValue::Ref(Some(JObject::new_string_utf16(
-                    units[start..end].to_vec(),
-                ))))
+                    .java_string_to_string_lossy()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_owned();
+                Some(JValue::Ref(Some(JObject::new_string(s))))
             }
             ("java/lang/String", "toLowerCase") => {
                 let s = this
@@ -2422,8 +2010,6 @@ impl super::Vm {
                     NativePayload::ByteArray(v) => NativePayload::ByteArray(v.clone()),
                     NativePayload::IntArray(v) => NativePayload::IntArray(v.clone()),
                     NativePayload::LongArray(v) => NativePayload::LongArray(v.clone()),
-                    NativePayload::ThreadLocalStorage(values) => NativePayload::ThreadLocalStorage(values.clone()),
-                    NativePayload::ThreadLocalMap(values) => NativePayload::ThreadLocalMap(values.clone()),
                     NativePayload::PrintStream(is_err) => NativePayload::PrintStream(*is_err),
                     NativePayload::ProcessPipeInputStream => NativePayload::ProcessPipeInputStream,
                     NativePayload::Lambda(f) => NativePayload::Lambda(f.clone()),
@@ -2455,7 +2041,6 @@ impl super::Vm {
                 };
                 let cloned = Rc::new(RefCell::new(crate::heap::JObject {
                     class_name: src.class_name.clone(),
-                    class_snapshot: src.class_snapshot.clone(),
                     fields,
                     native,
                 }));
@@ -2473,32 +2058,6 @@ impl super::Vm {
             }
             _ => None,
         }
-    }
-
-    fn resolve_annotation_method_default(
-        &mut self,
-        owner: &str,
-        method_name: &str,
-        descriptor: &str,
-    ) -> Option<JValue> {
-        self.ensure_class_ready(owner);
-        let (attrs, cp) = {
-            let cf = self.get_class(owner)?;
-            let method = cf.methods.iter().find(|m| {
-                cf.constant_pool.utf8(m.name_index) == method_name
-                    && cf.constant_pool.utf8(m.descriptor_index) == descriptor
-            })?;
-            (method.attributes.clone(), cf.constant_pool.clone())
-        };
-        for attr in attrs {
-            if let Attribute::Unknown { name, data } = attr {
-                if name == "AnnotationDefault" {
-                    let mut p = 0usize;
-                    return self.parse_annotation_element_value(&data, &mut p, &cp);
-                }
-            }
-        }
-        None
     }
 }
 
@@ -2521,7 +2080,8 @@ mod tests {
         );
 
         let arg = JValue::Ref(Some(JObject::new_string("broken.txt")));
-        let result = vm.native_classloader("getResourceAsStream", &[arg]);
+        let loader = JObject::new("java/lang/ClassLoader");
+        let result = vm.native_classloader(&loader, "getResourceAsStream", &[arg]);
 
         assert!(matches!(result, Some(JValue::Void)));
         let err = vm.pending_exception_err().expect("pending exception");

--- a/jvm-core/src/interpreter/trampoline.rs
+++ b/jvm-core/src/interpreter/trampoline.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
-use crate::class_file::{Attribute, BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry};
-use crate::heap::{JObject, JRef, JValue, NativePayload};
+use crate::class_file::{BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry};
+use crate::heap::{JObject, JRef, JValue};
 
 use super::cp_cache::CpCache;
 use super::descriptors::*;
@@ -33,14 +33,6 @@ pub(crate) struct FrameInfo {
     /// For ACC_SYNCHRONIZED methods: the monitor object to release on method exit.
     /// Instance methods use `this`, static methods use the class object.
     pub synchronized_monitor: Option<JRef>,
-}
-
-#[derive(Clone)]
-struct StackTraceFrame {
-    class_name: String,
-    method_name: String,
-    file_name: Option<String>,
-    line_number: i32,
 }
 
 /// Saved state for a StringConcatFactory recipe interrupted by toString().
@@ -129,10 +121,7 @@ impl Vm {
                 Err(err_msg) => {
                     match self.unwind_exception(call_stack, opcode_pc, &err_msg) {
                         Ok(()) => {} // handler found
-                        Err(e) => {
-                            self.ensure_pending_exception_from_err(&e);
-                            return Err(e);
-                        }
+                        Err(e) => return Err(e),
                     }
                 }
             }
@@ -211,10 +200,7 @@ impl Vm {
                 Err(err_msg) => {
                     match self.unwind_exception(call_stack, opcode_pc, &err_msg) {
                         Ok(()) => {}
-                        Err(e) => {
-                            self.ensure_pending_exception_from_err(&e);
-                            return Err(e);
-                        }
+                        Err(e) => return Err(e),
                     }
                 }
             }
@@ -267,11 +253,16 @@ impl Vm {
                             }
                         }
                         Ok(None) => {
-                            // Time slice exhausted or voluntary yield.
-                            // `Sleeping` is resumed by Scheduler::wake_sleepers.
+                            // Time slice exhausted or voluntary yield/sleep.
+                            // Normalize Yielded/Sleeping back to Runnable so
+                            // this thread can be scheduled again after other
+                            // threads get a turn.
                             let thread = self.scheduler.current_thread_mut();
-                            if thread.state == ThreadState::Yielded {
-                                thread.state = ThreadState::Runnable;
+                            match thread.state {
+                                ThreadState::Yielded | ThreadState::Sleeping => {
+                                    thread.state = ThreadState::Runnable;
+                                }
+                                _ => {}
                             }
                         }
                         Err(e) => {
@@ -288,12 +279,11 @@ impl Vm {
                 ThreadState::Terminated => {
                     // Skip terminated threads.
                 }
-                ThreadState::Yielded => {
+                ThreadState::Yielded | ThreadState::Sleeping => {
                     // Voluntary yield — set back to Runnable so this thread
                     // can be scheduled again after other threads get a turn.
                     self.scheduler.current_thread_mut().state = ThreadState::Runnable;
                 }
-                ThreadState::Sleeping => {}
                 ThreadState::Joining(_)
                 | ThreadState::WaitingOnMonitor(_) | ThreadState::WaitingOnCondition(_) => {
                     // Blocked — skip to next thread.
@@ -302,17 +292,12 @@ impl Vm {
 
             // Wake joiners/sleeping threads before trying to advance.
             self.scheduler.wake_joiners();
-            self.scheduler.wake_sleepers();
 
             // Advance to next runnable thread.
             if !self.scheduler.advance() {
                 // No runnable threads — check for deadlock or all terminated.
                 if self.scheduler.all_terminated() {
                     return Ok(JValue::Void);
-                }
-                if self.scheduler.has_sleeping_threads() {
-                    std::thread::sleep(std::time::Duration::from_millis(1));
-                    continue;
                 }
                 // Check if only blocked threads remain (potential deadlock).
                 if self.scheduler.runnable_count() == 0 {
@@ -335,22 +320,16 @@ impl Vm {
         while !self.scheduler.only_main_alive() && iterations < max_iterations {
             iterations += 1;
             self.scheduler.wake_joiners();
-            self.scheduler.wake_sleepers();
 
             if !self.scheduler.advance() {
-                if self.scheduler.has_sleeping_threads() {
-                    std::thread::sleep(std::time::Duration::from_millis(1));
-                    continue;
-                }
                 break;
             }
 
             let state = self.scheduler.current_thread().state;
             match state {
-                ThreadState::Yielded => {
+                ThreadState::Yielded | ThreadState::Sleeping => {
                     self.scheduler.current_thread_mut().state = ThreadState::Runnable;
                 }
-                ThreadState::Sleeping => continue,
                 ThreadState::Runnable => {}
                 _ => continue,
             }
@@ -387,19 +366,11 @@ impl Vm {
     ) -> Result<(), String> {
         let mut first = true;
         let mut trace = String::new();
-        while !call_stack.is_empty() {
-            let pc = if first {
-                initial_opcode_pc
-            } else {
-                call_stack.last().unwrap().frame.pc.saturating_sub(1)
-            };
+        while let Some(fi) = call_stack.last_mut() {
+            fi.concat_state = None;
+            let pc = if first { initial_opcode_pc } else { fi.frame.pc.saturating_sub(1) };
             first = false;
 
-            self.ensure_pending_exception_from_err(err_msg);
-            self.populate_pending_exception_stack_trace(call_stack, initial_opcode_pc);
-
-            let fi = call_stack.last_mut().unwrap();
-            fi.concat_state = None;
             if let Some((handler_pc, exc_obj)) = self.find_exception_handler(
                 &fi.frame, &fi.exception_table, &fi.cp, pc, err_msg,
             ) {
@@ -417,133 +388,6 @@ impl Vm {
             self.release_synchronized_monitor(&popped)?;
         }
         Err(if trace.is_empty() { err_msg.to_owned() } else { trace })
-    }
-
-    fn populate_pending_exception_stack_trace(
-        &mut self,
-        call_stack: &[FrameInfo],
-        initial_opcode_pc: usize,
-    ) {
-        let Some(exc) = self.scheduler.current_thread().pending_exception.clone() else {
-            return;
-        };
-        if !Self::should_populate_stack_trace(&exc) {
-            return;
-        }
-
-        let frames = self.capture_stack_trace_frames(call_stack, initial_opcode_pc);
-        if frames.is_empty() {
-            return;
-        }
-
-        let elements = frames
-            .into_iter()
-            .map(|frame| {
-                let ste = JObject::new("java/lang/StackTraceElement");
-                {
-                    let mut obj = ste.borrow_mut();
-                    obj.fields.insert(
-                        "declaringClass".to_owned(),
-                        JValue::Ref(Some(JObject::new_string(frame.class_name))),
-                    );
-                    obj.fields.insert(
-                        "methodName".to_owned(),
-                        JValue::Ref(Some(JObject::new_string(frame.method_name))),
-                    );
-                    obj.fields.insert(
-                        "fileName".to_owned(),
-                        JValue::Ref(frame.file_name.map(JObject::new_string)),
-                    );
-                    obj.fields
-                        .insert("lineNumber".to_owned(), JValue::Int(frame.line_number));
-                }
-                JValue::Ref(Some(ste))
-            })
-            .collect();
-        let stack_trace = JObject::new_array("[Ljava/lang/StackTraceElement;", elements);
-        exc.borrow_mut()
-            .fields
-            .insert("stackTrace".to_owned(), JValue::Ref(Some(stack_trace)));
-    }
-
-    fn should_populate_stack_trace(exc: &JRef) -> bool {
-        match exc.borrow().fields.get("stackTrace") {
-            Some(JValue::Ref(Some(stack_trace))) => {
-                matches!(&stack_trace.borrow().native, NativePayload::Array(elements) if elements.is_empty())
-            }
-            Some(JValue::Ref(None)) | None => true,
-            _ => false,
-        }
-    }
-
-    fn capture_stack_trace_frames(
-        &mut self,
-        call_stack: &[FrameInfo],
-        initial_opcode_pc: usize,
-    ) -> Vec<StackTraceFrame> {
-        let mut out = Vec::with_capacity(call_stack.len());
-        let mut first = true;
-        for fi in call_stack.iter().rev() {
-            let pc = if first {
-                initial_opcode_pc
-            } else {
-                fi.frame.pc.saturating_sub(1)
-            };
-            first = false;
-            if let Some(frame) = self.stack_trace_frame(fi, pc) {
-                out.push(frame);
-            }
-        }
-        out
-    }
-
-    fn stack_trace_frame(&mut self, fi: &FrameInfo, pc: usize) -> Option<StackTraceFrame> {
-        let (owner, method_name, descriptor) = Self::parse_frame_owner(&fi.frame_owner)?;
-        self.ensure_class_ready(owner);
-        let class = self.get_class(owner)?;
-        let source_file = class.attributes.iter().find_map(|attr| {
-            if let Attribute::SourceFile { sourcefile_index } = attr {
-                Some(class.constant_pool.utf8(*sourcefile_index).to_owned())
-            } else {
-                None
-            }
-        });
-        let method = class.methods.iter().find(|method| {
-            class.constant_pool.utf8(method.name_index) == method_name
-                && class.constant_pool.utf8(method.descriptor_index) == descriptor
-        })?;
-        let line_number = method
-            .code()
-            .and_then(|code| {
-                code.attributes.iter().find_map(|attr| {
-                    if let Attribute::LineNumberTable(entries) = attr {
-                        entries
-                            .iter()
-                            .take_while(|entry| usize::from(entry.start_pc) <= pc)
-                            .last()
-                            .map(|entry| i32::from(entry.line_number))
-                    } else {
-                        None
-                    }
-                })
-            })
-            .unwrap_or(-1);
-        Some(StackTraceFrame {
-            class_name: owner.replace('/', "."),
-            method_name: method_name.to_owned(),
-            file_name: source_file,
-            line_number,
-        })
-    }
-
-    fn parse_frame_owner(frame_owner: &str) -> Option<(&str, &str, &str)> {
-        let descriptor_start = frame_owner.find('(')?;
-        let method_sep = frame_owner[..descriptor_start].rfind('.')?;
-        Some((
-            &frame_owner[..method_sep],
-            &frame_owner[method_sep + 1..descriptor_start],
-            &frame_owner[descriptor_start..],
-        ))
     }
 
     /// Release the synchronized monitor when a frame is popped (normal return or exception unwind).
@@ -773,62 +617,12 @@ impl Vm {
     ) -> Result<Option<FrameInfo>, String> {
         // Pure Rust lambda closures are handled inline — not via frames.
         let is_bytecode_lambda;
-        let class_snapshot;
         {
             let borrow = this.borrow();
             if matches!(borrow.native, crate::heap::NativePayload::Lambda(_)) {
                 return Ok(None);
             }
             is_bytecode_lambda = matches!(borrow.native, crate::heap::NativePayload::BytecodeLambda { .. });
-            class_snapshot = borrow.class_snapshot.clone();
-        }
-
-        if !is_bytecode_lambda {
-            if let Some(snapshot) = class_snapshot.as_ref() {
-                let runtime_class = this.borrow().class_name.clone();
-                let mut isolated_snapshot = snapshot.clone();
-                isolated_snapshot.constant_pool.cache = Rc::new(std::cell::RefCell::new(
-                    vec![None; isolated_snapshot.constant_pool.entries.len()],
-                ));
-                let snapshot_key =
-                    self.ensure_snapshot_lookup_class(&this, &runtime_class, &isolated_snapshot);
-                if let Some(info) = self.resolve_method_exec_info(&snapshot_key, method_name, descriptor) {
-                    if info.access_flags & 0x0400 != 0 {
-                        let ms = format!("{}.{method_name}{}", info.class_name, info.descriptor);
-                        let exc = self.new_vm_exception_message("java/lang/AbstractMethodError", ms.clone());
-                        *self.pending_exception_mut() = Some(exc);
-                        return Err(format!("java/lang/AbstractMethodError: {ms}"));
-                    }
-                    if info.has_code {
-                        let (param_tokens, _) = Self::parse_method_descriptor_tokens(&info.descriptor);
-                        let req = 1 + param_tokens.iter().map(|t| if t == "J" || t == "D" { 2 } else { 1 }).sum::<usize>();
-                        let total = info.max_locals.max(req);
-                        let mut locals = vec![JValue::Void; total];
-                        locals[0] = JValue::Ref(Some(this.clone()));
-                        let mut li = 1usize;
-                        for (a, t) in args.clone().into_iter().zip(param_tokens.iter()) {
-                            if li >= locals.len() { break; }
-                            locals[li] = self.adapt_value_for_descriptor(t, a);
-                            li += if t == "J" || t == "D" { 2 } else { 1 };
-                        }
-                        let fo = format!("{}.{method_name}{}", info.class_name, info.descriptor);
-                        let synchronized_monitor = self.acquire_instance_synchronized_monitor(info.access_flags, &locals);
-                        return Ok(Some(FrameInfo {
-                            frame: Frame { locals, stack: Vec::new(), pc: 0 },
-                            code: info.code,
-                            cp: info.cp,
-                            cache: info.cache,
-                            frame_owner: fo,
-                            bootstrap_methods: info.bootstrap_methods,
-                            exception_table: info.exception_table,
-                            push_return,
-                            concat_state: None,
-                            lambda_return_adapt: None,
-                            synchronized_monitor,
-                        }));
-                    }
-                }
-            }
         }
 
         let runtime_class = this.borrow().class_name.clone();

--- a/jvm-core/src/interpreter/trampoline.rs
+++ b/jvm-core/src/interpreter/trampoline.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
-use crate::class_file::{BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry};
-use crate::heap::{JObject, JRef, JValue};
+use crate::class_file::{Attribute, BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry};
+use crate::heap::{JObject, JRef, JValue, NativePayload};
 
 use super::cp_cache::CpCache;
 use super::descriptors::*;
@@ -33,6 +33,14 @@ pub(crate) struct FrameInfo {
     /// For ACC_SYNCHRONIZED methods: the monitor object to release on method exit.
     /// Instance methods use `this`, static methods use the class object.
     pub synchronized_monitor: Option<JRef>,
+}
+
+#[derive(Clone)]
+struct StackTraceFrame {
+    class_name: String,
+    method_name: String,
+    file_name: Option<String>,
+    line_number: i32,
 }
 
 /// Saved state for a StringConcatFactory recipe interrupted by toString().
@@ -121,7 +129,10 @@ impl Vm {
                 Err(err_msg) => {
                     match self.unwind_exception(call_stack, opcode_pc, &err_msg) {
                         Ok(()) => {} // handler found
-                        Err(e) => return Err(e),
+                        Err(e) => {
+                            self.ensure_pending_exception_from_err(&e);
+                            return Err(e);
+                        }
                     }
                 }
             }
@@ -200,7 +211,10 @@ impl Vm {
                 Err(err_msg) => {
                     match self.unwind_exception(call_stack, opcode_pc, &err_msg) {
                         Ok(()) => {}
-                        Err(e) => return Err(e),
+                        Err(e) => {
+                            self.ensure_pending_exception_from_err(&e);
+                            return Err(e);
+                        }
                     }
                 }
             }
@@ -253,16 +267,11 @@ impl Vm {
                             }
                         }
                         Ok(None) => {
-                            // Time slice exhausted or voluntary yield/sleep.
-                            // Normalize Yielded/Sleeping back to Runnable so
-                            // this thread can be scheduled again after other
-                            // threads get a turn.
+                            // Time slice exhausted or voluntary yield.
+                            // `Sleeping` is resumed by Scheduler::wake_sleepers.
                             let thread = self.scheduler.current_thread_mut();
-                            match thread.state {
-                                ThreadState::Yielded | ThreadState::Sleeping => {
-                                    thread.state = ThreadState::Runnable;
-                                }
-                                _ => {}
+                            if thread.state == ThreadState::Yielded {
+                                thread.state = ThreadState::Runnable;
                             }
                         }
                         Err(e) => {
@@ -279,11 +288,12 @@ impl Vm {
                 ThreadState::Terminated => {
                     // Skip terminated threads.
                 }
-                ThreadState::Yielded | ThreadState::Sleeping => {
+                ThreadState::Yielded => {
                     // Voluntary yield — set back to Runnable so this thread
                     // can be scheduled again after other threads get a turn.
                     self.scheduler.current_thread_mut().state = ThreadState::Runnable;
                 }
+                ThreadState::Sleeping => {}
                 ThreadState::Joining(_)
                 | ThreadState::WaitingOnMonitor(_) | ThreadState::WaitingOnCondition(_) => {
                     // Blocked — skip to next thread.
@@ -292,12 +302,17 @@ impl Vm {
 
             // Wake joiners/sleeping threads before trying to advance.
             self.scheduler.wake_joiners();
+            self.scheduler.wake_sleepers();
 
             // Advance to next runnable thread.
             if !self.scheduler.advance() {
                 // No runnable threads — check for deadlock or all terminated.
                 if self.scheduler.all_terminated() {
                     return Ok(JValue::Void);
+                }
+                if self.scheduler.has_sleeping_threads() {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                    continue;
                 }
                 // Check if only blocked threads remain (potential deadlock).
                 if self.scheduler.runnable_count() == 0 {
@@ -320,16 +335,22 @@ impl Vm {
         while !self.scheduler.only_main_alive() && iterations < max_iterations {
             iterations += 1;
             self.scheduler.wake_joiners();
+            self.scheduler.wake_sleepers();
 
             if !self.scheduler.advance() {
+                if self.scheduler.has_sleeping_threads() {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                    continue;
+                }
                 break;
             }
 
             let state = self.scheduler.current_thread().state;
             match state {
-                ThreadState::Yielded | ThreadState::Sleeping => {
+                ThreadState::Yielded => {
                     self.scheduler.current_thread_mut().state = ThreadState::Runnable;
                 }
+                ThreadState::Sleeping => continue,
                 ThreadState::Runnable => {}
                 _ => continue,
             }
@@ -366,11 +387,19 @@ impl Vm {
     ) -> Result<(), String> {
         let mut first = true;
         let mut trace = String::new();
-        while let Some(fi) = call_stack.last_mut() {
-            fi.concat_state = None;
-            let pc = if first { initial_opcode_pc } else { fi.frame.pc.saturating_sub(1) };
+        while !call_stack.is_empty() {
+            let pc = if first {
+                initial_opcode_pc
+            } else {
+                call_stack.last().unwrap().frame.pc.saturating_sub(1)
+            };
             first = false;
 
+            self.ensure_pending_exception_from_err(err_msg);
+            self.populate_pending_exception_stack_trace(call_stack, initial_opcode_pc);
+
+            let fi = call_stack.last_mut().unwrap();
+            fi.concat_state = None;
             if let Some((handler_pc, exc_obj)) = self.find_exception_handler(
                 &fi.frame, &fi.exception_table, &fi.cp, pc, err_msg,
             ) {
@@ -388,6 +417,133 @@ impl Vm {
             self.release_synchronized_monitor(&popped)?;
         }
         Err(if trace.is_empty() { err_msg.to_owned() } else { trace })
+    }
+
+    fn populate_pending_exception_stack_trace(
+        &mut self,
+        call_stack: &[FrameInfo],
+        initial_opcode_pc: usize,
+    ) {
+        let Some(exc) = self.scheduler.current_thread().pending_exception.clone() else {
+            return;
+        };
+        if !Self::should_populate_stack_trace(&exc) {
+            return;
+        }
+
+        let frames = self.capture_stack_trace_frames(call_stack, initial_opcode_pc);
+        if frames.is_empty() {
+            return;
+        }
+
+        let elements = frames
+            .into_iter()
+            .map(|frame| {
+                let ste = JObject::new("java/lang/StackTraceElement");
+                {
+                    let mut obj = ste.borrow_mut();
+                    obj.fields.insert(
+                        "declaringClass".to_owned(),
+                        JValue::Ref(Some(JObject::new_string(frame.class_name))),
+                    );
+                    obj.fields.insert(
+                        "methodName".to_owned(),
+                        JValue::Ref(Some(JObject::new_string(frame.method_name))),
+                    );
+                    obj.fields.insert(
+                        "fileName".to_owned(),
+                        JValue::Ref(frame.file_name.map(JObject::new_string)),
+                    );
+                    obj.fields
+                        .insert("lineNumber".to_owned(), JValue::Int(frame.line_number));
+                }
+                JValue::Ref(Some(ste))
+            })
+            .collect();
+        let stack_trace = JObject::new_array("[Ljava/lang/StackTraceElement;", elements);
+        exc.borrow_mut()
+            .fields
+            .insert("stackTrace".to_owned(), JValue::Ref(Some(stack_trace)));
+    }
+
+    fn should_populate_stack_trace(exc: &JRef) -> bool {
+        match exc.borrow().fields.get("stackTrace") {
+            Some(JValue::Ref(Some(stack_trace))) => {
+                matches!(&stack_trace.borrow().native, NativePayload::Array(elements) if elements.is_empty())
+            }
+            Some(JValue::Ref(None)) | None => true,
+            _ => false,
+        }
+    }
+
+    fn capture_stack_trace_frames(
+        &mut self,
+        call_stack: &[FrameInfo],
+        initial_opcode_pc: usize,
+    ) -> Vec<StackTraceFrame> {
+        let mut out = Vec::with_capacity(call_stack.len());
+        let mut first = true;
+        for fi in call_stack.iter().rev() {
+            let pc = if first {
+                initial_opcode_pc
+            } else {
+                fi.frame.pc.saturating_sub(1)
+            };
+            first = false;
+            if let Some(frame) = self.stack_trace_frame(fi, pc) {
+                out.push(frame);
+            }
+        }
+        out
+    }
+
+    fn stack_trace_frame(&mut self, fi: &FrameInfo, pc: usize) -> Option<StackTraceFrame> {
+        let (owner, method_name, descriptor) = Self::parse_frame_owner(&fi.frame_owner)?;
+        self.ensure_class_ready(owner);
+        let class = self.get_class(owner)?;
+        let source_file = class.attributes.iter().find_map(|attr| {
+            if let Attribute::SourceFile { sourcefile_index } = attr {
+                Some(class.constant_pool.utf8(*sourcefile_index).to_owned())
+            } else {
+                None
+            }
+        });
+        let method = class.methods.iter().find(|method| {
+            class.constant_pool.utf8(method.name_index) == method_name
+                && class.constant_pool.utf8(method.descriptor_index) == descriptor
+        })?;
+        let line_number = method
+            .code()
+            .and_then(|code| {
+                code.attributes.iter().find_map(|attr| {
+                    if let Attribute::LineNumberTable(entries) = attr {
+                        entries
+                            .iter()
+                            .take_while(|entry| usize::from(entry.start_pc) <= pc)
+                            .last()
+                            .map(|entry| i32::from(entry.line_number))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or(-1);
+        Some(StackTraceFrame {
+            class_name: owner.replace('/', "."),
+            method_name: method_name.to_owned(),
+            file_name: source_file,
+            line_number,
+        })
+    }
+
+    fn parse_frame_owner(frame_owner: &str) -> Option<(&str, &str, &str)> {
+        let descriptor_start = frame_owner.find('(')?;
+        let method_sep = frame_owner[..descriptor_start].rfind('.')?;
+        Some((
+            &frame_owner[..method_sep],
+            &frame_owner[method_sep + 1..descriptor_start],
+            &frame_owner[descriptor_start..],
+        ))
     }
 
     /// Release the synchronized monitor when a frame is popped (normal return or exception unwind).
@@ -617,12 +773,62 @@ impl Vm {
     ) -> Result<Option<FrameInfo>, String> {
         // Pure Rust lambda closures are handled inline — not via frames.
         let is_bytecode_lambda;
+        let class_snapshot;
         {
             let borrow = this.borrow();
             if matches!(borrow.native, crate::heap::NativePayload::Lambda(_)) {
                 return Ok(None);
             }
             is_bytecode_lambda = matches!(borrow.native, crate::heap::NativePayload::BytecodeLambda { .. });
+            class_snapshot = borrow.class_snapshot.clone();
+        }
+
+        if !is_bytecode_lambda {
+            if let Some(snapshot) = class_snapshot.as_ref() {
+                let runtime_class = this.borrow().class_name.clone();
+                let mut isolated_snapshot = snapshot.clone();
+                isolated_snapshot.constant_pool.cache = Rc::new(std::cell::RefCell::new(
+                    vec![None; isolated_snapshot.constant_pool.entries.len()],
+                ));
+                let snapshot_key =
+                    self.ensure_snapshot_lookup_class(&this, &runtime_class, &isolated_snapshot);
+                if let Some(info) = self.resolve_method_exec_info(&snapshot_key, method_name, descriptor) {
+                    if info.access_flags & 0x0400 != 0 {
+                        let ms = format!("{}.{method_name}{}", info.class_name, info.descriptor);
+                        let exc = self.new_vm_exception_message("java/lang/AbstractMethodError", ms.clone());
+                        *self.pending_exception_mut() = Some(exc);
+                        return Err(format!("java/lang/AbstractMethodError: {ms}"));
+                    }
+                    if info.has_code {
+                        let (param_tokens, _) = Self::parse_method_descriptor_tokens(&info.descriptor);
+                        let req = 1 + param_tokens.iter().map(|t| if t == "J" || t == "D" { 2 } else { 1 }).sum::<usize>();
+                        let total = info.max_locals.max(req);
+                        let mut locals = vec![JValue::Void; total];
+                        locals[0] = JValue::Ref(Some(this.clone()));
+                        let mut li = 1usize;
+                        for (a, t) in args.clone().into_iter().zip(param_tokens.iter()) {
+                            if li >= locals.len() { break; }
+                            locals[li] = self.adapt_value_for_descriptor(t, a);
+                            li += if t == "J" || t == "D" { 2 } else { 1 };
+                        }
+                        let fo = format!("{}.{method_name}{}", info.class_name, info.descriptor);
+                        let synchronized_monitor = self.acquire_instance_synchronized_monitor(info.access_flags, &locals);
+                        return Ok(Some(FrameInfo {
+                            frame: Frame { locals, stack: Vec::new(), pc: 0 },
+                            code: info.code,
+                            cp: info.cp,
+                            cache: info.cache,
+                            frame_owner: fo,
+                            bootstrap_methods: info.bootstrap_methods,
+                            exception_table: info.exception_table,
+                            push_return,
+                            concat_state: None,
+                            lambda_return_adapt: None,
+                            synchronized_monitor,
+                        }));
+                    }
+                }
+            }
         }
 
         let runtime_class = this.borrow().class_name.clone();


### PR DESCRIPTION
## Summary

This PR tightens class identity handling around JVMS Chapter 5 class loading and linking.

It introduces the foundation for loader-scoped class identity by separating a class's binary internal name from the VM lookup key used to store dynamically defined classes. Classes defined through a `ClassLoader` are tracked by defining loader plus binary name, while `Class` mirrors continue to expose the binary name.

## Goal

Improve JVMS Chapter 5 conformance for class loading, definition, and resolution.

## Trigger

The issue was discovered while running Clojure upstream tests, where dynamically defined classes exposed differences between binary names, lookup keys, and defining-loader identity.

## Scope

This PR focuses on the lookup-key / loader-scoped identity foundation:

- track classes by defining loader and binary internal name
- separate VM lookup keys from class binary names
- preserve defining-loader information for class mirrors
- remap loader-context resolution where required for correct symbolic lookup
- keep only adjacent plumbing required for this identity model

Adjacent Clojure, reflection, resource-loading, regex, scheduler, stack-trace, ThreadLocal, and broad library behavior fixes are intentionally left out for separate PRs.

## Planned merge order

1. JVMS-5 [1/3]: loader-scoped lookup keys and class identity foundation
2. JVMS-5 [2/3]: defineClass identity hardening
3. JVMS-5 [3/3]: symbolic resolution cleanup

## Validation

- `docker-compose run --rm -w /app/jvm-core rust cargo test --package jvm-core --no-run`
- `docker-compose run --rm -w /app/jvm-core rust cargo test --package jvm-core --test integration_test classloader -- --nocapture`
