### PR TITLE
Clarify interface method resolution choice

### DIFF
--- a/docs/loader-architecture.md
+++ b/docs/loader-architecture.md
@@ -300,8 +300,9 @@ To resolve a symbolic reference from `D` to an interface method in interface `C`
    - first in `C`;
    - then as a public, non-static method of `Object`;
    - then among maximally-specific superinterface methods;
-   - then among other non-private, non-static superinterface methods permitted by
-     JVMS interface method resolution.
+   - then any non-private, non-static method declared in a superinterface of `C`,
+     with the implementation free to pick arbitrarily among multiple such
+     candidates (JVMS §5.4.3.4).
 4. If lookup fails, throw `NoSuchMethodError`.
 5. Apply access control from `D` to the resolved method.
 6. Impose loading constraints for class/interface names mentioned in the method


### PR DESCRIPTION
## Summary

- Clarify the interface method resolution wording for JVMS §5.4.3.4 step 5.
- State that an implementation may choose arbitrarily among multiple non-private, non-static superinterface method candidates.

## Context

Follow-up for https://github.com/kawasima/199xVM/pull/86#discussion_r3157471930.

## Validation

- `git diff --check`
- `.codex/bin/check-local-enforcement --hook pre-commit`
- `.codex/bin/check-local-enforcement --hook pre-push`