### PR TITLE
docs(loader-cache): clarify binary name usage in identity records

### DIFF
--- a/docs/loader-cache.md
+++ b/docs/loader-cache.md
@@ -100,7 +100,7 @@ the loader model and must not redefine class identity.
 Allowed values:
 
 - `(defining loader, binary name) -> class identity`;
-- `(initiating loader, name) -> class identity`;
+- `(initiating loader, binary name) -> class identity`;
 - `class identity -> binary name`;
 - `class identity -> defining loader`;
 - `class identity -> Class mirror`.


### PR DESCRIPTION
Addressing feedback from #87: https://github.com/kawasima/199xVM/pull/87#discussion_r3166540938

The 'name' term was ambiguous in 'Allowed values'. Updated to 'binary name' for clarity and consistency with the rest of the document.