### PR TITLE
ci: add cached smoke workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show Docker Compose version
+        run: docker compose version
+
+      - name: Build tool containers
+        run: docker compose build java node rust
+
+      - name: Build WebAssembly package
+        run: docker compose run --rm rust make wasm
+
+      - name: Build JDK shim
+        run: docker compose run --rm java make shim
+
+      - name: Build web compiler
+        run: docker compose run --rm node make javac
+
+      - name: Build test bundle
+        run: docker compose run --rm java make test-bundle
+
+      - name: Run compiler tests
+        run: docker compose run --rm node make test
+
+      - name: Run launcher tests
+        run: docker compose run --rm node make launcher-test
+
+      - name: Run Rust tests
+        run: docker compose run --rm rust cargo test --package jvm-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Validate Docker Compose config
         run: docker compose config --quiet
 
+      - name: Cache Rust build outputs
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-rust-target-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'jvm-core/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-target-
+
       - name: Build tool containers
         run: docker compose build java node rust
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,10 @@ jobs:
 
       - name: Run Rust unit tests
         run: docker compose run --rm rust cargo test --package jvm-core --lib
+
+      - name: Make Rust cache readable
+        if: always()
+        run: |
+          if [ -d target ]; then
+            sudo chown -R "$(id -u):$(id -g)" target
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ permissions:
   contents: read
 
 jobs:
-  build-and-test:
-    name: Build and test
+  smoke:
+    name: Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -24,6 +24,9 @@ jobs:
 
       - name: Show Docker Compose version
         run: docker compose version
+
+      - name: Validate Docker Compose config
+        run: docker compose config --quiet
 
       - name: Build tool containers
         run: docker compose build java node rust
@@ -37,14 +40,5 @@ jobs:
       - name: Build web compiler
         run: docker compose run --rm node make javac
 
-      - name: Build test bundle
-        run: docker compose run --rm java make test-bundle
-
-      - name: Run compiler tests
-        run: docker compose run --rm node make test
-
-      - name: Run launcher tests
-        run: docker compose run --rm node make launcher-test
-
-      - name: Run Rust tests
-        run: docker compose run --rm rust cargo test --package jvm-core
+      - name: Run Rust unit tests
+        run: docker compose run --rm rust cargo test --package jvm-core --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Show Docker Compose version
         run: docker compose version
@@ -29,7 +29,7 @@ jobs:
         run: docker compose config --quiet
 
       - name: Cache Rust build outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target
           key: ${{ runner.os }}-rust-target-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'jvm-core/Cargo.toml') }}


### PR DESCRIPTION
## Summary

- Add a GitHub Actions smoke workflow for pull requests and pushes to `develop`
- Build the Docker tool containers, WebAssembly package, JDK shim, web compiler, and Rust unit tests
- Cache Rust `target/` build outputs with `actions/cache@v5`
- Normalize Docker-owned `target/` permissions before cache save

## Validation

- Fork validation PR: https://github.com/hden/199xVM/pull/6
- Final fork run: https://github.com/hden/199xVM/actions/runs/27004554204
- Smoke passed in 2m40s
- Logs confirmed `Cache hit for: Linux-rust-target-...` and `Cache restored successfully`
- Local checks: `git diff --check`, `docker compose config --quiet`

## Notes

This is an independent CI-only PR targeting `develop`.
