### PR TITLE
feat(jvm): add loader-scoped class identity records

### DIFF
--- a/jvm-core/src/interpreter/class_identity.rs
+++ b/jvm-core/src/interpreter/class_identity.rs
@@ -1,0 +1,160 @@
+use std::collections::HashMap;
+
+/// VM-internal identity for a defining or initiating class loader.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct LoaderId(u64);
+
+impl LoaderId {
+    pub(crate) const BOOTSTRAP: Self = Self(0);
+    pub(crate) const SYSTEM: Self = Self(1);
+}
+
+/// VM-internal handle for a class identity record.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct ClassId(u64);
+
+impl ClassId {
+    fn new(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ClassRecord {
+    pub(crate) internal_name: String,
+    pub(crate) binary_name: String,
+    pub(crate) defining_loader: LoaderId,
+}
+
+#[derive(Debug)]
+pub(crate) struct ClassIdentityRegistry {
+    defined_classes: HashMap<(LoaderId, String), ClassId>,
+    class_records: HashMap<ClassId, ClassRecord>,
+    initiating_classes: HashMap<(LoaderId, String), ClassId>,
+    next_class_id: u64,
+}
+
+impl ClassIdentityRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            defined_classes: HashMap::new(),
+            class_records: HashMap::new(),
+            initiating_classes: HashMap::new(),
+            next_class_id: 0,
+        }
+    }
+
+    pub(crate) fn register_defined_class(
+        &mut self,
+        defining_loader: LoaderId,
+        internal_name: impl Into<String>,
+    ) -> ClassId {
+        let internal_name = internal_name.into();
+        let key = (defining_loader, internal_name.clone());
+        if let Some(class_id) = self.defined_classes.get(&key) {
+            return *class_id;
+        }
+
+        let class_id = ClassId::new(self.next_class_id);
+        self.next_class_id += 1;
+        let record = ClassRecord {
+            binary_name: binary_name_from_internal_name(&internal_name),
+            internal_name,
+            defining_loader,
+        };
+        self.defined_classes.insert(key, class_id);
+        self.class_records.insert(class_id, record);
+        class_id
+    }
+
+    pub(crate) fn record_initiating_loader(
+        &mut self,
+        initiating_loader: LoaderId,
+        lookup_name: impl Into<String>,
+        class_id: ClassId,
+    ) {
+        self.initiating_classes
+            .insert((initiating_loader, lookup_name.into()), class_id);
+    }
+
+    pub(crate) fn class_id_for_defined(
+        &self,
+        defining_loader: LoaderId,
+        internal_name: &str,
+    ) -> Option<ClassId> {
+        self.defined_classes
+            .get(&(defining_loader, internal_name.to_owned()))
+            .copied()
+    }
+
+    pub(crate) fn class_id_for_initiating(
+        &self,
+        initiating_loader: LoaderId,
+        lookup_name: &str,
+    ) -> Option<ClassId> {
+        self.initiating_classes
+            .get(&(initiating_loader, lookup_name.to_owned()))
+            .copied()
+    }
+
+    pub(crate) fn class_record(&self, class_id: ClassId) -> Option<&ClassRecord> {
+        self.class_records.get(&class_id)
+    }
+}
+
+fn binary_name_from_internal_name(internal_name: &str) -> String {
+    internal_name.replace('/', ".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClassIdentityRegistry, LoaderId};
+
+    #[test]
+    fn same_name_and_defining_loader_reuses_class_id() {
+        let mut registry = ClassIdentityRegistry::new();
+
+        let first = registry.register_defined_class(LoaderId::BOOTSTRAP, "pkg/Thing");
+        let second = registry.register_defined_class(LoaderId::BOOTSTRAP, "pkg/Thing");
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn same_name_under_distinct_defining_loaders_gets_distinct_class_ids() {
+        let mut registry = ClassIdentityRegistry::new();
+
+        let bootstrap = registry.register_defined_class(LoaderId::BOOTSTRAP, "pkg/Thing");
+        let system = registry.register_defined_class(LoaderId::SYSTEM, "pkg/Thing");
+
+        assert_ne!(bootstrap, system);
+        assert_ne!(LoaderId::BOOTSTRAP, LoaderId::SYSTEM);
+        assert_eq!(
+            registry.class_id_for_defined(LoaderId::BOOTSTRAP, "pkg/Thing"),
+            Some(bootstrap),
+        );
+        assert_eq!(
+            registry.class_id_for_defined(LoaderId::SYSTEM, "pkg/Thing"),
+            Some(system),
+        );
+    }
+
+    #[test]
+    fn initiating_loader_record_does_not_change_defining_loader_identity() {
+        let mut registry = ClassIdentityRegistry::new();
+
+        let class_id = registry.register_defined_class(LoaderId::BOOTSTRAP, "pkg/Thing");
+        registry.record_initiating_loader(LoaderId::SYSTEM, "pkg/Thing", class_id);
+
+        assert_eq!(
+            registry.class_id_for_initiating(LoaderId::SYSTEM, "pkg/Thing"),
+            Some(class_id),
+        );
+        assert_eq!(
+            registry
+                .class_record(class_id)
+                .map(|record| record.defining_loader),
+            Some(LoaderId::BOOTSTRAP),
+        );
+    }
+}

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -18,6 +18,7 @@ use crate::class_file::{
     self, Attribute, BootstrapMethod, ClassFile, ConstantPoolEntry, ExceptionTableEntry,
 };
 use crate::heap::{JavaStringValue, JObject, JRef, JValue};
+use class_identity::{ClassId, ClassIdentityRegistry, LoaderId};
 
 type OwnedJarArchive = zip::ZipArchive<std::io::Cursor<Vec<u8>>>;
 
@@ -256,6 +257,7 @@ pub(in crate::interpreter) enum LazyClass {
 
 mod annotations;
 mod bytecode;
+pub(crate) mod class_identity;
 pub(crate) mod cp_cache;
 mod descriptors;
 mod dispatch;
@@ -513,10 +515,14 @@ impl Scheduler {
 
 /// The central virtual machine that holds loaded classes and drives execution.
 pub struct Vm {
-    /// Class registry: keyed by internal name (`net/unit8/raoh/Result`).
+    /// Legacy class registry: keyed by internal name (`net/unit8/raoh/Result`).
+    /// Loader-scoped identity truth lives in `class_identities`; this map remains
+    /// as the Phase 1 bytecode storage path until execution is migrated.
     /// Entries start as `LazyClass::PendingBytes`/`PendingJarEntry` and are promoted to
     /// `LazyClass::Ready` (parsed `ClassFile`) on first access.
     pub(in crate::interpreter) classes: HashMap<String, LazyClass>,
+    /// Loader-owned class identity records for defining and initiating loaders.
+    class_identities: ClassIdentityRegistry,
     /// Interned strings cache keyed by UTF-16 content.
     pub(in crate::interpreter) string_pool: HashMap<JavaStringValue, JRef>,
     /// Static field storage keyed by class name → field name.
@@ -554,8 +560,8 @@ pub struct Vm {
     pub(in crate::interpreter) scheduler: Scheduler,
     /// Object monitors keyed by object identity (Rc pointer address).
     monitors: HashMap<usize, Monitor>,
-    /// Method resolution cache: (class, method_name, descriptor) → owner class name.
-    /// Avoids repeated super-chain walks for the same method lookup.
+    /// Legacy method resolution cache: (class, method_name, descriptor) → owner class name.
+    /// Loader-unsafe until the cpCache/member-resolution migration carries ClassId.
     method_owner_cache: HashMap<(String, String, String), Option<String>>,
     /// Bounded LRU cache for compiled host-side regular expressions.
     regex_cache: RegexCache,
@@ -572,6 +578,7 @@ impl Vm {
     pub fn new() -> Self {
         Vm {
             classes: HashMap::new(),
+            class_identities: ClassIdentityRegistry::new(),
             string_pool: HashMap::new(),
             static_fields: HashMap::new(),
             clinit_done: HashSet::new(),
@@ -976,9 +983,36 @@ impl Vm {
         }
     }
 
+    pub(crate) fn register_defined_class(
+        &mut self,
+        defining_loader: LoaderId,
+        internal_name: impl Into<String>,
+    ) -> ClassId {
+        self.class_identities.register_defined_class(defining_loader, internal_name)
+    }
+
+    pub(crate) fn record_initiating_loader(
+        &mut self,
+        initiating_loader: LoaderId,
+        lookup_name: impl Into<String>,
+        class_id: ClassId,
+    ) {
+        self.class_identities.record_initiating_loader(initiating_loader, lookup_name, class_id);
+    }
+
     /// Register a pre-parsed class file (always stored as `Ready`).
     pub fn load_class(&mut self, class_file: ClassFile) {
+        self.load_class_with_loader(LoaderId::SYSTEM, class_file);
+    }
+
+    pub(crate) fn load_class_with_loader(
+        &mut self,
+        defining_loader: LoaderId,
+        class_file: ClassFile,
+    ) {
         let name = class_file.constant_pool.class_name(class_file.this_class).to_owned();
+        let class_id = self.register_defined_class(defining_loader, name.clone());
+        self.record_initiating_loader(defining_loader, name.clone(), class_id);
         self.classes.insert(name, LazyClass::Ready(class_file));
     }
 
@@ -986,10 +1020,24 @@ impl Vm {
     /// The class is parsed only when first accessed via [`Self::ensure_class_ready`].
     /// If the class is already registered (e.g., as `Ready`), the existing entry is kept.
     pub fn load_lazy(&mut self, name: String, bytes: Vec<u8>) {
+        self.load_lazy_with_loader(LoaderId::SYSTEM, name, bytes);
+    }
+
+    pub(crate) fn load_lazy_with_loader(
+        &mut self,
+        defining_loader: LoaderId,
+        name: String,
+        bytes: Vec<u8>,
+    ) -> ClassId {
+        let class_id = self.register_defined_class(defining_loader, name.clone());
+        self.record_initiating_loader(defining_loader, name.clone(), class_id);
         self.classes.entry(name).or_insert(LazyClass::PendingBytes(bytes));
+        class_id
     }
 
     fn load_lazy_jar_entry(&mut self, name: String, entry: JarEntryRef) {
+        let class_id = self.register_defined_class(LoaderId::SYSTEM, name.clone());
+        self.record_initiating_loader(LoaderId::SYSTEM, name.clone(), class_id);
         self.classes.entry(name).or_insert(LazyClass::PendingJarEntry(entry));
     }
 


### PR DESCRIPTION
## Summary
- Add VM-internal loader-scoped `ClassId` / `LoaderId` identity records.
- Record defining and initiating loader ownership when classes are loaded through existing VM load paths.
- Keep the executable surface intentionally small for the first loader identity foundation slice.

## Validation
- `docker-compose run --rm rust cargo test --package jvm-core interpreter::class_identity --lib`

## PR Structure
- Independent PR targeting `develop`.
- Merge order: this PR first; later loader mirror/resolution/runtime-state slices should build on it after merge.
