### PR TITLE
fix(jvm): resolve members with loader-aware class identity

### DIFF
--- a/build-test-bundle.sh
+++ b/build-test-bundle.sh
@@ -23,7 +23,7 @@ COMPACT_SOURCES=()
 for f in "$SRC_DIR"/*.java; do
   # Strip package, import, blank, and single-line comment lines, then check for class keyword
   if sed -E '/^\s*$/d; /^\s*\/\//d; /^\s*package\s/d; /^\s*import\s/d; /^\s*\/?\*/d' "$f" \
-     | grep -qE '^\s*(public\s+|abstract\s+|final\s+)*(class|interface|enum|record|@interface)\s'; then
+     | grep -E '^\s*(public\s+|abstract\s+|final\s+)*(class|interface|enum|record|@interface)\s' >/dev/null; then
     NORMAL_SOURCES+=("$f")
   else
     COMPACT_SOURCES+=("$f")

--- a/jvm-core/src/interpreter/bytecode.rs
+++ b/jvm-core/src/interpreter/bytecode.rs
@@ -3,7 +3,7 @@ use crate::class_file::{BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry}
 use crate::heap::{JObject, JValue, NativePayload};
 
 use super::class_identity::ClassId;
-use super::{ResolvedFieldTarget, Vm};
+use super::{ResolvedFieldTarget, Vm, ACC_STATIC};
 use super::cp_cache::{CpCache, CpCacheEntry, ResolvedFieldEntry};
 use super::descriptors::*;
 use super::frame::*;
@@ -680,106 +680,72 @@ impl Vm {
                 // ---- Field access ----
                 0xb2 => { // getstatic
                     let idx = read_u16(code, &mut frame.pc);
-                    // Fast path: check cpCache for resolved field.
-                    let cached_val = {
-                        let cb = cache.borrow();
-                        if let Some(Some(CpCacheEntry::Field(e))) = cb.get(idx as usize) {
-                            let owner = self.class_record(e.owner_class_id)
-                                .map(|record| record.internal_name.as_str())
-                                .unwrap_or(e.owner_class.as_str());
-                            let v = self.static_fields.get(owner)
-                                .and_then(|m| m.get(&e.field_name))
-                                .cloned()
-                                .unwrap_or_else(|| default_value_for_descriptor(&e.field_descriptor));
-                            Some(v)
-                        } else {
-                            None
-                        }
-                    };
-                    if let Some(v) = cached_val {
-                        frame.stack.push(v);
-                    } else {
-                        let caller_class_id = caller_class_id
-                            .ok_or_else(|| "java/lang/NoClassDefFoundError: missing caller for getstatic".to_owned())?;
-                        let target = self.resolve_field_reference(caller_class_id, cp, idx)?;
-                        if target.access_flags & 0x0008 == 0 {
-                            let detail = format!("getstatic {}.{}:{}", target.owner_class, target.name, target.descriptor);
-                            self.throw_incompatible_class_change_error(&detail);
-                            return Err(format!("java/lang/IncompatibleClassChangeError: {detail}"));
-                        }
-                        self.ensure_class_init(&target.owner_class)?;
-                        let v = self.read_static_field_target(&target);
-                        frame.stack.push(v);
-                        cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
-                            ResolvedFieldEntry {
-                                owner_class_id: target.owner_class_id,
-                                owner_class: target.owner_class,
-                                field_name: target.name,
-                                field_descriptor: target.descriptor,
-                            }
-                        ));
-                    }
+                    let target = self.resolve_cached_field_target(
+                        caller_class_id,
+                        cp,
+                        cache,
+                        idx,
+                        "getstatic",
+                    )?;
+                    self.require_field_staticness(&target, true, "getstatic")?;
+                    self.ensure_class_init(&target.owner_class)?;
+                    let v = self.read_static_field_target(&target);
+                    frame.stack.push(v);
                 }
                 0xb3 => { // putstatic
                     let idx = read_u16(code, &mut frame.pc);
                     let val = frame.stack.pop().unwrap_or(JValue::Void);
-                    // Fast path: check cpCache.
-                    let cached = {
-                        let cb = cache.borrow();
-                        match cb.get(idx as usize) {
-                            Some(Some(CpCacheEntry::Field(e))) => Some((
-                                e.owner_class.clone(), e.field_name.clone(),
-                            )),
-                            _ => None,
-                        }
-                    };
-                    if let Some((owner, field)) = cached {
-                        self.static_fields.entry(owner).or_default().insert(field, val);
-                    } else {
-                        let caller_class_id = caller_class_id
-                            .ok_or_else(|| "java/lang/NoClassDefFoundError: missing caller for putstatic".to_owned())?;
-                        let target = self.resolve_field_reference(caller_class_id, cp, idx)?;
-                        if target.access_flags & 0x0008 == 0 {
-                            let detail = format!("putstatic {}.{}:{}", target.owner_class, target.name, target.descriptor);
-                            self.throw_incompatible_class_change_error(&detail);
-                            return Err(format!("java/lang/IncompatibleClassChangeError: {detail}"));
-                        }
-                        self.ensure_class_init(&target.owner_class)?;
-                        self.write_static_field_target(&target, val);
-                        cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
-                            ResolvedFieldEntry {
-                                owner_class_id: target.owner_class_id,
-                                owner_class: target.owner_class,
-                                field_name: target.name,
-                                field_descriptor: target.descriptor,
-                            }
-                        ));
-                    }
+                    let target = self.resolve_cached_field_target(
+                        caller_class_id,
+                        cp,
+                        cache,
+                        idx,
+                        "putstatic",
+                    )?;
+                    self.require_field_staticness(&target, true, "putstatic")?;
+                    self.ensure_class_init(&target.owner_class)?;
+                    self.write_static_field_target(&target, val);
                 }
                 0xb4 => { // getfield
                     let idx = read_u16(code, &mut frame.pc);
-                    let (_, gf_field_name, _) = resolve_fieldref_ref(cp, idx);
+                    let target = self.resolve_cached_field_target(
+                        caller_class_id,
+                        cp,
+                        cache,
+                        idx,
+                        "getfield",
+                    )?;
+                    self.require_field_staticness(&target, false, "getfield")?;
                     let obj_ref = frame.stack.pop()
-                        .ok_or_else(|| format!("getfield {gf_field_name}: empty stack in {class_name}"))?;
+                        .ok_or_else(|| format!("getfield {}: empty stack in {class_name}", target.name))?;
                     if matches!(obj_ref, JValue::Void) {
                         return Err(format!(
-                            "getfield {gf_field_name}: expected Ref on stack, got Void in {class_name}"
+                            "getfield {}: expected Ref on stack, got Void in {class_name}",
+                            target.name
                         ));
                     }
-                    let v = self.resolve_instance_field(cp, idx, &obj_ref)?;
+                    let v = self.read_instance_field_target(&target, &obj_ref)?;
                     frame.stack.push(v);
                 }
                 0xb5 => { // putfield
                     let idx = read_u16(code, &mut frame.pc);
+                    let target = self.resolve_cached_field_target(
+                        caller_class_id,
+                        cp,
+                        cache,
+                        idx,
+                        "putfield",
+                    )?;
+                    self.require_field_staticness(&target, false, "putfield")?;
                     let val = frame.stack.pop().unwrap_or(JValue::Void);
                     let obj_ref = frame.stack.pop().unwrap_or(JValue::Void);
                     if matches!(obj_ref, JValue::Void) {
-                        let (_, pf_field_name, _) = resolve_fieldref_ref(cp, idx);
                         return Err(format!(
-                            "putfield {pf_field_name}: expected Ref on stack, got Void in {class_name}"
+                            "putfield {}: expected Ref on stack, got Void in {class_name}",
+                            target.name
                         ));
                     }
-                    self.set_instance_field(cp, idx, &obj_ref, val)?;
+                    self.write_instance_field_target(&target, &obj_ref, val)?;
                 }
 
                 // ---- Method invocation ----
@@ -1140,33 +1106,80 @@ impl Vm {
             .insert(target.name.clone(), value);
     }
 
-    fn resolve_instance_field(
+    fn resolve_cached_field_target(
         &mut self,
+        caller_class_id: Option<ClassId>,
         cp: &[ConstantPoolEntry],
+        cache: &CpCache,
         idx: u16,
+        opcode: &str,
+    ) -> Result<ResolvedFieldTarget, String> {
+        if let Some(Some(CpCacheEntry::Field(entry))) = cache.borrow().get(idx as usize) {
+            return Ok(ResolvedFieldTarget {
+                owner_class_id: entry.owner_class_id,
+                owner_class: entry.owner_class.clone(),
+                name: entry.field_name.clone(),
+                descriptor: entry.field_descriptor.clone(),
+                access_flags: entry.access_flags,
+            });
+        }
+
+        let caller_class_id = caller_class_id
+            .ok_or_else(|| format!("java/lang/NoClassDefFoundError: missing caller for {opcode}"))?;
+        let target = self.resolve_field_reference(caller_class_id, cp, idx)?;
+        cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(ResolvedFieldEntry {
+            owner_class_id: target.owner_class_id,
+            owner_class: target.owner_class.clone(),
+            field_name: target.name.clone(),
+            field_descriptor: target.descriptor.clone(),
+            access_flags: target.access_flags,
+        }));
+        Ok(target)
+    }
+
+    fn require_field_staticness(
+        &mut self,
+        target: &ResolvedFieldTarget,
+        expected_static: bool,
+        opcode: &str,
+    ) -> Result<(), String> {
+        if (target.access_flags & ACC_STATIC != 0) == expected_static {
+            return Ok(());
+        }
+        let detail = format!(
+            "{opcode} {}.{}:{}",
+            target.owner_class, target.name, target.descriptor
+        );
+        self.throw_incompatible_class_change_error(&detail);
+        Err(format!("java/lang/IncompatibleClassChangeError: {detail}"))
+    }
+
+    fn read_instance_field_target(
+        &mut self,
+        target: &ResolvedFieldTarget,
         obj_ref: &JValue,
     ) -> Result<JValue, String> {
-        let (_, field_name, field_desc) = resolve_fieldref_ref(cp, idx);
         match obj_ref.as_ref() {
             Some(r) => {
-                let default = default_value_for_descriptor(field_desc);
-                Ok(r.borrow().fields.get(field_name).cloned().unwrap_or(default))
+                let default = default_value_for_descriptor(&target.descriptor);
+                Ok(r.borrow().fields.get(&target.name).cloned().unwrap_or(default))
             }
-            None => Err(format!("NullPointerException: getfield {field_name}")),
+            None => Err(format!("NullPointerException: getfield {}", target.name)),
         }
     }
 
-    fn set_instance_field(
+    fn write_instance_field_target(
         &mut self,
-        cp: &[ConstantPoolEntry],
-        idx: u16,
+        target: &ResolvedFieldTarget,
         obj_ref: &JValue,
         val: JValue,
     ) -> Result<(), String> {
-        let (_, field_name, _) = resolve_fieldref_ref(cp, idx);
         match obj_ref.as_ref() {
-            Some(r) => { r.borrow_mut().fields.insert(field_name.to_owned(), val); Ok(()) }
-            None => Err(format!("NullPointerException: putfield {field_name}")),
+            Some(r) => {
+                r.borrow_mut().fields.insert(target.name.clone(), val);
+                Ok(())
+            }
+            None => Err(format!("NullPointerException: putfield {}", target.name)),
         }
     }
 

--- a/jvm-core/src/interpreter/bytecode.rs
+++ b/jvm-core/src/interpreter/bytecode.rs
@@ -3,7 +3,7 @@ use crate::class_file::{BootstrapMethod, ConstantPoolEntry, ExceptionTableEntry}
 use crate::heap::{JObject, JValue, NativePayload};
 
 use super::class_identity::ClassId;
-use super::Vm;
+use super::{ResolvedFieldTarget, Vm};
 use super::cp_cache::{CpCache, CpCacheEntry, ResolvedFieldEntry};
 use super::descriptors::*;
 use super::frame::*;
@@ -684,7 +684,10 @@ impl Vm {
                     let cached_val = {
                         let cb = cache.borrow();
                         if let Some(Some(CpCacheEntry::Field(e))) = cb.get(idx as usize) {
-                            let v = self.static_fields.get(&e.owner_class)
+                            let owner = self.class_record(e.owner_class_id)
+                                .map(|record| record.internal_name.as_str())
+                                .unwrap_or(e.owner_class.as_str());
+                            let v = self.static_fields.get(owner)
                                 .and_then(|m| m.get(&e.field_name))
                                 .cloned()
                                 .unwrap_or_else(|| default_value_for_descriptor(&e.field_descriptor));
@@ -696,18 +699,23 @@ impl Vm {
                     if let Some(v) = cached_val {
                         frame.stack.push(v);
                     } else {
-                        // Slow path: resolve, push, then populate cache.
-                        let v = self.resolve_static_field(cp, idx)?;
-                        frame.stack.push(v.clone());
-                        // Populate cache with the resolved field owner.
-                        let (cn, fn_, fd) = resolve_fieldref_ref(cp, idx);
-                        let owner = self.find_static_field_owner_class(cn, fn_)
-                            .unwrap_or_else(|| cn.to_owned());
+                        let caller_class_id = caller_class_id
+                            .ok_or_else(|| "java/lang/NoClassDefFoundError: missing caller for getstatic".to_owned())?;
+                        let target = self.resolve_field_reference(caller_class_id, cp, idx)?;
+                        if target.access_flags & 0x0008 == 0 {
+                            let detail = format!("getstatic {}.{}:{}", target.owner_class, target.name, target.descriptor);
+                            self.throw_incompatible_class_change_error(&detail);
+                            return Err(format!("java/lang/IncompatibleClassChangeError: {detail}"));
+                        }
+                        self.ensure_class_init(&target.owner_class)?;
+                        let v = self.read_static_field_target(&target);
+                        frame.stack.push(v);
                         cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
                             ResolvedFieldEntry {
-                                owner_class: owner,
-                                field_name: fn_.to_owned(),
-                                field_descriptor: fd.to_owned(),
+                                owner_class_id: target.owner_class_id,
+                                owner_class: target.owner_class,
+                                field_name: target.name,
+                                field_descriptor: target.descriptor,
                             }
                         ));
                     }
@@ -728,16 +736,22 @@ impl Vm {
                     if let Some((owner, field)) = cached {
                         self.static_fields.entry(owner).or_default().insert(field, val);
                     } else {
-                        // Slow path.
-                        let (cls, fld, fd) = resolve_fieldref_ref(cp, idx);
-                        self.ensure_class_init(cls)?;
-                        self.static_fields.entry(cls.to_owned()).or_default().insert(fld.to_owned(), val);
-                        // Populate cache.
+                        let caller_class_id = caller_class_id
+                            .ok_or_else(|| "java/lang/NoClassDefFoundError: missing caller for putstatic".to_owned())?;
+                        let target = self.resolve_field_reference(caller_class_id, cp, idx)?;
+                        if target.access_flags & 0x0008 == 0 {
+                            let detail = format!("putstatic {}.{}:{}", target.owner_class, target.name, target.descriptor);
+                            self.throw_incompatible_class_change_error(&detail);
+                            return Err(format!("java/lang/IncompatibleClassChangeError: {detail}"));
+                        }
+                        self.ensure_class_init(&target.owner_class)?;
+                        self.write_static_field_target(&target, val);
                         cache.borrow_mut()[idx as usize] = Some(CpCacheEntry::Field(
                             ResolvedFieldEntry {
-                                owner_class: cls.to_owned(),
-                                field_name: fld.to_owned(),
-                                field_descriptor: fd.to_owned(),
+                                owner_class_id: target.owner_class_id,
+                                owner_class: target.owner_class,
+                                field_name: target.name,
+                                field_descriptor: target.descriptor,
                             }
                         ));
                     }
@@ -780,7 +794,7 @@ impl Vm {
                 }
                 0xb7 => { // invokespecial
                     let idx = read_u16(code, &mut frame.pc);
-                    self.dispatch_special(cp, idx, frame).map_err(|e| {
+                    self.dispatch_special(cp, idx, caller_class_id, frame).map_err(|e| {
                         if e.starts_with("NullPointerException") { format!("{e} in {class_name}") } else { e }
                     })?;
                 }
@@ -791,7 +805,7 @@ impl Vm {
                 0xb9 => { // invokeinterface
                     let idx = read_u16(code, &mut frame.pc);
                     frame.pc += 2; // count + 0
-                    self.dispatch_interface(cp, idx, frame).map_err(|e| {
+                    self.dispatch_interface(cp, idx, caller_class_id, frame).map_err(|e| {
                         if e.starts_with("NullPointerException") { format!("{e} in {class_name}") } else { e }
                     })?;
                 }
@@ -1080,118 +1094,50 @@ impl Vm {
         Ok(())
     }
 
-    fn resolve_static_field(
-        &mut self,
-        cp: &[ConstantPoolEntry],
-        idx: u16,
-    ) -> Result<JValue, String> {
-        let (class_name, field_name, descriptor) = resolve_fieldref_ref(cp, idx);
-        // Run <clinit> if not yet done (initialises static fields via putstatic).
-        self.ensure_class_init(class_name)?;
-        // Search this class and its super-class chain for the static field (JVMS §5.4.3.2).
-        if let Some(v) = self.resolve_static_field_in_hierarchy(class_name, field_name) {
-            return Ok(v);
-        }
-        // Well-known JDK static fields that cannot be initialised via <clinit>
-        // because the JDK classes are not in the bundle.
-        match (class_name, field_name) {
-            ("java/lang/System", "out") => {
-                if let Some(v) = self.static_fields.get("java/lang/System").and_then(|m| m.get("out")) {
-                    return Ok(v.clone());
+    fn read_static_field_target(&mut self, target: &ResolvedFieldTarget) -> JValue {
+        // Transitional Phase 4 bridge: static storage is still name-keyed until
+        // Phase 5, but bytecode resolution now chooses the declaring ClassId.
+        if let Some(v) = self.static_fields
+            .get(&target.owner_class)
+            .and_then(|fields| fields.get(&target.name))
+            .cloned()
+        {
+            if target.owner_class == "java/lang/System" && target.name == "in" {
+                if let Some(r) = v.as_ref() {
+                    self.system_stdin = Some(r.clone());
                 }
+            }
+            return v;
+        }
+
+        match (target.owner_class.as_str(), target.name.as_str()) {
+            ("java/lang/System", "out") => {
                 let v = JValue::Ref(Some(JObject::new_print_stream(false)));
-                self.static_fields.entry(class_name.to_owned()).or_default().insert(field_name.to_owned(), v.clone());
-                Ok(v)
+                self.write_static_field_target(target, v.clone());
+                v
             }
             ("java/lang/System", "err") => {
-                if let Some(v) = self.static_fields.get("java/lang/System").and_then(|m| m.get("err")) {
-                    return Ok(v.clone());
-                }
                 let v = JValue::Ref(Some(JObject::new_print_stream(true)));
-                self.static_fields.entry(class_name.to_owned()).or_default().insert(field_name.to_owned(), v.clone());
-                Ok(v)
+                self.write_static_field_target(target, v.clone());
+                v
             }
             ("java/lang/System", "in") => {
-                if let Some(v) = self.static_fields.get("java/lang/System").and_then(|m| m.get("in")) {
-                    if let Some(r) = v.as_ref() {
-                        self.system_stdin = Some(r.clone());
-                    }
-                    return Ok(v.clone());
-                }
                 let stdin = JObject::new_process_pipe_input_stream();
                 let v = JValue::Ref(Some(stdin.clone()));
                 self.system_stdin = Some(stdin);
-                self.static_fields.entry(class_name.to_owned()).or_default().insert(field_name.to_owned(), v.clone());
-                Ok(v)
+                self.write_static_field_target(target, v.clone());
+                v
             }
-            _ => Ok(default_value_for_descriptor(descriptor)),
+            _ => default_value_for_descriptor(&target.descriptor),
         }
     }
 
-    /// Walk the class hierarchy to find a static field value.
-    fn resolve_static_field_in_hierarchy(&mut self, class_name: &str, field_name: &str) -> Option<JValue> {
-        // Check this class first.
-        if let Some(v) = self.static_fields.get(class_name).and_then(|m| m.get(field_name)) {
-            return Some(v.clone());
-        }
-        // Check super class and interfaces.
-        self.ensure_class_ready(class_name);
-        let (super_name, iface_names) = if let Some(class) = self.get_class(class_name) {
-            let sup = if class.super_class != 0 {
-                Some(class.constant_pool.class_name(class.super_class).to_owned())
-            } else {
-                None
-            };
-            let ifaces: Vec<String> = class.interfaces.iter()
-                .map(|&idx| class.constant_pool.class_name(idx).to_owned())
-                .collect();
-            (sup, ifaces)
-        } else {
-            (None, vec![])
-        };
-        if let Some(super_name) = super_name {
-            if let Some(v) = self.resolve_static_field_in_hierarchy(&super_name, field_name) {
-                return Some(v);
-            }
-        }
-        for iface_name in iface_names {
-            if let Some(v) = self.resolve_static_field_in_hierarchy(&iface_name, field_name) {
-                return Some(v);
-            }
-        }
-        None
-    }
-
-    /// Walk the class hierarchy to find which class owns a static field.
-    fn find_static_field_owner_class(&mut self, class_name: &str, field_name: &str) -> Option<String> {
-        if self.static_fields.get(class_name).and_then(|m| m.get(field_name)).is_some() {
-            return Some(class_name.to_owned());
-        }
-        self.ensure_class_ready(class_name);
-        let (super_name, iface_names) = if let Some(class) = self.get_class(class_name) {
-            let sup = if class.super_class != 0 {
-                Some(class.constant_pool.class_name(class.super_class).to_owned())
-            } else {
-                None
-            };
-            let ifaces: Vec<String> = class.interfaces.iter()
-                .map(|&idx| class.constant_pool.class_name(idx).to_owned())
-                .collect();
-            (sup, ifaces)
-        } else {
-            (None, vec![])
-        };
-        if let Some(s) = super_name {
-            if let Some(owner) = self.find_static_field_owner_class(&s, field_name) {
-                return Some(owner);
-            }
-        }
-        for iface in iface_names {
-            if let Some(owner) = self.find_static_field_owner_class(&iface, field_name) {
-                return Some(owner);
-            }
-        }
-        None
+    fn write_static_field_target(&mut self, target: &ResolvedFieldTarget, value: JValue) {
+        // Transitional Phase 4 bridge: replace with ClassId-keyed static state in Phase 5.
+        self.static_fields
+            .entry(target.owner_class.clone())
+            .or_default()
+            .insert(target.name.clone(), value);
     }
 
     fn resolve_instance_field(

--- a/jvm-core/src/interpreter/cp_cache.rs
+++ b/jvm-core/src/interpreter/cp_cache.rs
@@ -44,17 +44,19 @@ pub(crate) struct ResolvedMethodEntry {
     pub method_name: String,
 }
 
-/// A resolved field entry for getstatic/putstatic fast path.
+/// A resolved field entry for field access bytecodes.
 pub(crate) struct ResolvedFieldEntry {
     /// Loader-scoped class identity that owns the resolved field.
     pub owner_class_id: ClassId,
-    /// Legacy class name that owns the field (after hierarchy walk).
-    /// Used only while static field storage remains name-keyed.
+    /// Legacy class name that owns the field after hierarchy traversal.
+    /// Static field storage remains name-keyed until Phase 5.
     pub owner_class: String,
     /// Field name.
     pub field_name: String,
     /// Field descriptor (for default value computation).
     pub field_descriptor: String,
+    /// Field access flags used to validate static/instance opcode compatibility.
+    pub access_flags: u16,
 }
 
 /// A cpCache entry: resolved method or field.

--- a/jvm-core/src/interpreter/cp_cache.rs
+++ b/jvm-core/src/interpreter/cp_cache.rs
@@ -46,7 +46,10 @@ pub(crate) struct ResolvedMethodEntry {
 
 /// A resolved field entry for getstatic/putstatic fast path.
 pub(crate) struct ResolvedFieldEntry {
-    /// The class that owns the field (after hierarchy walk).
+    /// Loader-scoped class identity that owns the resolved field.
+    pub owner_class_id: ClassId,
+    /// Legacy class name that owns the field (after hierarchy walk).
+    /// Used only while static field storage remains name-keyed.
     pub owner_class: String,
     /// Field name.
     pub field_name: String,

--- a/jvm-core/src/interpreter/dispatch.rs
+++ b/jvm-core/src/interpreter/dispatch.rs
@@ -64,25 +64,46 @@ impl Vm {
 
         // ---- SLOW PATH: first invocation — resolve and populate cache ----
         let (class_name, method_name, descriptor) = resolve_methodref_ref(cp, idx);
-        let resolved_class_id = caller_class_id
-            .and_then(|caller| self.resolve_methodref_owner_class(caller, cp, idx).ok());
-        let resolved_class_name = resolved_class_id
-            .and_then(|class_id| self.class_record(class_id).map(|record| record.internal_name.clone()))
+        let resolved_target = match caller_class_id {
+            Some(caller) => Some(self.resolve_method_reference(caller, cp, idx)?),
+            None => None,
+        };
+        let resolved_class_id = resolved_target.as_ref().map(|target| target.owner_class_id);
+        let resolved_class_name = resolved_target
+            .as_ref()
+            .map(|target| target.owner_class.clone())
             .unwrap_or_else(|| class_name.to_owned());
+        let resolved_method_name = resolved_target
+            .as_ref()
+            .map(|target| target.name.as_str())
+            .unwrap_or(method_name);
+        let resolved_descriptor = resolved_target
+            .as_ref()
+            .map(|target| target.descriptor.as_str())
+            .unwrap_or(descriptor);
+        if resolved_target
+            .as_ref()
+            .map(|target| target.access_flags & 0x0008 == 0)
+            .unwrap_or(false)
+        {
+            let detail = format!("{resolved_class_name}.{resolved_method_name}{resolved_descriptor}");
+            self.throw_incompatible_class_change_error(&detail);
+            return Err(format!("java/lang/IncompatibleClassChangeError: {detail}"));
+        }
         self.ensure_class_init(&resolved_class_name)?;
-        let n_args = count_args(descriptor);
+        let n_args = count_args(resolved_descriptor);
         let args = pop_args(frame, n_args);
 
         // Normalize descriptor and args (varargs synthesis) before branching.
         let orig_args = args.clone();
         let (desc, args) = if resolved_class_id.is_some() {
-            (descriptor.to_owned(), args)
+            (resolved_descriptor.to_owned(), args)
         } else {
-            match self.prepare_static_args(&resolved_class_name, method_name, descriptor, args) {
+            match self.prepare_static_args(&resolved_class_name, resolved_method_name, resolved_descriptor, args) {
                 Some(pair) => pair,
                 None => {
                     // Method flags not found — fall back to invoke_static with original args.
-                    let result = self.invoke_static(&resolved_class_name, method_name, descriptor, orig_args)?;
+                    let result = self.invoke_static(&resolved_class_name, resolved_method_name, resolved_descriptor, orig_args)?;
                     if !matches!(result, JValue::Void) { frame.stack.push(result); }
                     return Ok(None);
                 }
@@ -92,40 +113,26 @@ impl Vm {
         let push_return = !desc.ends_with(")V");
         // Resolve method exec info once (used for both frame building and cache population).
         let exec_info = resolved_class_id
-            .and_then(|class_id| self.resolve_method_exec_info_for_class_id(class_id, method_name, &desc))
-            .or_else(|| self.resolve_method_exec_info(&resolved_class_name, method_name, &desc));
+            .and_then(|class_id| self.resolve_method_exec_info_for_class_id(class_id, resolved_method_name, &desc))
+            .or_else(|| self.resolve_method_exec_info(&resolved_class_name, resolved_method_name, &desc));
         match exec_info {
             Some(info) if info.has_code => {
                 // Bytecode method — build frame and populate cache.
-                let fi = self.build_static_frame_from_exec_info(&info, method_name, &desc, args, push_return);
-                self.populate_static_method_cache(cache, idx, method_name, &desc, &info);
+                let fi = self.build_static_frame_from_exec_info(&info, resolved_method_name, &desc, args, push_return);
+                self.populate_static_method_cache(cache, idx, resolved_method_name, &desc, &info);
                 *self.pending_frame_mut() = Some(fi);
                 Ok(None)
             }
             _ => {
                 // Native or unresolved — cache and fall back to invoke_static.
-                self.populate_static_native_cache(cache, idx, &resolved_class_name, method_name, &desc);
-                let result = self.invoke_static(&resolved_class_name, method_name, &desc, args)?;
+                self.populate_static_native_cache(cache, idx, resolved_class_id, &resolved_class_name, resolved_method_name, &desc);
+                let result = self.invoke_static(&resolved_class_name, resolved_method_name, &desc, args)?;
                 if !matches!(result, JValue::Void) {
                     frame.stack.push(result);
                 }
                 Ok(None)
             }
         }
-    }
-
-    fn resolve_methodref_owner_class(
-        &mut self,
-        caller_class_id: ClassId,
-        cp: &[ConstantPoolEntry],
-        idx: u16,
-    ) -> Result<ClassId, String> {
-        let class_index = match cp.get(idx as usize) {
-            Some(ConstantPoolEntry::Methodref { class_index, .. })
-            | Some(ConstantPoolEntry::InterfaceMethodref { class_index, .. }) => *class_index,
-            _ => return Err(format!("java/lang/NoClassDefFoundError: invalid method reference #{idx}")),
-        };
-        self.resolve_symbolic_class(caller_class_id, cp, class_index)
     }
 
     /// Build a FrameInfo from a pre-resolved MethodExecInfo (avoids double resolution).
@@ -244,13 +251,14 @@ impl Vm {
         &self,
         cache: &CpCache,
         idx: u16,
+        class_id: Option<ClassId>,
         class_name: &str,
         method_name: &str,
         descriptor: &str,
     ) {
         let (param_tokens, _) = Self::parse_method_descriptor_tokens(descriptor);
         let entry = ResolvedMethodEntry {
-            owner_class_id: None,
+            owner_class_id: class_id,
             owner_class: class_name.to_owned(),
             code: Rc::new(Vec::new()),
             exception_table: Rc::new(Vec::new()),
@@ -370,33 +378,63 @@ impl Vm {
         &mut self,
         cp: &[ConstantPoolEntry],
         idx: u16,
+        caller_class_id: Option<ClassId>,
         frame: &mut Frame,
     ) -> Result<Option<JValue>, String> {
         let (class_name, method_name, descriptor) = resolve_methodref_ref(cp, idx);
-        let n_args = count_args(descriptor);
+        let resolved_target = match caller_class_id {
+            Some(caller) => Some(self.resolve_method_reference(caller, cp, idx)?),
+            None => None,
+        };
+        let resolved_class_name = resolved_target
+            .as_ref()
+            .map(|target| target.owner_class.as_str())
+            .unwrap_or(class_name);
+        let resolved_method_name = resolved_target
+            .as_ref()
+            .map(|target| target.name.as_str())
+            .unwrap_or(method_name);
+        let resolved_descriptor = resolved_target
+            .as_ref()
+            .map(|target| target.descriptor.as_str())
+            .unwrap_or(descriptor);
+        let n_args = count_args(resolved_descriptor);
         let args = pop_args(frame, n_args);
         let this_val = frame.stack.pop().unwrap();
         match this_val {
             JValue::Ref(Some(r)) => {
                 if method_name == "<init>" {
-                    if class_name == "java/lang/String" {
-                        let s = self.string_from_init_args(&descriptor, &args, &r);
+                    if resolved_class_name == "java/lang/String" {
+                        let s = self.string_from_init_args(resolved_descriptor, &args, &r);
                         r.borrow_mut().native = NativePayload::JavaString(s);
                         return Ok(None); // void
                     }
-                    let has_method = self.method_exists(&class_name, &method_name, &descriptor);
-                    if !has_method {
-                        return Ok(None); // no-op
+                    if resolved_target.is_none() && !self.method_exists(class_name, method_name, descriptor) {
+                        return Ok(None); // legacy no-op for non-loader-aware helper paths
                     }
                 }
-                let push_return = !descriptor.ends_with(")V");
-                match self.build_special_frame_inner(r.clone(), &class_name, &method_name, &descriptor, args.clone(), push_return)? {
+                let push_return = !resolved_descriptor.ends_with(")V");
+                match self.build_special_frame_inner(
+                    r.clone(),
+                    resolved_target.as_ref().map(|target| target.owner_class_id),
+                    resolved_class_name,
+                    resolved_method_name,
+                    resolved_descriptor,
+                    args.clone(),
+                    push_return,
+                )? {
                     Some(fi) => {
                         *self.pending_frame_mut() = Some(fi);
                         Ok(None)
                     }
                     None => {
-                        let result = self.invoke_special(r, &class_name, &method_name, &descriptor, args)?;
+                        let result = self.invoke_special(
+                            r,
+                            resolved_class_name,
+                            resolved_method_name,
+                            resolved_descriptor,
+                            args,
+                        )?;
                         if !matches!(result, JValue::Void) {
                             frame.stack.push(result);
                         }
@@ -415,24 +453,55 @@ impl Vm {
         &mut self,
         cp: &[ConstantPoolEntry],
         idx: u16,
+        caller_class_id: Option<ClassId>,
         frame: &mut Frame,
     ) -> Result<Option<JValue>, String> {
         let (class_name, method_name, descriptor) = resolve_methodref_ref(cp, idx);
-        let n_args = count_args(descriptor);
+        let resolved_target = match caller_class_id {
+            Some(caller) => Some(self.resolve_method_reference(caller, cp, idx)?),
+            None => None,
+        };
+        let resolved_class_name = resolved_target
+            .as_ref()
+            .map(|target| target.owner_class.as_str())
+            .unwrap_or(class_name);
+        let resolved_method_name = resolved_target
+            .as_ref()
+            .map(|target| target.name.as_str())
+            .unwrap_or(method_name);
+        let resolved_descriptor = resolved_target
+            .as_ref()
+            .map(|target| target.descriptor.as_str())
+            .unwrap_or(descriptor);
+        let n_args = count_args(resolved_descriptor);
         let args = pop_args(frame, n_args);
 
-        let is_static = self.find_method_flags(class_name, method_name, descriptor)
-            .map(|flags| flags & 0x0008 != 0)
+        let is_static = resolved_target
+            .as_ref()
+            .map(|target| target.access_flags & 0x0008 != 0)
+            .or_else(|| self.find_method_flags(resolved_class_name, resolved_method_name, resolved_descriptor)
+                .map(|flags| flags & 0x0008 != 0))
             .unwrap_or(false);
         if is_static {
-            let push_return = !descriptor.ends_with(")V");
-            match self.build_static_frame(class_name, method_name, descriptor, args.clone(), push_return)? {
+            let push_return = !resolved_descriptor.ends_with(")V");
+            match self.build_static_frame(
+                resolved_class_name,
+                resolved_method_name,
+                resolved_descriptor,
+                args.clone(),
+                push_return,
+            )? {
                 Some(fi) => {
                     *self.pending_frame_mut() = Some(fi);
                     return Ok(None);
                 }
                 None => {
-                    let result = self.invoke_static(class_name, method_name, descriptor, args)?;
+                    let result = self.invoke_static(
+                        resolved_class_name,
+                        resolved_method_name,
+                        resolved_descriptor,
+                        args,
+                    )?;
                     if !matches!(result, JValue::Void) {
                         frame.stack.push(result);
                     }
@@ -444,8 +513,16 @@ impl Vm {
         let this_val = frame.stack.pop().unwrap();
         match this_val {
             JValue::Ref(Some(r)) => {
-                let push_return = !descriptor.ends_with(")V");
-                self.dispatch_virtual_on_ref(r, class_name, method_name, descriptor, args, push_return, frame)
+                let push_return = !resolved_descriptor.ends_with(")V");
+                self.dispatch_virtual_on_ref(
+                    r,
+                    resolved_class_name,
+                    resolved_method_name,
+                    resolved_descriptor,
+                    args,
+                    push_return,
+                    frame,
+                )
             }
             JValue::Ref(None) => Err(format!("NullPointerException: invokeinterface {class_name}.{method_name}{descriptor}")),
             other => Err(format!(

--- a/jvm-core/src/interpreter/invoke.rs
+++ b/jvm-core/src/interpreter/invoke.rs
@@ -86,7 +86,7 @@ impl Vm {
         descriptor: &str,
         args: Vec<JValue>,
     ) -> Result<JValue, String> {
-        match self.build_special_frame_inner(this.clone(), class_name, method_name, descriptor, args.clone(), true)? {
+        match self.build_special_frame_inner(this.clone(), None, class_name, method_name, descriptor, args.clone(), true)? {
             Some(fi) => {
                 let frame_owner = fi.frame_owner.clone();
                 let mut call_stack = vec![fi];

--- a/jvm-core/src/interpreter/mod.rs
+++ b/jvm-core/src/interpreter/mod.rs
@@ -23,6 +23,12 @@ use class_identity::{ClassId, ClassIdentityRegistry, ClassRecord, DefineClassErr
 
 type OwnedJarArchive = zip::ZipArchive<std::io::Cursor<Vec<u8>>>;
 
+const ACC_PUBLIC: u16 = 0x0001;
+const ACC_PRIVATE: u16 = 0x0002;
+const ACC_STATIC: u16 = 0x0008;
+const ACC_INTERFACE: u16 = 0x0200;
+const ACC_ABSTRACT: u16 = 0x0400;
+
 /// All execution-time data extracted from a resolved method in a single pass.
 /// Returned by [`Vm::resolve_method_exec_info`] to avoid repeated `find_method`
 /// calls and to give each field a self-documenting name.
@@ -48,6 +54,24 @@ pub(super) struct MethodExecInfo {
     /// Bootstrap methods from the `BootstrapMethods` attribute.
     pub bootstrap_methods: Vec<BootstrapMethod>,
     /// `access_flags` from the method_info entry.
+    pub access_flags: u16,
+}
+
+/// Loader-aware field resolution result for bytecode Fieldref entries.
+pub(super) struct ResolvedFieldTarget {
+    pub owner_class_id: ClassId,
+    pub owner_class: String,
+    pub name: String,
+    pub descriptor: String,
+    pub access_flags: u16,
+}
+
+/// Loader-aware method resolution result for bytecode Methodref entries.
+pub(super) struct ResolvedMethodTarget {
+    pub owner_class_id: ClassId,
+    pub owner_class: String,
+    pub name: String,
+    pub descriptor: String,
     pub access_flags: u16,
 }
 
@@ -574,9 +598,6 @@ pub struct Vm {
     pub(in crate::interpreter) scheduler: Scheduler,
     /// Object monitors keyed by object identity (Rc pointer address).
     monitors: HashMap<usize, Monitor>,
-    /// Legacy method resolution cache: (class, method_name, descriptor) → owner class name.
-    /// Loader-unsafe until the cpCache/member-resolution migration carries ClassId.
-    method_owner_cache: HashMap<(String, String, String), Option<String>>,
     /// Bounded LRU cache for compiled host-side regular expressions.
     regex_cache: RegexCache,
     /// Materialized non-class resources from loaded JARs, keyed by path.
@@ -616,7 +637,6 @@ impl Vm {
             system_classloader: None,
             scheduler: Scheduler::new(),
             monitors: HashMap::new(),
-            method_owner_cache: HashMap::new(),
             regex_cache: RegexCache::new(64),
             resources: HashMap::new(),
             pending_resources: HashMap::new(),
@@ -1514,6 +1534,21 @@ impl Vm {
         *self.pending_exception_mut() = Some(exc);
     }
 
+    pub(in crate::interpreter) fn throw_no_such_field_error(&mut self, detail: &str) {
+        let exc = self.new_vm_exception_message("java/lang/NoSuchFieldError", detail);
+        *self.pending_exception_mut() = Some(exc);
+    }
+
+    pub(in crate::interpreter) fn throw_no_such_method_error(&mut self, detail: &str) {
+        let exc = self.new_vm_exception_message("java/lang/NoSuchMethodError", detail);
+        *self.pending_exception_mut() = Some(exc);
+    }
+
+    pub(in crate::interpreter) fn throw_incompatible_class_change_error(&mut self, detail: &str) {
+        let exc = self.new_vm_exception_message("java/lang/IncompatibleClassChangeError", detail);
+        *self.pending_exception_mut() = Some(exc);
+    }
+
     /// Set `pending_exception` to a new `ClassNotFoundException` for `name`.
     /// `name` should be the runtime (dot-separated) class name.
     pub(in crate::interpreter) fn throw_class_not_found(&mut self, name: &str) {
@@ -1815,6 +1850,379 @@ impl Vm {
         self.resolve_class(name)
     }
 
+    fn class_is_interface_by_id(&mut self, class_id: ClassId) -> bool {
+        self.ensure_class_ready_by_id(class_id);
+        self.get_class_by_id(class_id)
+            .map(|class| class.access_flags & ACC_INTERFACE != 0)
+            .unwrap_or(false)
+    }
+
+    fn member_name_and_descriptor(
+        cp: &[ConstantPoolEntry],
+        name_and_type_index: u16,
+    ) -> Option<(String, String)> {
+        let ConstantPoolEntry::NameAndType { name_index, descriptor_index } =
+            cp.get(name_and_type_index as usize)?
+        else {
+            return None;
+        };
+        let name = match cp.get(*name_index as usize)? {
+            ConstantPoolEntry::Utf8(name) => name.clone(),
+            _ => return None,
+        };
+        let descriptor = match cp.get(*descriptor_index as usize)? {
+            ConstantPoolEntry::Utf8(descriptor) => descriptor.clone(),
+            _ => return None,
+        };
+        Some((name, descriptor))
+    }
+
+    pub(super) fn resolve_field_reference(
+        &mut self,
+        caller_class_id: ClassId,
+        cp: &[ConstantPoolEntry],
+        idx: u16,
+    ) -> Result<ResolvedFieldTarget, String> {
+        let (class_index, name_and_type_index) = match cp.get(idx as usize) {
+            Some(ConstantPoolEntry::Fieldref { class_index, name_and_type_index }) => {
+                (*class_index, *name_and_type_index)
+            }
+            _ => return Err(format!("java/lang/NoSuchFieldError: invalid field reference #{idx}")),
+        };
+        let (name, descriptor) = Self::member_name_and_descriptor(cp, name_and_type_index)
+            .ok_or_else(|| format!("java/lang/NoSuchFieldError: invalid field reference #{idx}"))?;
+        let referenced_class_id = self.resolve_symbolic_class(caller_class_id, cp, class_index)?;
+        self.find_field_owner_by_class_id(referenced_class_id, &name, &descriptor)
+            .ok_or_else(|| {
+                let referenced_class = self
+                    .class_record(referenced_class_id)
+                    .map(|record| record.internal_name.clone())
+                    .unwrap_or_else(|| "<invalid>".to_owned());
+                let detail = format!("{referenced_class}.{name}:{descriptor}");
+                self.throw_no_such_field_error(&detail);
+                format!("java/lang/NoSuchFieldError: {detail}")
+            })
+    }
+
+    pub(super) fn resolve_method_reference(
+        &mut self,
+        caller_class_id: ClassId,
+        cp: &[ConstantPoolEntry],
+        idx: u16,
+    ) -> Result<ResolvedMethodTarget, String> {
+        let (class_index, name_and_type_index, is_interface_ref) = match cp.get(idx as usize) {
+            Some(ConstantPoolEntry::Methodref { class_index, name_and_type_index }) => {
+                (*class_index, *name_and_type_index, false)
+            }
+            Some(ConstantPoolEntry::InterfaceMethodref { class_index, name_and_type_index }) => {
+                (*class_index, *name_and_type_index, true)
+            }
+            _ => return Err(format!("java/lang/NoSuchMethodError: invalid method reference #{idx}")),
+        };
+        let (name, descriptor) = Self::member_name_and_descriptor(cp, name_and_type_index)
+            .ok_or_else(|| format!("java/lang/NoSuchMethodError: invalid method reference #{idx}"))?;
+        let referenced_class_id = self.resolve_symbolic_class(caller_class_id, cp, class_index)?;
+        let is_interface = self.class_is_interface_by_id(referenced_class_id);
+        if is_interface_ref != is_interface {
+            let referenced_class = self
+                .class_record(referenced_class_id)
+                .map(|record| record.internal_name.clone())
+                .unwrap_or_else(|| "<invalid>".to_owned());
+            let detail = if is_interface_ref {
+                format!("InterfaceMethodref resolved to non-interface {referenced_class}")
+            } else {
+                format!("Methodref resolved to interface {referenced_class}")
+            };
+            self.throw_incompatible_class_change_error(&detail);
+            return Err(format!("java/lang/IncompatibleClassChangeError: {detail}"));
+        }
+
+        let target = if is_interface_ref {
+            self.find_interface_method_owner_by_class_id(referenced_class_id, &name, &descriptor)
+        } else {
+            self.find_method_owner_by_class_id(referenced_class_id, &name, &descriptor)
+        };
+        target.ok_or_else(|| {
+            let referenced_class = self
+                .class_record(referenced_class_id)
+                .map(|record| record.internal_name.clone())
+                .unwrap_or_else(|| "<invalid>".to_owned());
+            let detail = format!("{referenced_class}.{name}{descriptor}");
+            self.throw_no_such_method_error(&detail);
+            format!("java/lang/NoSuchMethodError: {detail}")
+        })
+    }
+
+    pub(super) fn find_field_owner_by_class_id(
+        &mut self,
+        class_id: ClassId,
+        field_name: &str,
+        descriptor: &str,
+    ) -> Option<ResolvedFieldTarget> {
+        self.ensure_class_ready_by_id(class_id);
+        let class = self.get_class_by_id(class_id)?;
+        for field in &class.fields {
+            let name = class.constant_pool.utf8(field.name_index);
+            let desc = class.constant_pool.utf8(field.descriptor_index);
+            if name == field_name && desc == descriptor {
+                let owner_class = class.constant_pool.class_name(class.this_class).to_owned();
+                return Some(ResolvedFieldTarget {
+                    owner_class_id: class_id,
+                    owner_class,
+                    name: name.to_owned(),
+                    descriptor: desc.to_owned(),
+                    access_flags: field.access_flags,
+                });
+            }
+        }
+        let cp = Rc::clone(&class.constant_pool.entries);
+        let super_class = class.super_class;
+        let interfaces = class.interfaces.clone();
+
+        for interface_index in interfaces {
+            if let Ok(interface_id) = self.resolve_symbolic_class(class_id, &cp, interface_index) {
+                if let Some(target) = self.find_field_owner_by_class_id(interface_id, field_name, descriptor) {
+                    return Some(target);
+                }
+            }
+        }
+        if super_class != 0 {
+            if let Ok(super_id) = self.resolve_symbolic_class(class_id, &cp, super_class) {
+                if let Some(target) = self.find_field_owner_by_class_id(super_id, field_name, descriptor) {
+                    return Some(target);
+                }
+            }
+        }
+        None
+    }
+
+    pub(super) fn find_method_owner_by_class_id(
+        &mut self,
+        class_id: ClassId,
+        method_name: &str,
+        descriptor: &str,
+    ) -> Option<ResolvedMethodTarget> {
+        if let Some(target) = self.declared_method_by_class_id(class_id, method_name, descriptor) {
+            return Some(target);
+        }
+        let class = self.get_class_by_id(class_id)?;
+        let cp = Rc::clone(&class.constant_pool.entries);
+        let super_class = class.super_class;
+
+        if super_class != 0 {
+            if let Ok(super_id) = self.resolve_symbolic_class(class_id, &cp, super_class) {
+                if let Some(target) =
+                    self.find_method_owner_by_class_id(super_id, method_name, descriptor)
+                {
+                    return Some(target);
+                }
+            }
+        }
+        let candidates = self.superinterface_method_candidates(class_id, method_name, descriptor);
+        self.choose_superinterface_method_candidate(candidates)
+    }
+
+    fn find_interface_method_owner_by_class_id(
+        &mut self,
+        interface_id: ClassId,
+        method_name: &str,
+        descriptor: &str,
+    ) -> Option<ResolvedMethodTarget> {
+        if let Some(target) =
+            self.declared_method_by_class_id(interface_id, method_name, descriptor)
+        {
+            return Some(target);
+        }
+        if let Some(target) = self.object_public_instance_method(method_name, descriptor) {
+            return Some(target);
+        }
+
+        let candidates =
+            self.superinterface_method_candidates(interface_id, method_name, descriptor);
+        self.choose_superinterface_method_candidate(candidates)
+    }
+
+    fn choose_superinterface_method_candidate(
+        &mut self,
+        candidates: Vec<ResolvedMethodTarget>,
+    ) -> Option<ResolvedMethodTarget> {
+        let mut concrete_maximally_specific_index = None;
+        let mut concrete_maximally_specific_count = 0;
+        for (index, candidate) in candidates.iter().enumerate() {
+            let shadowed_by_subinterface = candidates.iter().any(|other| {
+                other.owner_class_id != candidate.owner_class_id
+                    && self.interface_extends_by_id(other.owner_class_id, candidate.owner_class_id)
+            });
+            if !shadowed_by_subinterface && candidate.access_flags & ACC_ABSTRACT == 0 {
+                concrete_maximally_specific_count += 1;
+                concrete_maximally_specific_index.get_or_insert(index);
+            }
+        }
+        if concrete_maximally_specific_count == 1 {
+            if let Some(index) = concrete_maximally_specific_index {
+                return candidates.into_iter().nth(index);
+            }
+        }
+
+        candidates.into_iter().next()
+    }
+
+    fn declared_method_by_class_id(
+        &mut self,
+        class_id: ClassId,
+        method_name: &str,
+        descriptor: &str,
+    ) -> Option<ResolvedMethodTarget> {
+        self.ensure_class_ready_by_id(class_id);
+        let class = self.get_class_by_id(class_id)?;
+        for method in &class.methods {
+            let name = class.constant_pool.utf8(method.name_index);
+            let desc = class.constant_pool.utf8(method.descriptor_index);
+            if name == method_name && desc == descriptor {
+                let owner_class = class.constant_pool.class_name(class.this_class).to_owned();
+                return Some(ResolvedMethodTarget {
+                    owner_class_id: class_id,
+                    owner_class,
+                    name: name.to_owned(),
+                    descriptor: desc.to_owned(),
+                    access_flags: method.access_flags,
+                });
+            }
+        }
+        None
+    }
+
+    fn object_public_instance_method(
+        &mut self,
+        method_name: &str,
+        descriptor: &str,
+    ) -> Option<ResolvedMethodTarget> {
+        let object_id = self.loaded_class_id_by_name("java/lang/Object")?;
+        let target = self.declared_method_by_class_id(object_id, method_name, descriptor)?;
+        if Self::is_public_instance_method(target.access_flags) {
+            Some(target)
+        } else {
+            None
+        }
+    }
+
+    fn loaded_class_id_by_name(&mut self, internal_name: &str) -> Option<ClassId> {
+        let existing = self
+            .class_id_for_defined(LoaderId::SYSTEM, internal_name)
+            .or_else(|| self.class_id_for_defined(LoaderId::BOOTSTRAP, internal_name));
+        if existing.is_some() {
+            return existing;
+        }
+        self.resolve_class(internal_name)?;
+        self.class_id_for_defined(LoaderId::SYSTEM, internal_name)
+            .or_else(|| self.class_id_for_defined(LoaderId::BOOTSTRAP, internal_name))
+    }
+
+    fn superinterface_method_candidates(
+        &mut self,
+        class_or_interface_id: ClassId,
+        method_name: &str,
+        descriptor: &str,
+    ) -> Vec<ResolvedMethodTarget> {
+        let mut candidates = Vec::new();
+        let mut seen = HashSet::new();
+        for direct_interface_id in self.direct_interface_ids(class_or_interface_id) {
+            self.collect_interface_method_candidates(
+                direct_interface_id,
+                method_name,
+                descriptor,
+                &mut seen,
+                &mut candidates,
+            );
+        }
+        candidates
+    }
+
+    fn collect_interface_method_candidates(
+        &mut self,
+        interface_id: ClassId,
+        method_name: &str,
+        descriptor: &str,
+        seen: &mut HashSet<ClassId>,
+        candidates: &mut Vec<ResolvedMethodTarget>,
+    ) {
+        if !seen.insert(interface_id) {
+            return;
+        }
+        if let Some(target) =
+            self.declared_method_by_class_id(interface_id, method_name, descriptor)
+        {
+            if Self::is_inherited_interface_method_candidate(target.access_flags) {
+                candidates.push(target);
+            }
+        }
+        for superinterface_id in self.direct_interface_ids(interface_id) {
+            self.collect_interface_method_candidates(
+                superinterface_id,
+                method_name,
+                descriptor,
+                seen,
+                candidates,
+            );
+        }
+    }
+
+    fn interface_extends_by_id(
+        &mut self,
+        child_interface_id: ClassId,
+        ancestor_interface_id: ClassId,
+    ) -> bool {
+        let mut seen = HashSet::new();
+        self.interface_extends_by_id_inner(child_interface_id, ancestor_interface_id, &mut seen)
+    }
+
+    fn interface_extends_by_id_inner(
+        &mut self,
+        child_interface_id: ClassId,
+        ancestor_interface_id: ClassId,
+        seen: &mut HashSet<ClassId>,
+    ) -> bool {
+        if !seen.insert(child_interface_id) {
+            return false;
+        }
+        for direct_interface_id in self.direct_interface_ids(child_interface_id) {
+            if direct_interface_id == ancestor_interface_id
+                || self.interface_extends_by_id_inner(
+                    direct_interface_id,
+                    ancestor_interface_id,
+                    seen,
+                )
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn direct_interface_ids(&mut self, class_id: ClassId) -> Vec<ClassId> {
+        self.ensure_class_ready_by_id(class_id);
+        let Some(class) = self.get_class_by_id(class_id) else {
+            return Vec::new();
+        };
+        let cp = Rc::clone(&class.constant_pool.entries);
+        let interfaces = class.interfaces.clone();
+        interfaces
+            .into_iter()
+            .filter_map(|interface_index| {
+                self.resolve_symbolic_class(class_id, &cp, interface_index)
+                    .ok()
+            })
+            .collect()
+    }
+
+    fn is_public_instance_method(access_flags: u16) -> bool {
+        access_flags & ACC_PUBLIC != 0 && access_flags & ACC_STATIC == 0
+    }
+
+    fn is_inherited_interface_method_candidate(access_flags: u16) -> bool {
+        access_flags & (ACC_PRIVATE | ACC_STATIC) == 0
+    }
+
     /// Find the `access_flags` of a method by name and descriptor in a class
     /// (including super-chain). Returns `None` if the method is not found.
     ///
@@ -1916,8 +2324,9 @@ impl Vm {
         method_name: &str,
         descriptor: &str,
     ) -> Option<MethodExecInfo> {
-        self.ensure_class_ready_by_id(class_id);
-        let class = self.get_class_by_id(class_id)?;
+        let owner = self.find_method_owner_by_class_id(class_id, method_name, descriptor)?;
+        self.ensure_class_ready_by_id(owner.owner_class_id);
+        let class = self.get_class_by_id(owner.owner_class_id)?;
         let method_idx = class.methods.iter().position(|m| {
             class.constant_pool.utf8(m.name_index) == method_name
                 && class.constant_pool.utf8(m.descriptor_index) == descriptor
@@ -1937,7 +2346,7 @@ impl Vm {
             if let Attribute::BootstrapMethods(bms) = a { Some(bms.clone()) } else { None }
         }).unwrap_or_default();
         Some(MethodExecInfo {
-            class_id: Some(class_id),
+            class_id: Some(owner.owner_class_id),
             class_name: class_name_out,
             descriptor: descriptor_out,
             access_flags,
@@ -1959,25 +2368,6 @@ impl Vm {
         method_name: &str,
         descriptor: &str,
     ) -> Option<String> {
-        let cache_key = (class_name.to_owned(), method_name.to_owned(), descriptor.to_owned());
-        if let Some(cached) = self.method_owner_cache.get(&cache_key) {
-            return cached.clone();
-        }
-        let result = self.find_method_owner_uncached(class_name, method_name, descriptor);
-        // Only cache positive results — negative lookups (None) may become valid
-        // after new classes are registered via load_lazy/load_class.
-        if result.is_some() {
-            self.method_owner_cache.insert(cache_key, result.clone());
-        }
-        result
-    }
-
-    fn find_method_owner_uncached(
-        &mut self,
-        class_name: &str,
-        method_name: &str,
-        descriptor: &str,
-    ) -> Option<String> {
         self.ensure_class_ready(class_name);
         let class = self.get_class(class_name)?;
         for m in &class.methods {
@@ -1993,21 +2383,16 @@ impl Vm {
         } else {
             None
         };
-        let iface_names: Vec<String> = class.interfaces.iter()
-            .map(|&idx| class.constant_pool.class_name(idx).to_owned())
-            .collect();
         // borrow on `class` ends here
         if let Some(super_name) = super_name {
             if let Some(owner) = self.find_method_owner(&super_name, method_name, descriptor) {
                 return Some(owner);
             }
         }
-        for iface_name in &iface_names {
-            if let Some(owner) = self.find_method_owner(iface_name, method_name, descriptor) {
-                return Some(owner);
-            }
-        }
-        None
+        let class_id = self.loaded_class_id_by_name(class_name)?;
+        let candidates = self.superinterface_method_candidates(class_id, method_name, descriptor);
+        self.choose_superinterface_method_candidate(candidates)
+            .map(|target| target.owner_class)
     }
 
     /// Returns `true` if the named method exists in the class hierarchy.

--- a/jvm-core/src/interpreter/trampoline.rs
+++ b/jvm-core/src/interpreter/trampoline.rs
@@ -712,13 +712,25 @@ impl Vm {
     pub(crate) fn build_special_frame_inner(
         &mut self,
         this: JRef,
+        resolved_owner_class_id: Option<ClassId>,
         class_name: &str,
         method_name: &str,
         descriptor: &str,
         args: Vec<JValue>,
         push_return: bool,
     ) -> Result<Option<FrameInfo>, String> {
-        if let Some(class_id) = self.custom_loader_class_id_for_object(&this) {
+        if let Some(class_id) = resolved_owner_class_id {
+            if let Some(frame) = self.try_custom_loader_instance_frame(
+                class_id,
+                Rc::clone(&this),
+                method_name,
+                descriptor,
+                &args,
+                push_return,
+            )? {
+                return Ok(Some(frame));
+            }
+        } else if let Some(class_id) = self.custom_loader_class_id_for_object(&this) {
             if let Some(frame) = self.try_custom_loader_instance_frame(
                 class_id,
                 Rc::clone(&this),

--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -637,6 +637,39 @@ fn member_reference_kind_mismatch_throws_icce() {
 }
 
 #[test]
+fn field_access_kind_mismatch_throws_icce() {
+    let result = run_jar_test(
+        "MemberReferenceKindMismatchTest",
+        "fieldAccessKindMismatch",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(
+        result,
+        "IncompatibleClassChangeError|IncompatibleClassChangeError|IncompatibleClassChangeError|IncompatibleClassChangeError"
+    );
+}
+
+#[test]
+fn instance_field_resolution_uses_caller_loader() {
+    let result = run_jar_test(
+        "MemberReferenceKindMismatchTest",
+        "instanceFieldResolutionUsesCallerLoader",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "none|IncompatibleClassChangeError");
+}
+
+#[test]
+fn missing_instance_field_throws_no_such_field_error() {
+    let result = run_jar_test(
+        "MemberReferenceKindMismatchTest",
+        "missingInstanceField",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "NoSuchFieldError");
+}
+
+#[test]
 fn anewarray_preserves_array_component_descriptor() {
     let result = run_jar_test(
         "AnewArrayComponentDescriptorTest",

--- a/jvm-core/tests/integration_test.rs
+++ b/jvm-core/tests/integration_test.rs
@@ -566,7 +566,7 @@ fn loader_linkage_error_survives_symbolic_resolution() {
 }
 
 #[test]
-#[ignore = "Phase 0 regression target for cpCache owner isolation"]
+#[ignore = "Phase 5 regression target for ClassId-scoped static field storage"]
 fn cp_cache_keeps_loader_distinct_member_owners_isolated() {
     let result = run_jar_test(
         "CpCacheOwnerIsolationTest",
@@ -577,16 +577,63 @@ fn cp_cache_keeps_loader_distinct_member_owners_isolated() {
 }
 
 #[test]
-fn failed_symbolic_class_resolution_repeats_same_error_family() {
+fn invokespecial_uses_resolved_declaring_owner_for_custom_loader_classes() {
     let result = run_jar_test(
-        "RepeatedResolutionFailureTest",
+        "InvokespecialResolvedOwnerTest",
         "run",
         "()Ljava/lang/String;",
     );
-    assert_eq!(
-        result,
-        "NoClassDefFoundError"
+    assert_eq!(result, "base");
+}
+
+#[test]
+fn failed_symbolic_class_resolution_repeats_same_error_family() {
+    let result = run_jar_test(
+        "RepeatedResolutionFailureTest",
+        "missingClass",
+        "()Ljava/lang/String;",
     );
+    assert_eq!(result, "NoClassDefFoundError");
+}
+
+#[test]
+fn failed_symbolic_field_resolution_repeats_same_error_family() {
+    let result = run_jar_test(
+        "RepeatedResolutionFailureTest",
+        "missingField",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "NoSuchFieldError");
+}
+
+#[test]
+fn failed_symbolic_method_resolution_repeats_same_error_family() {
+    let result = run_jar_test(
+        "RepeatedResolutionFailureTest",
+        "missingMethod",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "NoSuchMethodError");
+}
+
+#[test]
+fn failed_symbolic_interface_method_resolution_repeats_same_error_family() {
+    let result = run_jar_test(
+        "RepeatedResolutionFailureTest",
+        "missingInterfaceMethod",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "NoSuchMethodError");
+}
+
+#[test]
+fn member_reference_kind_mismatch_throws_icce() {
+    let result = run_jar_test(
+        "MemberReferenceKindMismatchTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "IncompatibleClassChangeError|IncompatibleClassChangeError");
 }
 
 #[test]
@@ -656,7 +703,7 @@ fn clinit_erroneous_state_throws_ncdfe_on_second_access() {
 }
 
 // ---------------------------------------------------------------------------
-// JVMS §6.5: invokeinterface dispatches to interface default method
+// JVMS §5.4.3.4 / §6.5: interface method resolution and dispatch
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -667,6 +714,16 @@ fn interface_default_method_dispatch() {
         "()Ljava/lang/String;",
     );
     assert_eq!(result, "I am Thing");
+}
+
+#[test]
+fn interface_method_resolution_ignores_private_and_static_superinterface_methods() {
+    let result = run_jar_test(
+        "InterfaceMethodResolutionChoiceTest",
+        "run",
+        "()Ljava/lang/String;",
+    );
+    assert_eq!(result, "ignored-static|ignored-private");
 }
 
 #[test]

--- a/test-sources/InterfaceMethodResolutionChoiceTest.java
+++ b/test-sources/InterfaceMethodResolutionChoiceTest.java
@@ -1,0 +1,39 @@
+public class InterfaceMethodResolutionChoiceTest {
+    interface IgnoredStaticMethod {
+        static String value() {
+            return "static";
+        }
+    }
+
+    interface IgnoredPrivateMethod {
+        private String value() {
+            return "private";
+        }
+    }
+
+    interface DefaultAgainstStaticMethod {
+        default String value() {
+            return "ignored-static";
+        }
+    }
+
+    interface DefaultAgainstPrivateMethod {
+        default String value() {
+            return "ignored-private";
+        }
+    }
+
+    interface StaticCombined extends IgnoredStaticMethod, DefaultAgainstStaticMethod {}
+
+    interface PrivateCombined extends IgnoredPrivateMethod, DefaultAgainstPrivateMethod {}
+
+    static final class StaticImpl implements StaticCombined {}
+
+    static final class PrivateImpl implements PrivateCombined {}
+
+    public static String run() {
+        StaticCombined staticCombined = new StaticImpl();
+        PrivateCombined privateCombined = new PrivateImpl();
+        return staticCombined.value() + "|" + privateCombined.value();
+    }
+}

--- a/test-sources/InvokespecialResolvedOwnerTest.java
+++ b/test-sources/InvokespecialResolvedOwnerTest.java
@@ -1,0 +1,11 @@
+public class InvokespecialResolvedOwnerTest {
+    public static String run() throws Exception {
+        LoaderPhase0Fixtures.BytesLoader loader = new LoaderPhase0Fixtures.BytesLoader(
+                new String[] { "phase0.SpecialChild", "phase0.SpecialBase" },
+                new byte[][] {
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.SPECIAL_CHILD_B64),
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.SPECIAL_BASE_B64)
+                });
+        return LoaderPhase0Fixtures.invokeString(loader.loadClass("phase0.SpecialChild"), "run");
+    }
+}

--- a/test-sources/LoaderPhase0Fixtures.java
+++ b/test-sources/LoaderPhase0Fixtures.java
@@ -181,6 +181,79 @@ final class LoaderPhase0Fixtures {
         return out;
     }
 
+    static byte[] bytesWithMethodReferenceTag(String encoded, String owner, String name, int tag) {
+        byte[] out = bytes(encoded);
+        int cpCount = u16(out, 8);
+        int[] tags = new int[cpCount];
+        int[] a = new int[cpCount];
+        int[] b = new int[cpCount];
+        int[] offset = new int[cpCount];
+        String[] utf8 = new String[cpCount];
+        int p = 10;
+        for (int i = 1; i < cpCount; i++) {
+            offset[i] = p;
+            int cpTag = out[p++] & 0xff;
+            tags[i] = cpTag;
+            switch (cpTag) {
+                case 1:
+                    int length = u16(out, p);
+                    p += 2;
+                    utf8[i] = ascii(out, p, length);
+                    p += length;
+                    break;
+                case 3:
+                case 4:
+                    p += 4;
+                    break;
+                case 5:
+                case 6:
+                    p += 8;
+                    i++;
+                    break;
+                case 7:
+                case 8:
+                case 16:
+                case 19:
+                case 20:
+                    a[i] = u16(out, p);
+                    p += 2;
+                    break;
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 17:
+                case 18:
+                    a[i] = u16(out, p);
+                    b[i] = u16(out, p + 2);
+                    p += 4;
+                    break;
+                case 15:
+                    p += 3;
+                    break;
+                default:
+                    throw new IllegalArgumentException("unsupported cp tag");
+            }
+        }
+        for (int i = 1; i < cpCount; i++) {
+            if ((tags[i] == 10 || tags[i] == 11)
+                    && owner.equals(utf8[a[a[i]]])
+                    && name.equals(utf8[a[b[i]]])) {
+                out[offset[i]] = (byte) tag;
+                return out;
+            }
+        }
+        throw new IllegalArgumentException("method reference not found");
+    }
+
+    private static String ascii(byte[] bytes, int offset, int length) {
+        char[] chars = new char[length];
+        for (int i = 0; i < length; i++) {
+            chars[i] = (char) (bytes[offset + i] & 0xff);
+        }
+        return new String(chars);
+    }
+
     private static int u16(byte[] bytes, int offset) {
         return ((bytes[offset] & 0xff) << 8) | (bytes[offset + 1] & 0xff);
     }
@@ -221,4 +294,10 @@ final class LoaderPhase0Fixtures {
     static final String MISSING_METHOD_OWNER_NO_METHOD_B64 = "yv66vgAAADQADQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWBwAIAQAZcGhhc2UwL01pc3NpbmdNZXRob2RPd25lcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAApTb3VyY2VGaWxlAQAXTWlzc2luZ01ldGhvZE93bmVyLmphdmEAIQAHAAIAAAAAAAEAAQAFAAYAAQAJAAAAHQABAAEAAAAFKrcAAbEAAAABAAoAAAAGAAEAAAABAAEACwAAAAIADA==";
     static final String MISSING_INTERFACE_NO_METHOD_B64 = "yv66vgAAADQABwcAAgEAF3BoYXNlMC9NaXNzaW5nSW50ZXJmYWNlBwAEAQAQamF2YS9sYW5nL09iamVjdAEAClNvdXJjZUZpbGUBABVNaXNzaW5nSW50ZXJmYWNlLmphdmEGAQABAAMAAAAAAAAAAQAFAAAAAgAG";
     static final String MISSING_INTERFACE_IMPL_B64 = "yv66vgAAADQAEwoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCAAIAQAEaW1wbAcACgEAG3BoYXNlMC9NaXNzaW5nSW50ZXJmYWNlSW1wbAcADAEAF3BoYXNlMC9NaXNzaW5nSW50ZXJmYWNlAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEABXZhbHVlAQAUKClMamF2YS9sYW5nL1N0cmluZzsBAApTb3VyY2VGaWxlAQAZTWlzc2luZ0ludGVyZmFjZUltcGwuamF2YQAhAAkAAgABAAsAAAACAAEABQAGAAEADQAAAB0AAQABAAAABSq3AAGxAAAAAQAOAAAABgABAAAAAQABAA8AEAABAA0AAAAbAAEAAQAAAAMSB7AAAAABAA4AAAAGAAEAAAABAAEAEQAAAAIAEg==";
+    static final String INTERFACE_TARGET_B64 = "yv66vgAAAEUADQgAAgEABWlmYWNlBwAEAQAWcGhhc2UwL0ludGVyZmFjZVRhcmdldAcABgEAEGphdmEvbGFuZy9PYmplY3QBAAV2YWx1ZQEAFCgpTGphdmEvbGFuZy9TdHJpbmc7AQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAClNvdXJjZUZpbGUBABRJbnRlcmZhY2VUYXJnZXQuamF2YQYBAAMABQAAAAAAAQAJAAcACAABAAkAAAAbAAEAAAAAAAMSAbAAAAABAAoAAAAGAAEAAAADAAEACwAAAAIADA==";
+    static final String CLASS_TARGET_B64 = "yv66vgAAAEUAEQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCAAIAQAFY2xhc3MHAAoBABJwaGFzZTAvQ2xhc3NUYXJnZXQBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQAFdmFsdWUBABQoKUxqYXZhL2xhbmcvU3RyaW5nOwEAClNvdXJjZUZpbGUBABBDbGFzc1RhcmdldC5qYXZhACEACQACAAAAAAACAAEABQAGAAEACwAAAB0AAQABAAAABSq3AAGxAAAAAQAMAAAABgABAAAAAgAJAA0ADgABAAsAAAAbAAEAAAAAAAMSB7AAAAABAAwAAAAGAAEAAAADAAEADwAAAAIAEA==";
+    static final String METHODREF_TO_INTERFACE_CALLER_B64 = "yv66vgAAAEUAFAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCwAIAAkHAAoMAAsADAEAFnBoYXNlMC9JbnRlcmZhY2VUYXJnZXQBAAV2YWx1ZQEAFCgpTGphdmEvbGFuZy9TdHJpbmc7BwAOAQAhcGhhc2UwL01ldGhvZHJlZlRvSW50ZXJmYWNlQ2FsbGVyAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAA3J1bgEAClNvdXJjZUZpbGUBAB9NZXRob2RyZWZUb0ludGVyZmFjZUNhbGxlci5qYXZhACEADQACAAAAAAACAAEABQAGAAEADwAAAB0AAQABAAAABSq3AAGxAAAAAQAQAAAABgABAAAAAgAJABEADAABAA8AAAAcAAEAAAAAAAS4AAewAAAAAQAQAAAABgABAAAAAwABABIAAAACABM=";
+    static final String INTERFACE_METHODREF_TO_CLASS_CALLER_B64 = "yv66vgAAAEUAFAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCgAIAAkHAAoMAAsADAEAEnBoYXNlMC9DbGFzc1RhcmdldAEABXZhbHVlAQAUKClMamF2YS9sYW5nL1N0cmluZzsHAA4BACZwaGFzZTAvSW50ZXJmYWNlTWV0aG9kcmVmVG9DbGFzc0NhbGxlcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAANydW4BAApTb3VyY2VGaWxlAQAkSW50ZXJmYWNlTWV0aG9kcmVmVG9DbGFzc0NhbGxlci5qYXZhACEADQACAAAAAAACAAEABQAGAAEADwAAAB0AAQABAAAABSq3AAGxAAAAAQAQAAAABgABAAAAAgAJABEADAABAA8AAAAcAAEAAAAAAAS4AAewAAAAAQAQAAAABgABAAAAAwABABIAAAACABM=";
+    static final String SPECIAL_BASE_B64 = "yv66vgAAADQAEQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCAAIAQAEYmFzZQcACgEAEnBoYXNlMC9TcGVjaWFsQmFzZQEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAARtYXJrAQAUKClMamF2YS9sYW5nL1N0cmluZzsBAApTb3VyY2VGaWxlAQAQU3BlY2lhbEJhc2UuamF2YQAhAAkAAgAAAAAAAgABAAUABgABAAsAAAAdAAEAAQAAAAUqtwABsQAAAAEADAAAAAYAAQAAAAQAAQANAA4AAQALAAAAGwABAAEAAAADEgewAAAAAQAMAAAABgABAAAABwABAA8AAAACABA=";
+    static final String SPECIAL_CHILD_B64 = "yv66vgAAADQAGAoAAgADBwAEDAAFAAYBABJwaGFzZTAvU3BlY2lhbEJhc2UBAAY8aW5pdD4BAAMoKVYIAAgBAAVjaGlsZAoAAgAKDAALAAwBAARtYXJrAQAUKClMamF2YS9sYW5nL1N0cmluZzsHAA4BABNwaGFzZTAvU3BlY2lhbENoaWxkCgANAAMKAA0AEQwAEgAMAQAJY2FsbFN1cGVyAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAA3J1bgEAClNvdXJjZUZpbGUBABFTcGVjaWFsQ2hpbGQuamF2YQAhAA0AAgAAAAAABAABAAUABgABABMAAAAhAAEAAQAAAAUqtwABsQAAAAEAFAAAAAoAAgAAAAUABAAGAAEACwAMAAEAEwAAABsAAQABAAAAAxIHsAAAAAEAFAAAAAYAAQAAAAkAAQASAAwAAQATAAAAHQABAAEAAAAFKrcACbAAAAABABQAAAAGAAEAAAANAAkAFQAMAAEAEwAAACMAAgAAAAAAC7sADVm3AA+2ABCwAAAAAQAUAAAABgABAAAAEQABABYAAAACABc=";
 }

--- a/test-sources/LoaderPhase0Fixtures.java
+++ b/test-sources/LoaderPhase0Fixtures.java
@@ -79,9 +79,17 @@ final class LoaderPhase0Fixtures {
     }
 
     static String repeatedFailure(String callerName, String[] names, byte[][] bytes) throws Exception {
+        return repeatedFailure(callerName, "run", names, bytes);
+    }
+
+    static String repeatedFailure(
+            String callerName,
+            String methodName,
+            String[] names,
+            byte[][] bytes) throws Exception {
         BytesLoader loader = new BytesLoader(names, bytes);
         Class<?> caller = loader.loadClass(callerName);
-        Method m = caller.getDeclaredMethod("run", new Class<?>[0]);
+        Method m = caller.getDeclaredMethod(methodName, new Class<?>[0]);
         String first = failureFamily(m);
         String second = failureFamily(m);
         return first.equals(second) ? first : new StringBuilder().append(first).append("!=").append(second).toString();
@@ -246,6 +254,75 @@ final class LoaderPhase0Fixtures {
         throw new IllegalArgumentException("method reference not found");
     }
 
+    static byte[] bytesWithFieldStaticFlag(String encoded, String fieldName, boolean isStatic) {
+        byte[] out = bytes(encoded);
+        int cpCount = u16(out, 8);
+        String[] utf8 = new String[cpCount];
+        int p = 10;
+        for (int i = 1; i < cpCount; i++) {
+            int cpTag = out[p++] & 0xff;
+            switch (cpTag) {
+                case 1:
+                    int length = u16(out, p);
+                    p += 2;
+                    utf8[i] = ascii(out, p, length);
+                    p += length;
+                    break;
+                case 3:
+                case 4:
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 17:
+                case 18:
+                    p += 4;
+                    break;
+                case 5:
+                case 6:
+                    p += 8;
+                    i++;
+                    break;
+                case 7:
+                case 8:
+                case 16:
+                case 19:
+                case 20:
+                    p += 2;
+                    break;
+                case 15:
+                    p += 3;
+                    break;
+                default:
+                    throw new IllegalArgumentException("unsupported cp tag");
+            }
+        }
+        p += 6;
+        int interfaceCount = u16(out, p);
+        p += 2 + interfaceCount * 2;
+        int fieldCount = u16(out, p);
+        p += 2;
+        for (int i = 0; i < fieldCount; i++) {
+            int accessOffset = p;
+            int accessFlags = u16(out, p);
+            int nameIndex = u16(out, p + 2);
+            int attributeCount = u16(out, p + 6);
+            p += 8;
+            if (fieldName.equals(utf8[nameIndex])) {
+                int updated = isStatic ? accessFlags | 0x0008 : accessFlags & ~0x0008;
+                out[accessOffset] = (byte) (updated >> 8);
+                out[accessOffset + 1] = (byte) updated;
+                return out;
+            }
+            for (int j = 0; j < attributeCount; j++) {
+                p += 2;
+                int attributeLength = u32(out, p);
+                p += 4 + attributeLength;
+            }
+        }
+        throw new IllegalArgumentException("field not found");
+    }
+
     private static String ascii(byte[] bytes, int offset, int length) {
         char[] chars = new char[length];
         for (int i = 0; i < length; i++) {
@@ -256,6 +333,13 @@ final class LoaderPhase0Fixtures {
 
     private static int u16(byte[] bytes, int offset) {
         return ((bytes[offset] & 0xff) << 8) | (bytes[offset + 1] & 0xff);
+    }
+
+    private static int u32(byte[] bytes, int offset) {
+        return ((bytes[offset] & 0xff) << 24)
+                | ((bytes[offset + 1] & 0xff) << 16)
+                | ((bytes[offset + 2] & 0xff) << 8)
+                | (bytes[offset + 3] & 0xff);
     }
 
     private static int decode(char ch) {
@@ -300,4 +384,7 @@ final class LoaderPhase0Fixtures {
     static final String INTERFACE_METHODREF_TO_CLASS_CALLER_B64 = "yv66vgAAAEUAFAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCgAIAAkHAAoMAAsADAEAEnBoYXNlMC9DbGFzc1RhcmdldAEABXZhbHVlAQAUKClMamF2YS9sYW5nL1N0cmluZzsHAA4BACZwaGFzZTAvSW50ZXJmYWNlTWV0aG9kcmVmVG9DbGFzc0NhbGxlcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAANydW4BAApTb3VyY2VGaWxlAQAkSW50ZXJmYWNlTWV0aG9kcmVmVG9DbGFzc0NhbGxlci5qYXZhACEADQACAAAAAAACAAEABQAGAAEADwAAAB0AAQABAAAABSq3AAGxAAAAAQAQAAAABgABAAAAAgAJABEADAABAA8AAAAcAAEAAAAAAAS4AAewAAAAAQAQAAAABgABAAAAAwABABIAAAACABM=";
     static final String SPECIAL_BASE_B64 = "yv66vgAAADQAEQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCAAIAQAEYmFzZQcACgEAEnBoYXNlMC9TcGVjaWFsQmFzZQEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAARtYXJrAQAUKClMamF2YS9sYW5nL1N0cmluZzsBAApTb3VyY2VGaWxlAQAQU3BlY2lhbEJhc2UuamF2YQAhAAkAAgAAAAAAAgABAAUABgABAAsAAAAdAAEAAQAAAAUqtwABsQAAAAEADAAAAAYAAQAAAAQAAQANAA4AAQALAAAAGwABAAEAAAADEgewAAAAAQAMAAAABgABAAAABwABAA8AAAACABA=";
     static final String SPECIAL_CHILD_B64 = "yv66vgAAADQAGAoAAgADBwAEDAAFAAYBABJwaGFzZTAvU3BlY2lhbEJhc2UBAAY8aW5pdD4BAAMoKVYIAAgBAAVjaGlsZAoAAgAKDAALAAwBAARtYXJrAQAUKClMamF2YS9sYW5nL1N0cmluZzsHAA4BABNwaGFzZTAvU3BlY2lhbENoaWxkCgANAAMKAA0AEQwAEgAMAQAJY2FsbFN1cGVyAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAA3J1bgEAClNvdXJjZUZpbGUBABFTcGVjaWFsQ2hpbGQuamF2YQAhAA0AAgAAAAAABAABAAUABgABABMAAAAhAAEAAQAAAAUqtwABsQAAAAEAFAAAAAoAAgAAAAUABAAGAAEACwAMAAEAEwAAABsAAQABAAAAAxIHsAAAAAEAFAAAAAYAAQAAAAkAAQASAAwAAQATAAAAHQABAAEAAAAFKrcACbAAAAABABQAAAAGAAEAAAANAAkAFQAMAAEAEwAAACMAAgAAAAAAC7sADVm3AA+2ABCwAAAAAQAUAAAABgABAAAAEQABABYAAAACABc=";
+    static final String INSTANCE_FIELD_CALLER_B64 = "yv66vgAAADQAHAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWBwAIAQAZcGhhc2UwL0luc3RhbmNlRmllbGRPd25lcgoABwADCQAHAAsMAAwADQEADWluc3RhbmNlVmFsdWUBAAFJCQAHAA8MABAADQEAC3N0YXRpY1ZhbHVlBwASAQAacGhhc2UwL0luc3RhbmNlRmllbGRDYWxsZXIBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQALZ2V0SW5zdGFuY2UBAAMoKUkBAAtwdXRJbnN0YW5jZQEACWdldFN0YXRpYwEACXB1dFN0YXRpYwEAClNvdXJjZUZpbGUBABhJbnN0YW5jZUZpZWxkQ2FsbGVyLmphdmEAIQARAAIAAAAAAAUAAQAFAAYAAQATAAAAHQABAAEAAAAFKrcAAbEAAAABABQAAAAGAAEAAAADAAkAFQAWAAEAEwAAACMAAgAAAAAAC7sAB1m3AAm0AAqsAAAAAQAUAAAABgABAAAABQAJABcABgABABMAAAAoAAIAAAAAAAy7AAdZtwAJBrUACrEAAAABABQAAAAKAAIAAAAJAAsACgAJABgAFgABABMAAAAcAAEAAAAAAASyAA6sAAAAAQAUAAAABgABAAAADQAJABkABgABABMAAAAhAAEAAAAAAAUHswAOsQAAAAEAFAAAAAoAAgAAABEABAASAAEAGgAAAAIAGw==";
+    static final String INSTANCE_FIELD_OWNER_B64 = "yv66vgAAADQAEAoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWBwAIAQAZcGhhc2UwL0luc3RhbmNlRmllbGRPd25lcgEADWluc3RhbmNlVmFsdWUBAAFJAQALc3RhdGljVmFsdWUBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQAKU291cmNlRmlsZQEAF0luc3RhbmNlRmllbGRPd25lci5qYXZhACEABwACAAAAAgABAAkACgAAAAkACwAKAAAAAQABAAUABgABAAwAAAAdAAEAAQAAAAUqtwABsQAAAAEADQAAAAYAAQAAAAMAAQAOAAAAAgAP";
+    static final String INSTANCE_FIELD_OWNER_NO_FIELDS_B64 = "yv66vgAAADQADQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWBwAIAQAZcGhhc2UwL0luc3RhbmNlRmllbGRPd25lcgEABENvZGUBAA9MaW5lTnVtYmVyVGFibGUBAApTb3VyY2VGaWxlAQAXSW5zdGFuY2VGaWVsZE93bmVyLmphdmEAIQAHAAIAAAAAAAEAAQAFAAYAAQAJAAAAHQABAAEAAAAFKrcAAbEAAAABAAoAAAAGAAEAAAADAAEACwAAAAIADA==";
 }

--- a/test-sources/MemberReferenceKindMismatchTest.java
+++ b/test-sources/MemberReferenceKindMismatchTest.java
@@ -28,4 +28,79 @@ public class MemberReferenceKindMismatchTest {
                 .append(interfaceMethodrefToClass)
                 .toString();
     }
+
+    public static String fieldAccessKindMismatch() throws Exception {
+        String[] names = { "phase0.InstanceFieldCaller", "phase0.InstanceFieldOwner" };
+        byte[] caller = LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.INSTANCE_FIELD_CALLER_B64);
+        byte[] instanceAsStatic = LoaderPhase0Fixtures.bytesWithFieldStaticFlag(
+                LoaderPhase0Fixtures.INSTANCE_FIELD_OWNER_B64,
+                "instanceValue",
+                true);
+        byte[] staticAsInstance = LoaderPhase0Fixtures.bytesWithFieldStaticFlag(
+                LoaderPhase0Fixtures.INSTANCE_FIELD_OWNER_B64,
+                "staticValue",
+                false);
+        return new StringBuilder()
+                .append(LoaderPhase0Fixtures.repeatedFailure(
+                        "phase0.InstanceFieldCaller",
+                        "getInstance",
+                        names,
+                        new byte[][] { caller, instanceAsStatic }))
+                .append('|')
+                .append(LoaderPhase0Fixtures.repeatedFailure(
+                        "phase0.InstanceFieldCaller",
+                        "putInstance",
+                        names,
+                        new byte[][] { caller, instanceAsStatic }))
+                .append('|')
+                .append(LoaderPhase0Fixtures.repeatedFailure(
+                        "phase0.InstanceFieldCaller",
+                        "getStatic",
+                        names,
+                        new byte[][] { caller, staticAsInstance }))
+                .append('|')
+                .append(LoaderPhase0Fixtures.repeatedFailure(
+                        "phase0.InstanceFieldCaller",
+                        "putStatic",
+                        names,
+                        new byte[][] { caller, staticAsInstance }))
+                .toString();
+    }
+
+    public static String instanceFieldResolutionUsesCallerLoader() throws Exception {
+        String[] names = { "phase0.InstanceFieldCaller", "phase0.InstanceFieldOwner" };
+        byte[] caller = LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.INSTANCE_FIELD_CALLER_B64);
+        String normal = LoaderPhase0Fixtures.repeatedFailure(
+                "phase0.InstanceFieldCaller",
+                "getInstance",
+                names,
+                new byte[][] {
+                    caller,
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.INSTANCE_FIELD_OWNER_B64)
+                });
+        String loaderDistinct = LoaderPhase0Fixtures.repeatedFailure(
+                "phase0.InstanceFieldCaller",
+                "getInstance",
+                names,
+                new byte[][] {
+                    caller,
+                    LoaderPhase0Fixtures.bytesWithFieldStaticFlag(
+                            LoaderPhase0Fixtures.INSTANCE_FIELD_OWNER_B64,
+                            "instanceValue",
+                            true)
+                });
+        return new StringBuilder().append(normal).append('|').append(loaderDistinct).toString();
+    }
+
+    public static String missingInstanceField() throws Exception {
+        return LoaderPhase0Fixtures.repeatedFailure(
+                "phase0.InstanceFieldCaller",
+                "getInstance",
+                new String[] { "phase0.InstanceFieldCaller", "phase0.InstanceFieldOwner" },
+                new byte[][] {
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.INSTANCE_FIELD_CALLER_B64),
+                    LoaderPhase0Fixtures.bytes(
+                            LoaderPhase0Fixtures.INSTANCE_FIELD_OWNER_NO_FIELDS_B64)
+                });
+    }
 }

--- a/test-sources/MemberReferenceKindMismatchTest.java
+++ b/test-sources/MemberReferenceKindMismatchTest.java
@@ -1,0 +1,31 @@
+public class MemberReferenceKindMismatchTest {
+    public static String run() throws Exception {
+        String methodrefToInterface = LoaderPhase0Fixtures.repeatedFailure(
+                "phase0.MethodrefToInterfaceCaller",
+                new String[] { "phase0.MethodrefToInterfaceCaller", "phase0.InterfaceTarget" },
+                new byte[][] {
+                    LoaderPhase0Fixtures.bytesWithMethodReferenceTag(
+                            LoaderPhase0Fixtures.METHODREF_TO_INTERFACE_CALLER_B64,
+                            "phase0/InterfaceTarget",
+                            "value",
+                            10),
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.INTERFACE_TARGET_B64)
+                });
+        String interfaceMethodrefToClass = LoaderPhase0Fixtures.repeatedFailure(
+                "phase0.InterfaceMethodrefToClassCaller",
+                new String[] { "phase0.InterfaceMethodrefToClassCaller", "phase0.ClassTarget" },
+                new byte[][] {
+                    LoaderPhase0Fixtures.bytesWithMethodReferenceTag(
+                            LoaderPhase0Fixtures.INTERFACE_METHODREF_TO_CLASS_CALLER_B64,
+                            "phase0/ClassTarget",
+                            "value",
+                            11),
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.CLASS_TARGET_B64)
+                });
+        return new StringBuilder()
+                .append(methodrefToInterface)
+                .append('|')
+                .append(interfaceMethodrefToClass)
+                .toString();
+    }
+}

--- a/test-sources/RepeatedResolutionFailureTest.java
+++ b/test-sources/RepeatedResolutionFailureTest.java
@@ -1,11 +1,58 @@
 public class RepeatedResolutionFailureTest {
     public static String run() throws Exception {
-        String missingClass = LoaderPhase0Fixtures.repeatedFailure(
+        return new StringBuilder()
+                .append(missingClass())
+                .append('|')
+                .append(missingField())
+                .append('|')
+                .append(missingMethod())
+                .append('|')
+                .append(missingInterfaceMethod())
+                .toString();
+    }
+
+    public static String missingClass() throws Exception {
+        return LoaderPhase0Fixtures.repeatedFailure(
                 "phase0.MissingClassCaller",
                 new String[] { "phase0.MissingClassCaller" },
                 new byte[][] {
                     LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.MISSING_CLASS_CALLER_B64)
                 });
-        return missingClass;
     }
+
+    public static String missingField() throws Exception {
+        return LoaderPhase0Fixtures.repeatedFailure(
+                "phase0.MissingFieldCaller",
+                new String[] { "phase0.MissingFieldCaller", "phase0.MissingFieldOwner" },
+                new byte[][] {
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.MISSING_FIELD_CALLER_B64),
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.MISSING_FIELD_OWNER_NO_FIELD_B64)
+                });
+    }
+
+    public static String missingMethod() throws Exception {
+        return LoaderPhase0Fixtures.repeatedFailure(
+                "phase0.MissingMethodCaller",
+                new String[] { "phase0.MissingMethodCaller", "phase0.MissingMethodOwner" },
+                new byte[][] {
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.MISSING_METHOD_CALLER_B64),
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.MISSING_METHOD_OWNER_NO_METHOD_B64)
+                });
+    }
+
+    public static String missingInterfaceMethod() throws Exception {
+        return LoaderPhase0Fixtures.repeatedFailure(
+                "phase0.MissingInterfaceCaller",
+                new String[] {
+                    "phase0.MissingInterfaceCaller",
+                    "phase0.MissingInterface",
+                    "phase0.MissingInterfaceImpl"
+                },
+                new byte[][] {
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.MISSING_INTERFACE_CALLER_B64),
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.MISSING_INTERFACE_NO_METHOD_B64),
+                    LoaderPhase0Fixtures.bytes(LoaderPhase0Fixtures.MISSING_INTERFACE_IMPL_B64)
+                });
+    }
+
 }


### PR DESCRIPTION
## Summary

- resolve field, method, and interface symbolic references from the caller's loader-scoped `ClassId`
- propagate the resolved declaring owner through constant-pool caches and static, special, virtual, and interface dispatch
- follow JVMS field lookup order and filter private/static superinterface methods from inherited candidates
- preserve the resolved owner for `invokespecial` on custom-loader classes
- report stable `NoSuchFieldError`, `NoSuchMethodError`, and `IncompatibleClassChangeError` families for repeated resolution failures

## Scope

This is the Phase 4 member-resolution slice and targets `develop` directly.

Static field and class-initialization state are still name-keyed. The loader-isolation regression for that state remains ignored and is explicitly reserved for Phase 5.

Access-control checks and loading-constraint validation are not introduced in this PR.

## Validation

- `./build-test-bundle.sh` (243 classes)
- `docker-compose run --rm -w /app/jvm-core rust cargo check --package jvm-core`
- `docker-compose run --rm -w /app/jvm-core rust cargo test --package jvm-core --test integration_test` (95 passed, 2 ignored)
- `docker-compose run --rm -w /app/jvm-core rust cargo test --package jvm-core --lib` (24 passed)
- `git diff --check upstream/develop...HEAD`